### PR TITLE
implement HashTree backed by leveldb

### DIFF
--- a/go/backend/hashtree/hashtree.go
+++ b/go/backend/hashtree/hashtree.go
@@ -17,8 +17,8 @@ type PageProvider interface {
 	GetPage(page int) ([]byte, error)
 }
 
-// HashTreeFactory creates a new instance of the HashTree
-type HashTreeFactory interface {
+// Factory creates a new instance of the HashTree
+type Factory interface {
 
 	// Create creates a new instance of hash tree with given branching factor and page provider
 	Create(pageProvider PageProvider) HashTree

--- a/go/backend/store/file/hashtree.go
+++ b/go/backend/store/file/hashtree.go
@@ -33,7 +33,7 @@ func CreateHashTreeFactory(path string, branchingFactor int) *hashTreeFactory {
 	return &hashTreeFactory{path: path, branchingFactor: branchingFactor}
 }
 
-// Create creates a new instance of the HashTree, this will be a singleton
+// Create creates a new instance of the HashTree
 func (f *hashTreeFactory) Create(pageProvider hashtree.PageProvider) hashtree.HashTree {
 	return NewHashTree(f.path, f.branchingFactor, pageProvider)
 }

--- a/go/backend/store/ldb/hashtree.go
+++ b/go/backend/store/ldb/hashtree.go
@@ -1,0 +1,231 @@
+package ldb
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"hash"
+)
+
+const (
+	HashLength = 32
+)
+
+// HashTree is a structure allowing to make a hash of the whole database state.
+// It obtains hashes of individual data pages and reduce them to a hash of the entire state.
+type HashTree struct {
+	db           *leveldb.DB
+	table        common.TableSpace
+	factor       int          // the branching factor - amount of child nodes per one parent node
+	dirtyPages   map[int]bool // set of dirty flags of the tree nodes
+	maxPage      int
+	pageProvider hashtree.PageProvider
+}
+
+// hashTreeFactory is used for implementation of hashTreeFactory method
+type hashTreeFactory struct {
+	db              *leveldb.DB
+	table           common.TableSpace
+	branchingFactor int
+}
+
+// CreateHashTreeFactory creates a new instance of the hashTreeFactory
+func CreateHashTreeFactory(db *leveldb.DB, table common.TableSpace, branchingFactor int) *hashTreeFactory {
+	return &hashTreeFactory{db: db, table: table, branchingFactor: branchingFactor}
+}
+
+// Create creates a new instance of the HashTree
+func (f *hashTreeFactory) Create(pageProvider hashtree.PageProvider) hashtree.HashTree {
+	return NewHashTree(f.db, f.table, f.branchingFactor, pageProvider)
+}
+
+// NewHashTree constructs a new HashTree
+func NewHashTree(db *leveldb.DB, table common.TableSpace, branchingFactor int, pageProvider hashtree.PageProvider) *HashTree {
+	return &HashTree{
+		db:           db,
+		table:        table,
+		factor:       branchingFactor,
+		dirtyPages:   map[int]bool{},
+		pageProvider: pageProvider,
+	}
+}
+
+// MarkUpdated marks a page as changed - to be included into the hash recalculation on commit
+func (ht *HashTree) MarkUpdated(page int) {
+	ht.dirtyPages[page] = true
+	if page > ht.maxPage {
+		ht.maxPage = page
+	}
+}
+
+// HashRoot provides the hash in the root of the hashing tree
+func (ht *HashTree) HashRoot() (out common.Hash, err error) {
+	h, err := ht.commit()
+	if err != nil {
+		return common.Hash{}, err
+	}
+	copy(out[:], h)
+	return
+}
+
+// childrenOfNode provides a concatenation of all children of given node
+func (ht *HashTree) childrenOfNode(layer, node int) (data []byte, err error) {
+	// use iterator to read nodes for the current branching factor
+	firstNode := ht.firstChildOf(node)
+	lastNode := firstNode + ht.factor
+	r := util.Range{Start: ht.convertKey(layer-1, firstNode), Limit: ht.convertKey(layer-1, lastNode)}
+	iter := ht.db.NewIterator(&r, nil)
+	defer iter.Release()
+
+	// create the page first
+	for iter.Next() {
+		data = append(data, iter.Value()...)
+	}
+
+	// extend the page if needed
+	if len(data) < ht.factor*HashLength {
+		extraBytes := make([]byte, ht.factor*HashLength-len(data))
+		data = append(data, extraBytes...)
+	}
+
+	err = iter.Error()
+	return
+}
+
+// layerLength returns index of last nodes in this layer, which is the length of this layer
+func (ht *HashTree) layerLength(layer int) (length int, err error) {
+	// set the range for full layer
+	firstNode := ht.convertKey(layer, 0)
+	lastNode := ht.convertKey(layer, 0xFFFF)
+	r := util.Range{Start: firstNode, Limit: lastNode}
+	iter := ht.db.NewIterator(&r, nil)
+	defer iter.Release()
+	if iter.Last() {
+		key := iter.Key()
+		// layer length are two last bytes (i.e. the index of the last node in the layer)
+		length = int(binary.BigEndian.Uint16(key[len(key)-2:]))
+	}
+	err = iter.Error()
+	return
+}
+
+// getRootHash reads the root hash from the database
+func (ht *HashTree) getRootHash() (hash []byte, err error) {
+	// set the range for full layers
+	firstNode := ht.convertKey(0, 0)
+	lastNode := ht.convertKey(0xFF, 0)
+	r := util.Range{Start: firstNode, Limit: lastNode}
+	iter := ht.db.NewIterator(&r, nil)
+	defer iter.Release()
+	if iter.Last() {
+		hash = iter.Value()
+	}
+	err = iter.Error()
+
+	return
+}
+
+// updateNode updates the hash-node value to the given value
+func (ht *HashTree) updateNode(layer, node int, nodeHash []byte) error {
+	return ht.db.Put(ht.convertKey(layer, node), nodeHash, nil)
+}
+
+// parentOf provides an index of a parent node, by the child index
+func (ht *HashTree) parentOf(childIdx int) int {
+	return childIdx / ht.factor
+}
+
+// firstChildOf provides an index of the first child, by the index of the parent node
+func (ht *HashTree) firstChildOf(parentIdx int) int {
+	return parentIdx * ht.factor
+}
+
+// calculateHash computes the hash of given data
+func (ht *HashTree) calculateHash(hasher hash.Hash, content []byte) (hash []byte, err error) {
+	hasher.Reset()
+	_, err = hasher.Write(content)
+	if err != nil {
+		return nil, err
+	}
+	return hasher.Sum(nil), nil
+}
+
+// updateDirtyNodes updates parent nodes marked as dirty with a hash of its children
+func (ht *HashTree) updateDirtyNodes(layer int, dirtyNodes map[int]bool, hasher hash.Hash) (newDirtyNodes map[int]bool, nodeHash []byte, err error) {
+	newDirtyNodes = make(map[int]bool)
+	for node, _ := range dirtyNodes {
+		var content []byte
+		if layer == 0 {
+			// hash the data of the page
+			content, err = ht.pageProvider.GetPage(node)
+		} else {
+			// hash children of the current node
+			content, err = ht.childrenOfNode(layer, node)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		nodeHash, err = ht.calculateHash(hasher, content)
+		if err != nil {
+			return nil, nil, err
+		}
+		// update the hash of this node
+		err = ht.updateNode(layer, node, nodeHash)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to update hashtree node %d/%d; %s", layer, node, err)
+		}
+		// parent of the updated node needs to be updated - mark dirty
+		newDirtyNodes[ht.parentOf(node)] = true
+	}
+	return
+}
+
+// commit updates the necessary parts of the hashing tree
+func (ht *HashTree) commit() (hash []byte, err error) {
+
+	// singular case there was no change (i.e. commit called either multiple times or on an empty tree
+	if len(ht.dirtyPages) == 0 {
+		return ht.getRootHash()
+	}
+
+	hasher := sha256.New()
+	dirtyNodes := ht.dirtyPages // nodes at level 0 are 1:1 to pages
+	ht.dirtyPages = make(map[int]bool)
+
+	// fetch the number of pages at the bottom
+	numPages, err := ht.layerLength(0)
+	if ht.maxPage > numPages {
+		numPages = ht.maxPage
+	}
+	numPages++ // max node index is N-1, increase to have N pages
+
+	for layerId := 0; ; layerId++ {
+		// hash children nodes into (dirty) parent nodes
+		dirtyNodes, hash, err = ht.updateDirtyNodes(layerId, dirtyNodes, hasher)
+		if numPages <= 1 || err != nil {
+			break
+		}
+		// ceiling when the division overflows to a next page
+		padding := 0
+		if numPages%ht.factor != 0 {
+			padding = 1
+		}
+		// reduce number of pages for next loop
+		numPages = numPages/ht.factor + padding
+	}
+
+	return
+}
+
+func (ht *HashTree) convertKey(layer, node int) []byte {
+	//  the key is: [tableSpace]H[layer][node]
+	// layer is 8bit (256 layers Max)
+	// node is 16bit
+	return ht.table.AppendKey(
+		common.HashKey.AppendKey(
+			binary.BigEndian.AppendUint16([]byte{uint8(layer)}, uint16(node))))
+}

--- a/go/backend/store/ldb/hashtree_test.go
+++ b/go/backend/store/ldb/hashtree_test.go
@@ -1,0 +1,241 @@
+package ldb
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"os"
+	"testing"
+)
+
+var zeroHash = common.Hash{}
+
+// Test initial and modified state to have different hashes
+func TestHashTreeInitialState(t *testing.T) {
+	tmpDir := createHashTreeTmp(t)
+	defer removeHashTreeTmp(tmpDir)
+
+	db := openHashTreeDb(t, tmpDir)
+	defer closeHashTreeDb(t, db)
+
+	pages := [][]byte{}
+	tree := CreateHashTreeFactory(db, common.ValueKey, 3).Create(testingPageProvider{pages: pages})
+
+	hash, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+	if hash != zeroHash {
+		t.Errorf("Initial hash is not zero")
+	}
+
+	tree.MarkUpdated(0)
+	hash, err = tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+	if hash == zeroHash {
+		t.Errorf("Hash of modified state must not be zero")
+	}
+}
+
+// Test that without actual change, the hash does not change
+func TestHashTreeUnchangedState(t *testing.T) {
+	tmpDir := createHashTreeTmp(t)
+	defer removeHashTreeTmp(tmpDir)
+
+	db := openHashTreeDb(t, tmpDir)
+	defer closeHashTreeDb(t, db)
+
+	pages := make([][]byte, 10)
+	tree := CreateHashTreeFactory(db, common.ValueKey, 3).Create(testingPageProvider{pages: pages})
+
+	for i := 0; i < 10; i++ {
+		pages[i] = []byte{byte(i)}
+		tree.MarkUpdated(i)
+	}
+	hashBefore, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+
+	tree.MarkUpdated(5)
+	tree.MarkUpdated(3)
+
+	hashAfter, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+
+	if hashBefore != hashAfter {
+		t.Errorf("Hash for unchanged state is different")
+	}
+}
+
+// Test that a change changes the hash
+func TestHashTreeChangedState(t *testing.T) {
+	tmpDir := createHashTreeTmp(t)
+	defer removeHashTreeTmp(tmpDir)
+
+	db := openHashTreeDb(t, tmpDir)
+	defer closeHashTreeDb(t, db)
+
+	pages := make([][]byte, 10)
+	tree := CreateHashTreeFactory(db, common.ValueKey, 3).Create(testingPageProvider{pages: pages})
+
+	for i := 0; i < 10; i++ {
+		pages[i] = []byte{byte(i)}
+		tree.MarkUpdated(i)
+	}
+
+	hashBefore, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+
+	pages[5] = []byte{42}
+	tree.MarkUpdated(5)
+
+	hashAfter, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+
+	if hashBefore == hashAfter {
+		t.Errorf("Hash for the changed state is the same")
+	}
+}
+
+// Test that two ways of building the same state leads to the same hash
+func TestTwoTreesWithSameStateProvidesSameHash(t *testing.T) {
+	tmpDirA := createNamedHashTreeTmp(t, "file-based-store-test-a")
+	defer removeHashTreeTmp(tmpDirA)
+	tmpDirB := createNamedHashTreeTmp(t, "file-based-store-test-b")
+	defer removeHashTreeTmp(tmpDirB)
+
+	db1 := openHashTreeDb(t, tmpDirA)
+	defer closeHashTreeDb(t, db1)
+
+	db2 := openHashTreeDb(t, tmpDirB)
+	defer closeHashTreeDb(t, db2)
+
+	// initialize two different states
+	pagesA := [][]byte{{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {0}, {0}}
+	pagesB := [][]byte{{0}, {42}, {2}, {3}, {4}, {5}, {6}, {7}, {0}, {0}, {0}, {0}}
+	treeA := CreateHashTreeFactory(db1, common.ValueKey, 3).Create(testingPageProvider{pages: pagesA})
+	treeB := CreateHashTreeFactory(db2, common.ValueKey, 3).Create(testingPageProvider{pages: pagesB})
+	for i := 0; i < 8; i++ {
+		treeA.MarkUpdated(i)
+		treeB.MarkUpdated(i)
+	}
+	treeA.MarkUpdated(8)
+	treeA.MarkUpdated(9)
+	firstHashA, err := treeA.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+	firstHashB, err := treeB.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+	if firstHashA == firstHashB {
+		t.Errorf("different starting states provides the same hash")
+	}
+
+	// transition the states to the same state
+	pagesB[1] = []byte{1}
+	pagesB[8] = []byte{8}
+	pagesB[9] = []byte{9}
+	treeB.MarkUpdated(1)
+	treeB.MarkUpdated(8)
+	treeB.MarkUpdated(9)
+	firstHashA, err = treeA.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to commit; %s", err)
+	}
+	firstHashB, err = treeB.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to commit; %s", err)
+	}
+
+	if firstHashA != firstHashB {
+		t.Errorf("hashes differ")
+	}
+}
+
+// TestTreePersisted tests tree is persisted and returns still correct hashes after recovery
+func TestTreePersisted(t *testing.T) {
+	tmpDir := createHashTreeTmp(t)
+	defer removeHashTreeTmp(tmpDir)
+
+	db := openHashTreeDb(t, tmpDir)
+
+	pages := make([][]byte, 10)
+	tree := CreateHashTreeFactory(db, common.ValueKey, 3).Create(testingPageProvider{pages: pages})
+
+	for i := 0; i < 10; i++ {
+		pages[i] = []byte{byte(i)}
+		tree.MarkUpdated(i)
+	}
+	hashBefore, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+
+	// reopen and check the hash is still there
+	closeHashTreeDb(t, db)
+	db = openHashTreeDb(t, tmpDir)
+	tree = CreateHashTreeFactory(db, common.ValueKey, 3).Create(testingPageProvider{pages: pages})
+
+	hashReopen, err := tree.HashRoot()
+	if err != nil {
+		t.Fatalf("failed to hash; %s", err)
+	}
+	if hashBefore != hashReopen {
+		t.Errorf("hashes differ")
+	}
+}
+
+type testingPageProvider struct {
+	pages [][]byte
+}
+
+func (pp testingPageProvider) GetPage(page int) ([]byte, error) {
+	if page >= len(pp.pages) {
+		return []byte{}, nil
+	}
+	return pp.pages[page], nil
+}
+
+func openHashTreeDb(t *testing.T, path string) (db *leveldb.DB) {
+	db, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		t.Errorf("Cannot open DB, err: %s", err)
+	}
+	return
+}
+
+func closeHashTreeDb(t *testing.T, db *leveldb.DB) {
+	if err := db.Close(); err != nil {
+		t.Errorf("Cannot close DB")
+	}
+}
+
+func createHashTreeTmp(t *testing.T) (tmpDir string) {
+	tmpDir, err := os.MkdirTemp("", "file-based-store-test")
+	if err != nil {
+		t.Errorf("unable to create testing db directory")
+	}
+	return
+}
+
+func createNamedHashTreeTmp(t *testing.T, name string) (tmpDir string) {
+	tmpDir, err := os.MkdirTemp("", name)
+	if err != nil {
+		t.Errorf("unable to create testing db directory")
+	}
+	return
+}
+
+func removeHashTreeTmp(tmpDir string) {
+	_ = os.RemoveAll(tmpDir)
+}

--- a/go/backend/store/ldb/leveldb.go
+++ b/go/backend/store/ldb/leveldb.go
@@ -25,7 +25,7 @@ func NewStore[I common.Identifier, V any](
 	table common.TableSpace,
 	serializer common.Serializer[V],
 	indexSerializer common.Serializer[I],
-	hashTreeFactory hashtree.HashTreeFactory,
+	hashTreeFactory hashtree.Factory,
 	itemDefault V,
 	pageSize int) (store *KVStore[I, V], err error) {
 

--- a/go/backend/store/memory/hashtree.go
+++ b/go/backend/store/memory/hashtree.go
@@ -26,7 +26,7 @@ func CreateHashTreeFactory(branchingFactor int) *hashTreeFactory {
 	return &hashTreeFactory{branchingFactor: branchingFactor}
 }
 
-// Create creates a new instance of the HashTree, this will be a singleton
+// Create creates a new instance of the HashTree
 func (f *hashTreeFactory) Create(pageProvider hashtree.PageProvider) hashtree.HashTree {
 	return NewHashTree(f.branchingFactor, pageProvider)
 }

--- a/go/common/scheme.go
+++ b/go/common/scheme.go
@@ -7,11 +7,13 @@ const (
 	// BalanceKey is a respective "table space"
 	BalanceKey TableSpace = 'B'
 	// NonceKey is a respective "table space"
-	NonceKey = 'N'
+	NonceKey TableSpace = 'N'
 	// SlotKey is a respective "table space"
-	SlotKey = 'S'
+	SlotKey TableSpace = 'S'
 	// ValueKey is a respective "table space"
-	ValueKey = 'V'
+	ValueKey TableSpace = 'V'
+	// HashKey is a respective "table space" for the hash tree
+	HashKey TableSpace = 'H'
 )
 
 // AppendKey converts the input key to its respective table space


### PR DESCRIPTION
It is our third implementation of the HashTree - it stores data in leveldb.
Every node of the HashTree is stored as a unique key in the database