### PR TITLE
Test indexes hashing by comparison

### DIFF
--- a/go/backend/index/hashindex/hashindex.go
+++ b/go/backend/index/hashindex/hashindex.go
@@ -1,4 +1,4 @@
-package index
+package hashindex
 
 import (
 	"crypto/sha256"

--- a/go/backend/index/hashindex/hashindex_test.go
+++ b/go/backend/index/hashindex/hashindex_test.go
@@ -1,4 +1,4 @@
-package index
+package hashindex
 
 import (
 	"fmt"

--- a/go/backend/index/index_test.go
+++ b/go/backend/index/index_test.go
@@ -1,0 +1,65 @@
+package index
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/memory"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"os"
+	"testing"
+)
+
+func compareHashes(indexA Index[common.Address, uint32], indexB Index[common.Address, uint32]) error {
+	hashA, err := indexA.GetStateHash()
+	if err != nil {
+		return err
+	}
+	hashB, err := indexB.GetStateHash()
+	if err != nil {
+		return err
+	}
+	if hashA != hashB {
+		return fmt.Errorf("different hashes: %x != %x", hashA, hashB)
+	}
+	return nil
+}
+
+func TestIndexesHashingByComparison(t *testing.T) {
+	tmpLdbDir, err := os.MkdirTemp("", "leveldb-based-index-test")
+	if err != nil {
+		t.Fatalf("unable to create testing db directory")
+	}
+	defer os.RemoveAll(tmpLdbDir)
+	db, err := leveldb.OpenFile(tmpLdbDir, nil)
+	if err != nil {
+		t.Fatalf("failed to init leveldb; %s", err)
+	}
+	defer db.Close()
+
+	memindex := memory.NewMemory[common.Address, uint32](common.AddressSerializer{})
+	defer memindex.Close()
+	ldbindex, _ := ldb.NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
+	defer ldbindex.Close()
+
+	if err := compareHashes(memindex, ldbindex); err != nil {
+		t.Errorf("initial hash: %s", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		idxA, err := memindex.GetOrAdd(common.Address{byte(0x20 + i)})
+		if err != nil {
+			t.Fatalf("failed to set memstore item %d; %s", i, err)
+		}
+		idxB, err := ldbindex.GetOrAdd(common.Address{byte(0x20 + i)})
+		if err != nil {
+			t.Fatalf("failed to set filestore item %d; %s", i, err)
+		}
+		if idxA != idxB {
+			t.Errorf("indexes does not match for inserted item %d: %d != %d", i, idxA, idxB)
+		}
+		if err := compareHashes(memindex, ldbindex); err != nil {
+			t.Errorf("hash does not match after inserting item %d: %s", i, err)
+		}
+	}
+}

--- a/go/backend/index/ldb/leveldb.go
+++ b/go/backend/index/ldb/leveldb.go
@@ -1,7 +1,7 @@
 package ldb
 
 import (
-	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/hashindex"
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -18,7 +18,7 @@ type KVIndex[K comparable, I common.Identifier] struct {
 	table           common.TableSpace
 	keySerializer   common.Serializer[K]
 	indexSerializer common.Serializer[I]
-	hashIndex       *index.HashIndex[K]
+	hashIndex       *hashindex.HashIndex[K]
 	lastIndex       I
 	hashSerializer  common.HashSerializer
 }
@@ -56,7 +56,7 @@ func NewKVIndex[K comparable, I common.Identifier](
 		table:           table,
 		keySerializer:   keySerializer,
 		indexSerializer: indexSerializer,
-		hashIndex:       index.InitHashIndex[K](hashSerializer.FromBytes(hash), keySerializer),
+		hashIndex:       hashindex.InitHashIndex[K](hashSerializer.FromBytes(hash), keySerializer),
 		lastIndex:       indexSerializer.FromBytes(last),
 		hashSerializer:  hashSerializer,
 	}

--- a/go/backend/index/ldb/leveldb_test.go
+++ b/go/backend/index/ldb/leveldb_test.go
@@ -32,7 +32,7 @@ func TestBasicOperation(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	db := openDb(t, tmpDir)
-	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -94,7 +94,7 @@ func TestDataPersisted(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	db := openDb(t, tmpDir)
-	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -112,7 +112,7 @@ func TestDataPersisted(t *testing.T) {
 	// close and reopen
 	closeDb(t, db, persistent)
 	db = openDb(t, tmpDir)
-	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -147,7 +147,7 @@ func TestHash(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	db := openDb(t, tmpDir)
-	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -196,7 +196,7 @@ func TestHashPersisted(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	db := openDb(t, tmpDir)
-	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -207,7 +207,7 @@ func TestHashPersisted(t *testing.T) {
 	closeDb(t, db, persistent)
 
 	db = openDb(t, tmpDir)
-	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -228,7 +228,7 @@ func TestHashPersistedAndAdded(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	db := openDb(t, tmpDir)
-	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ := NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()
@@ -237,7 +237,7 @@ func TestHashPersistedAndAdded(t *testing.T) {
 	// reopen
 	closeDb(t, db, persistent)
 	db = openDb(t, tmpDir)
-	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.IdentifierSerializer32[uint32]{})
+	persistent, _ = NewKVIndex[common.Address, uint32](db, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
 	defer func() {
 		closeDb(t, db, persistent)
 	}()

--- a/go/backend/index/memory/memory.go
+++ b/go/backend/index/memory/memory.go
@@ -1,7 +1,7 @@
 package memory
 
 import (
-	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/hashindex"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -9,7 +9,7 @@ import (
 type Memory[K comparable, I common.Identifier] struct {
 	data          map[K]I
 	keySerializer common.Serializer[K]
-	hashIndex     *index.HashIndex[K]
+	hashIndex     *hashindex.HashIndex[K]
 }
 
 // NewMemory constructs a new Memory instance.
@@ -17,7 +17,7 @@ func NewMemory[K comparable, I common.Identifier](serializer common.Serializer[K
 	memory := Memory[K, I]{
 		data:          make(map[K]I),
 		keySerializer: serializer,
-		hashIndex:     index.NewHashIndex[K](serializer),
+		hashIndex:     hashindex.NewHashIndex[K](serializer),
 	}
 	return &memory
 }

--- a/go/backend/store/ldb/leveldb_test.go
+++ b/go/backend/store/ldb/leveldb_test.go
@@ -39,7 +39,7 @@ func TestEmpty(t *testing.T) {
 
 	db := openDb(t, tmpDir)
 	hashTree := memory.CreateHashTreeFactory(BranchingFactor)
-	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	if err != nil {
@@ -59,7 +59,7 @@ func TestBasicOperations(t *testing.T) {
 
 	db := openDb(t, tmpDir)
 	hashTree := memory.CreateHashTreeFactory(BranchingFactor)
-	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	if err := s.Set(10, A); err != nil {
@@ -80,7 +80,7 @@ func TestPages(t *testing.T) {
 	db := openDb(t, tmpDir)
 	hashTree := memory.CreateHashTreeFactory(BranchingFactor)
 	serializer := common.ValueSerializer{}
-	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	// fill-in three pages
@@ -164,7 +164,7 @@ func TestDataPersisted(t *testing.T) {
 
 	db := openDb(t, tmpDir)
 	hashTree := memory.CreateHashTreeFactory(BranchingFactor)
-	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, err := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	if err := s.Set(10, A); err != nil {
@@ -174,7 +174,7 @@ func TestDataPersisted(t *testing.T) {
 	closeDb(db, s)
 	db = openDb(t, tmpDir)
 	hashTree = memory.CreateHashTreeFactory(BranchingFactor)
-	s, _ = NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, _ = NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	if val, err := s.Get(10); err != nil || val != A {
@@ -190,7 +190,7 @@ func TestBasicHashing(t *testing.T) {
 
 	db := openDb(t, tmpDir)
 	hashTree := memory.CreateHashTreeFactory(BranchingFactor)
-	s, _ := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.IdentifierSerializer32[uint32]{}, hashTree, defaultItem, PageSize)
+	s, _ := NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, hashTree, defaultItem, PageSize)
 	defer closeDb(db, s)
 
 	if hash, err := s.GetStateHash(); (err != nil || hash != common.Hash{}) {

--- a/go/backend/store/store_test.go
+++ b/go/backend/store/store_test.go
@@ -16,7 +16,7 @@ const (
 	Factor   = 3
 )
 
-func compareHashes(storeA Store[uint32, common.Value], storeB Store[uint32, common.Value]) error {
+func compareHashes(storeA Store[uint32, common.Value], storeB Store[uint32, common.Value], storeC Store[uint32, common.Value]) error {
 	hashA, err := storeA.GetStateHash()
 	if err != nil {
 		return err
@@ -25,38 +25,48 @@ func compareHashes(storeA Store[uint32, common.Value], storeB Store[uint32, comm
 	if err != nil {
 		return err
 	}
+	hashC, err := storeC.GetStateHash()
+	if err != nil {
+		return err
+	}
 	if hashA != hashB {
 		return fmt.Errorf("different hashes: %x != %x", hashA, hashB)
+	}
+	if hashA != hashC {
+		return fmt.Errorf("different hashes: %x != %x", hashA, hashC)
 	}
 	return nil
 }
 
 func TestStoresHashingByComparison(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "file-based-store-test")
+	tmpFileDir, err := os.MkdirTemp("", "file-based-store-test")
 	if err != nil {
 		t.Fatalf("unable to create testing db directory")
 	}
-	defer os.RemoveAll(tmpDir)
-
-	db, err := leveldb.OpenFile(tmpDir, nil)
-	defer func() { _ = db.Close() }()
+	defer os.RemoveAll(tmpFileDir)
+	tmpLdbDir, err := os.MkdirTemp("", "leveldb-based-store-test")
+	if err != nil {
+		t.Fatalf("unable to create testing db directory")
+	}
+	defer os.RemoveAll(tmpLdbDir)
+	db, err := leveldb.OpenFile(tmpLdbDir, nil)
+	if err != nil {
+		t.Fatalf("failed to init leveldb; %s", err)
+	}
+	defer db.Close()
 
 	defaultItem := common.Value{}
 	serializer := common.ValueSerializer{}
-	indexSerializer := common.IdentifierSerializer32[uint32]{}
+	indexSerializer := common.Identifier32Serializer{}
 
 	memstore := memory.NewStore[uint32, common.Value](serializer, defaultItem, PageSize, Factor)
 	defer memstore.Close()
-	filestore, err := file.NewStore[uint32, common.Value](tmpDir, serializer, defaultItem, PageSize, Factor)
+	filestore, err := file.NewStore[uint32, common.Value](tmpFileDir, serializer, defaultItem, PageSize, Factor)
 	defer filestore.Close()
 	levelStore, err := ldb.NewStore[uint32, common.Value](db, common.ValueKey, serializer, indexSerializer, ldb.CreateHashTreeFactory(db, common.ValueKey, Factor), defaultItem, PageSize)
 	defer func() { _ = levelStore.Close() }()
 
-	if err := compareHashes(memstore, filestore); err != nil {
-		t.Errorf("initial hash: %s", err)
-	}
-
-	if err := compareHashes(memstore, levelStore); err != nil {
+	if err := compareHashes(memstore, filestore, levelStore); err != nil {
 		t.Errorf("initial hash: %s", err)
 	}
 
@@ -68,12 +78,9 @@ func TestStoresHashingByComparison(t *testing.T) {
 			t.Fatalf("failed to set filestore item %d; %s", i, err)
 		}
 		if err := levelStore.Set(uint32(i), common.Value{byte(0x10 + i)}); err != nil {
-			t.Fatalf("failed to set filestore item %d; %s", i, err)
+			t.Fatalf("failed to set levelStore item %d; %s", i, err)
 		}
-		if err := compareHashes(memstore, filestore); err != nil {
-			t.Errorf("hash does not match after inserting item %d: %s", i, err)
-		}
-		if err := compareHashes(memstore, levelStore); err != nil {
+		if err := compareHashes(memstore, filestore, levelStore); err != nil {
 			t.Errorf("hash does not match after inserting item %d: %s", i, err)
 		}
 	}

--- a/go/common/serializers.go
+++ b/go/common/serializers.go
@@ -94,7 +94,7 @@ func (a NonceSerializer) Size() int {
 
 // SlotIdxSerializer32 is a Serializer of the Value type
 type SlotIdxSerializer32 struct {
-	identifierSerializer32 IdentifierSerializer32[uint32]
+	identifierSerializer32 Identifier32Serializer
 }
 
 func (a SlotIdxSerializer32) ToBytes(value SlotIdx[uint32]) []byte {
@@ -113,15 +113,15 @@ func (a SlotIdxSerializer32) Size() int {
 	return 8 // two 32bit integers
 }
 
-// IdentifierSerializer32 is a Serializer of the Value type
-type IdentifierSerializer32[I Identifier] struct{}
+// Identifier32Serializer is a Serializer of the uint32 Identifier type
+type Identifier32Serializer struct{}
 
-func (a IdentifierSerializer32[I]) ToBytes(value I) []byte {
-	return binary.BigEndian.AppendUint32([]byte{}, uint32(value))
+func (a Identifier32Serializer) ToBytes(value uint32) []byte {
+	return binary.BigEndian.AppendUint32([]byte{}, value)
 }
-func (a IdentifierSerializer32[I]) FromBytes(bytes []byte) I {
-	return I(binary.BigEndian.Uint32(bytes))
+func (a Identifier32Serializer) FromBytes(bytes []byte) uint32 {
+	return binary.BigEndian.Uint32(bytes)
 }
-func (a IdentifierSerializer32[I]) Size() int {
-	return 4 //
+func (a Identifier32Serializer) Size() int {
+	return 4
 }


### PR DESCRIPTION
* Compare hashes generated by different index implementations. (Have been done for stores only before.)
* Remove type parameter from IdentifierSerializer32[I]. (it should be used with uint32 only)
* Move hashindex into standalone package to avoid cyclic dependency.