### PR TITLE
set capacity of the list with dirty keys to prevent frequent allocation

### DIFF
--- a/go/backend/index/benchmarkhash_test.go
+++ b/go/backend/index/benchmarkhash_test.go
@@ -1,0 +1,52 @@
+package index_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/hashindex"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"testing"
+)
+
+var updateKeysSizes = []int{100}
+
+var hashSink interface{}
+
+// hashWrapper wraps an instance of the hash index to have serializers and the hash index available at hand
+type hashWrapper[K comparable] struct {
+	serializer common.Serializer[K]
+	hashIdx    *hashindex.HashIndex[K]
+}
+
+// BenchmarkHashTree benchmarks only computation of the hash for the index
+func BenchmarkHashIndex(b *testing.B) {
+	serializer := common.KeySerializer{}
+	hw := hashWrapper[common.Key]{serializer, hashindex.NewHashIndex[common.Key](serializer)}
+	for _, updateHashSize := range updateKeysSizes {
+		b.Run(fmt.Sprintf("HashIndex updsteSize %d", updateHashSize), func(b *testing.B) {
+			hw.benchmarkHash(b, updateHashSize)
+		})
+	}
+}
+
+func (hw hashWrapper[K]) benchmarkHash(b *testing.B, updateKeys int) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		for ii := 0; ii < updateKeys; ii++ {
+			hw.hashIdx.AddKey(hw.toKey(uint32(ii)))
+		}
+		b.StartTimer()
+
+		h, err := hw.hashIdx.Commit()
+		if err != nil {
+			b.Fatalf("Error to hash %s", err)
+		}
+		hashSink = h
+	}
+}
+
+// toKey converts the key from an input uint32 to the generic Key
+func (hw hashWrapper[K]) toKey(key uint32) K {
+	keyBytes := binary.BigEndian.AppendUint32([]byte{}, key)
+	return hw.serializer.FromBytes(keyBytes)
+}

--- a/go/backend/index/hashindex/hashindex.go
+++ b/go/backend/index/hashindex/hashindex.go
@@ -5,6 +5,9 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
+// KeyBufferInitialCapacity is a capacity of dirty keys list to prevent frequent allocations
+const KeyBufferInitialCapacity = 1000
+
 // HashIndex is a cache of accumulated keys and their recursive hash. It is expected that it stores the keys that are
 // not yet included in the hash. The keys shall be cleared and the hash updated once in a while. The hash is set to
 // 32 byte empty array 0x0...0 at first. Then the keys are being added into the structure. Upon a request, the keys are
@@ -21,7 +24,7 @@ type HashIndex[K comparable] struct {
 func NewHashIndex[K comparable](serializer common.Serializer[K]) *HashIndex[K] {
 	return &HashIndex[K]{
 		hash:           common.Hash{},
-		keys:           []K{},
+		keys:           make([]K, 0, KeyBufferInitialCapacity),
 		serializer:     serializer,
 		hashSerializer: common.HashSerializer{},
 	}
@@ -31,7 +34,7 @@ func NewHashIndex[K comparable](serializer common.Serializer[K]) *HashIndex[K] {
 func InitHashIndex[K comparable](hash common.Hash, serializer common.Serializer[K]) *HashIndex[K] {
 	return &HashIndex[K]{
 		hash:           hash,
-		keys:           []K{},
+		keys:           make([]K, 0, KeyBufferInitialCapacity),
 		serializer:     serializer,
 		hashSerializer: common.HashSerializer{},
 	}
@@ -64,7 +67,7 @@ func (hi *HashIndex[K]) Commit() (common.Hash, error) {
 	}
 
 	hi.hash = hi.hashSerializer.FromBytes(hashTmp)
-	hi.keys = []K{}
+	hi.keys = hi.keys[0:0]
 
 	return hi.hash, nil
 }

--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -19,7 +19,8 @@ const (
 )
 
 // initial number of values inserted into the Store before the benchmark
-var initialSizes = []int{1 << 20, 1 << 24, 1 << 30}
+// var initialSizes = []int{1 << 20, 1 << 24, 1 << 30}
+var initialSizes = []int{1 << 20, 1 << 24}
 
 // number of values updated before each measured hash recalculation
 var updateSizes = []int{100}


### PR DESCRIPTION
This reduces relocation of the list of dirty keys. 
![after](https://user-images.githubusercontent.com/7114574/195662502-ba5c78ff-a09e-4f24-944f-c4197046a65b.png)
![before](https://user-images.githubusercontent.com/7114574/195662506-86810968-87e8-4707-bc8f-94cad4c42250.png)
