### PR TITLE
Add stores/indexes benchmarks

### DIFF
--- a/go/backend/index/benchmark_test.go
+++ b/go/backend/index/benchmark_test.go
@@ -1,0 +1,115 @@
+package index
+
+import (
+	"encoding/binary"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/memory"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"io"
+	"testing"
+)
+
+func BenchmarkWriteMemIndex(b *testing.B) {
+	var index = memory.NewMemory[common.Key, uint32](common.KeySerializer{})
+	benchmarkWriteIndex(b, index)
+}
+
+func BenchmarkWriteLevelDbStore(b *testing.B) {
+	index, closer := initLevelDbIndex(b)
+	defer closer.Close()
+	benchmarkWriteIndex(b, index)
+}
+
+func BenchmarkReadMemIndex(b *testing.B) {
+	var store = memory.NewMemory[common.Key, uint32](common.KeySerializer{})
+	benchmarkReadIndex(b, store)
+}
+
+func BenchmarkReadLevelDbStore(b *testing.B) {
+	index, closer := initLevelDbIndex(b)
+	defer closer.Close()
+	benchmarkReadIndex(b, index)
+}
+
+func BenchmarkHashMemIndex(b *testing.B) {
+	var store = memory.NewMemory[common.Key, uint32](common.KeySerializer{})
+	benchmarkHashIndex(b, store, 10)
+}
+
+func BenchmarkHashLevelDbStore(b *testing.B) {
+	index, closer := initLevelDbIndex(b)
+	defer closer.Close()
+	benchmarkHashIndex(b, index, 10)
+}
+
+func initLevelDbIndex(b *testing.B) (idx Index[common.Key, uint32], closer io.Closer) {
+	db, err := leveldb.OpenFile(b.TempDir(), nil)
+	if err != nil {
+		b.Errorf("failed to init leveldb; %s", err)
+	}
+	index, err := ldb.NewKVIndex[common.Key, uint32](db, common.SlotKey, common.KeySerializer{}, common.Identifier32Serializer{})
+	if err != nil {
+		b.Fatalf("failed to init leveldb index; %s", err)
+	}
+	return index, db
+}
+
+var sink interface{}
+
+func benchmarkWriteIndex(b *testing.B, idx Index[common.Key, uint32]) {
+	for i := 0; i < b.N; i++ {
+		key := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		index, err := idx.GetOrAdd(common.Key{key[0], key[1], key[2], key[3]})
+		if err != nil {
+			b.Fatalf("failed to add item into index; %s", err)
+		}
+		sink = index // prevent compiler to optimize it out
+	}
+}
+
+func benchmarkReadIndex(b *testing.B, idx Index[common.Key, uint32]) {
+	b.StopTimer() // dont measure initialization
+	for i := 0; i < b.N; i++ {
+		key := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		_, err := idx.GetOrAdd(common.Key{key[0], key[1], key[2], key[3]})
+		if err != nil {
+			b.Fatalf("failed to add item into index; %s", err)
+		}
+	}
+	b.StartTimer() // end of initialization
+
+	for i := 0; i < b.N; i++ {
+		// TODO: read randomly selected items
+		key := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		index, err := idx.GetOrAdd(common.Key{key[0], key[1], key[2], key[3]})
+		if err != nil {
+			b.Fatalf("failed to add item into index; %s", err)
+		}
+		sink = index // prevent compiler to optimize it out
+	}
+}
+
+func benchmarkHashIndex(b *testing.B, idx Index[common.Key, uint32], batchsize uint32) {
+	b.StopTimer() // dont measure initialization
+	for i := 0; i < b.N; i++ {
+		keyPrefix := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		for ii := uint32(0); ii < batchsize; ii++ {
+			// TODO: change randomly selected items
+			key := binary.BigEndian.AppendUint32(keyPrefix, ii)
+			_, err := idx.GetOrAdd(common.Key{key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[7]})
+			if err != nil {
+				b.Fatalf("failed to add item into index; %s", err)
+			}
+		}
+		b.StartTimer()
+
+		hash, err := idx.GetStateHash()
+		if err != nil {
+			b.Fatalf("failed to hash index; %s", err)
+		}
+		sink = hash // prevent compiler to optimize it out
+
+		b.StopTimer()
+	}
+}

--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -1,0 +1,133 @@
+package store
+
+import (
+	"encoding/binary"
+	"github.com/Fantom-foundation/Carmen/go/backend/store/file"
+	"github.com/Fantom-foundation/Carmen/go/backend/store/ldb"
+	"github.com/Fantom-foundation/Carmen/go/backend/store/memory"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"io"
+	"testing"
+)
+
+func BenchmarkWriteMemStore(b *testing.B) {
+	var store = memory.NewStore[uint32, common.Value](common.ValueSerializer{}, common.Value{}, PageSize, Factor)
+	benchmarkWriteStore(b, store)
+}
+
+func BenchmarkWriteFileStore(b *testing.B) {
+	benchmarkWriteStore(b, initFileStore(b))
+}
+
+func BenchmarkWriteLevelDbStore(b *testing.B) {
+	store, closer := initLevelDbStore(b)
+	defer closer.Close()
+	benchmarkWriteStore(b, store)
+}
+
+func BenchmarkReadMemStore(b *testing.B) {
+	var store = memory.NewStore[uint32, common.Value](common.ValueSerializer{}, common.Value{}, PageSize, Factor)
+	benchmarkReadStore(b, store)
+}
+
+func BenchmarkReadFileStore(b *testing.B) {
+	benchmarkReadStore(b, initFileStore(b))
+}
+
+func BenchmarkReadLevelDbStore(b *testing.B) {
+	store, closer := initLevelDbStore(b)
+	defer closer.Close()
+	benchmarkReadStore(b, store)
+}
+
+func BenchmarkHashMemStore(b *testing.B) {
+	var store = memory.NewStore[uint32, common.Value](common.ValueSerializer{}, common.Value{}, PageSize, Factor)
+	benchmarkHashStore(b, store)
+}
+
+func BenchmarkHashFileStore(b *testing.B) {
+	benchmarkHashStore(b, initFileStore(b))
+}
+
+func BenchmarkHashLevelDbStore(b *testing.B) {
+	store, closer := initLevelDbStore(b)
+	defer closer.Close()
+	benchmarkHashStore(b, store)
+}
+
+func initFileStore(b *testing.B) (idx Store[uint32, common.Value]) {
+	store, err := file.NewStore[uint32, common.Value](b.TempDir(), common.ValueSerializer{}, common.Value{}, PageSize, Factor)
+	if err != nil {
+		b.Fatalf("failed to init file store; %s", err)
+	}
+	return store
+}
+
+func initLevelDbStore(b *testing.B) (store Store[uint32, common.Value], closer io.Closer) {
+	db, err := leveldb.OpenFile(b.TempDir(), nil)
+	if err != nil {
+		b.Errorf("failed to init leveldb; %s", err)
+	}
+	hashTree := memory.CreateHashTreeFactory(Factor)
+	store, err = ldb.NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, common.Value{}, PageSize)
+	if err != nil {
+		b.Fatalf("failed to init leveldb store; %s", err)
+	}
+	return store, db
+}
+
+var sink interface{}
+
+func benchmarkWriteStore(b *testing.B, store Store[uint32, common.Value]) {
+	for i := 0; i < b.N; i++ {
+		// TODO: write at randomly selected index
+		value := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		err := store.Set(uint32(i), common.Value{value[0], value[1], value[2], value[3]})
+		if err != nil {
+			b.Fatalf("failed to set store item; %s", err)
+		}
+	}
+}
+
+func benchmarkReadStore(b *testing.B, store Store[uint32, common.Value]) {
+	b.StopTimer() // dont measure initialization
+	for i := 0; i < b.N; i++ {
+		value := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		err := store.Set(uint32(i), common.Value{value[0], value[1], value[2], value[3]})
+		if err != nil {
+			b.Fatalf("failed to set store item; %s", err)
+		}
+	}
+	b.StartTimer() // end of initialization
+
+	for i := 0; i < b.N; i++ {
+		// TODO: read randomly selected items
+		value, err := store.Get(uint32(i))
+		if err != nil {
+			b.Fatalf("failed to read item from store; %s", err)
+		}
+		sink = value // prevent compiler to optimize it out
+	}
+}
+
+func benchmarkHashStore(b *testing.B, store Store[uint32, common.Value]) {
+	b.StopTimer() // dont measure initialization
+	for i := 0; i < b.N; i++ {
+		// TODO: change batches of randomly selected items
+		value := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		err := store.Set(uint32(i), common.Value{value[0], value[1], value[2], value[3]})
+		if err != nil {
+			b.Fatalf("failed to set store item; %s", err)
+		}
+		b.StartTimer()
+
+		hash, err := store.GetStateHash()
+		if err != nil {
+			b.Fatalf("failed to hash store; %s", err)
+		}
+		sink = hash // prevent compiler to optimize it out
+
+		b.StopTimer()
+	}
+}


### PR DESCRIPTION
Add simple benchmark comparing different implementations of store/index.

This is only skeleton, to be extended later - reads keys in sequence instead of random selection for example.