### PR TITLE
Add first micro benchmark measuring the initialisation speed of empty storage files.

### DIFF
--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -11,9 +11,9 @@ http_archive(
 
 http_archive(
     name = "com_github_google_benchmark",
-    urls = ["https://github.com/google/benchmark/archive/bf585a2789e30585b4e3ce6baf11ef2750b54677.zip"],
-    strip_prefix = "benchmark-bf585a2789e30585b4e3ce6baf11ef2750b54677",
-    sha256 = "2a778d821997df7d8646c9c59b8edb9a573a6e04c534c01892a40aa524a7b68c",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.7.0.zip"],
+    strip_prefix = "benchmark-1.7.0",
+    sha256 = "e0e6a0f2a5e8971198e5d382507bfe8e4be504797d75bb7aec44b5ea368fa100",
 )
 
 http_archive(

--- a/cpp/backend/store/file/BUILD
+++ b/cpp/backend/store/file/BUILD
@@ -35,6 +35,17 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "file_benchmark",
+    srcs = ["file_benchmark.cc"],
+    deps = [
+        ":file",
+        "//common:file_util",
+        "@com_github_google_benchmark//:benchmark_main",
+    ],
+    testonly = True,
+)
+
 cc_library(
     name = "page_pool",
     hdrs = ["page_pool.h"],

--- a/cpp/backend/store/file/file_benchmark.cc
+++ b/cpp/backend/store/file/file_benchmark.cc
@@ -1,0 +1,88 @@
+
+
+#include <filesystem>
+#include <sstream>
+
+#include "backend/store/file/file.h"
+#include "benchmark/benchmark.h"
+#include "common/file_util.h"
+
+namespace carmen::backend::store {
+namespace {
+
+// An utility wrapper to be specialized for various file implementations to
+// handle them uniformely within benchmarks.
+template <typename F>
+class FileWrapper;
+
+// A specialization of a FileWrapper for the InMemoryFile reference
+// implementation.
+template <std::size_t page_size>
+class FileWrapper<InMemoryFile<page_size>> {
+ public:
+  InMemoryFile<page_size>& GetFile() { return file_; }
+
+ private:
+  InMemoryFile<page_size> file_;
+};
+
+// A specialization of a FileWrapper for the SingleFile implementation. In
+// addition to maintaining a File instance, this wrapper also handles the
+// ownership of a temporary file on disk backing owned file instance. In
+// particular, it creates a temporary file when being instantiated and removes
+// it upon destruction of the wrapper instance.
+template <std::size_t page_size>
+class FileWrapper<SingleFile<page_size>> {
+ public:
+  FileWrapper() : file_(std::make_unique<SingleFile<page_size>>(temp_file_)) {}
+  ~FileWrapper() {
+    file_->Flush();
+    file_.reset();
+    std::filesystem::remove(temp_file_);
+  }
+  SingleFile<page_size>& GetFile() { return *file_; }
+
+ private:
+  TempFile temp_file_;
+  std::unique_ptr<SingleFile<page_size>> file_;
+};
+
+// A benchmark testing the filling of a file with zeros by starting from an
+// empty file and loading new pages in sequence.
+template <typename F>
+void BM_SequentialFileFilling(benchmark::State& state) {
+  constexpr static auto kPageSize = F::kPageSize;
+  const auto target_size = state.range(0);
+  using Page = std::array<std::byte, kPageSize>;
+
+  for (auto _ : state) {
+    FileWrapper<F> wrapper;
+    F& file = wrapper.GetFile();
+    for (std::size_t i = 0; i < target_size / kPageSize; i++) {
+      // Loading a page initializes the page to zero on disk.
+      Page trg;
+      file.LoadPage(i, trg);
+      benchmark::DoNotOptimize(trg[0]);
+    }
+  }
+}
+
+// Test the creation of files between 1 and 64 MiB.
+constexpr int kMinSize = 1 << 20;
+constexpr int kMaxSize = 1 << 26;
+
+BENCHMARK(BM_SequentialFileFilling<InMemoryFile<256>>)
+    ->Range(kMinSize, kMaxSize);
+BENCHMARK(BM_SequentialFileFilling<InMemoryFile<4096>>)
+    ->Range(kMinSize, kMaxSize);
+BENCHMARK(BM_SequentialFileFilling<InMemoryFile<16384>>)
+    ->Range(kMinSize, kMaxSize);
+
+BENCHMARK(BM_SequentialFileFilling<SingleFile<256>>)->Range(kMinSize, kMaxSize);
+BENCHMARK(BM_SequentialFileFilling<SingleFile<4096>>)
+    ->Range(kMinSize, kMaxSize);
+BENCHMARK(BM_SequentialFileFilling<SingleFile<16384>>)
+    ->Range(kMinSize, kMaxSize);
+
+}  // namespace
+}  // namespace carmen::backend::store


### PR DESCRIPTION
The main purpose of this pull request is to establish infrastructure for running micro-benchmarks in C++.