### PR TITLE
Unify benchmark parameters and outputs

### DIFF
--- a/go/backend/store/store_test.go
+++ b/go/backend/store/store_test.go
@@ -11,11 +11,6 @@ import (
 	"testing"
 )
 
-const (
-	PageSize = 2
-	Factor   = 3
-)
-
 func initStores(t *testing.T) (stores []store.Store[uint32, common.Value]) {
 	db, err := leveldb.OpenFile(t.TempDir(), nil)
 	if err != nil {
@@ -26,9 +21,9 @@ func initStores(t *testing.T) (stores []store.Store[uint32, common.Value]) {
 	valSerializer := common.ValueSerializer{}
 	idSerializer := common.Identifier32Serializer{}
 
-	memstore := memory.NewStore[uint32, common.Value](valSerializer, defaultItem, PageSize, Factor)
-	filestore, err := file.NewStore[uint32, common.Value](t.TempDir(), valSerializer, defaultItem, PageSize, Factor)
-	treeFac := ldb.CreateHashTreeFactory(db, common.ValueKey, Factor)
+	memstore := memory.NewStore[uint32, common.Value](valSerializer, defaultItem, PageSize, BranchingFactor)
+	filestore, err := file.NewStore[uint32, common.Value](t.TempDir(), valSerializer, defaultItem, PageSize, BranchingFactor)
+	treeFac := ldb.CreateHashTreeFactory(db, common.ValueKey, BranchingFactor)
 	ldbstore, err := ldb.NewStore[uint32, common.Value](db, common.ValueKey, valSerializer, idSerializer, treeFac, defaultItem, PageSize)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
Unify the benchmark parameters names by the design document:
https://docs.google.com/document/d/1iAHNuwbitBcLnGcx3eTUuHkoVdMZV0Ga7pFxwUJ4YDw/

Unify the benchmark output (variants names) into format:
```
BenchmarkInsert/Store_Memory_initialSize_1048576-32         	21349237	       133.8 ns/op
BenchmarkInsert/Store_File_initialSize_1048576-32           	  418737	      2864 ns/op
BenchmarkInsert/Store_LevelDb_initialSize_1048576-32        	  579496	      1822 ns/op
BenchmarkRead/Store_Memory_initialSize_1048576_dist_Sequential-32         	29694700	        36.05 ns/op
BenchmarkRead/Store_Memory_initialSize_1048576_dist_Uniform-32            	 9275376	       118.6 ns/op
BenchmarkRead/Store_Memory_initialSize_1048576_dist_Exponential-32        	13749699	        75.68 ns/op
BenchmarkHash/Store_File_initialSize_1048576_updateSize_100_dist_Sequential-32           	       1	2791923071 ns/op
BenchmarkHash/Store_File_initialSize_1048576_updateSize_100_dist_Uniform-32              	     775	   1585888 ns/op
BenchmarkRead/Index_LevelDb_initialSize_1048576_dist_Uniform-32           	  229723	      4624 ns/op
BenchmarkRead/Index_LevelDb_initialSize_1048576_dist_Exponential-32       	  344578	      3014 ns/op
BenchmarkHash/Index_Memory_initialSize_1048576_updateSize_100-32          	   39003	     31052 ns/op
BenchmarkHash/Index_LevelDb_initialSize_1048576_updateSize_100-32         	   37038	     32296 ns/op
```