### PR TITLE
Add benchmark for SHA256 hash computation

### DIFF
--- a/cpp/common/BUILD
+++ b/cpp/common/BUILD
@@ -103,3 +103,13 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_binary(
+    name = "hash_benchmark",
+    srcs = ["hash_benchmark.cc"],
+    deps = [
+        ":hash",
+        "@com_github_google_benchmark//:benchmark_main",
+        "//third_party/gperftools:profiler",
+    ],
+)

--- a/cpp/common/hash.cc
+++ b/cpp/common/hash.cc
@@ -54,6 +54,10 @@ void Sha256Hasher::Ingest(std::span<const std::byte> data) {
   _impl->Ingest(data.data(), data.size());
 }
 
+void Sha256Hasher::Ingest(const std::span<std::byte> data) {
+  _impl->Ingest(data.data(), data.size());
+}
+
 void Sha256Hasher::Ingest(std::string_view str) {
   Ingest(reinterpret_cast<const std::byte*>(str.data()), str.size());
 }

--- a/cpp/common/hash.h
+++ b/cpp/common/hash.h
@@ -34,6 +34,9 @@ class Sha256Hasher {
   // Same as above, but using a span to represent a sequence of bytes.
   void Ingest(const std::span<const std::byte> span);
 
+  // Same as above, but for a span of mutable bytes.
+  void Ingest(const std::span<std::byte> span);
+
   // A convenience variant of the function above, supporting the hashing of
   // strings through a single parameter.
   void Ingest(std::string_view str);

--- a/cpp/common/hash_benchmark.cc
+++ b/cpp/common/hash_benchmark.cc
@@ -1,0 +1,57 @@
+#include <span>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "common/hash.h"
+
+namespace carmen::backend::store {
+namespace {
+
+// To run benchmarks, use the following command:
+//    bazel run -c opt //common:hash_benchmark
+
+// Benchmark the hashing of a sequence of bytes.
+void BM_Sha256Hash(benchmark::State& state) {
+  auto num_bytes = state.range(0);
+  std::vector<std::byte> data(num_bytes);
+  std::span<const std::byte> span = data;
+  Sha256Hasher hasher;
+  for (auto _ : state) {
+    auto hash = GetHash(hasher, span);
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+BENCHMARK(BM_Sha256Hash)->Range(1, 1 << 20);
+
+// Same as above, but uses a new Sha256 context every time.
+void BM_Sha256HashNoReuse(benchmark::State& state) {
+  auto num_bytes = state.range(0);
+  std::vector<std::byte> data(num_bytes);
+  std::span<std::byte> span = data;
+  for (auto _ : state) {
+    auto hash = GetSha256Hash(span);
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+BENCHMARK(BM_Sha256HashNoReuse)->Range(1, 1 << 20);
+
+// Benchmarks the computation of a chain of hashes from 32 byte keys.
+void BM_Sha256HashKeyChain(benchmark::State& state) {
+  auto num_keys = state.range(0);
+  std::vector<Key> keys(num_keys);
+  Sha256Hasher hasher;
+  for (auto _ : state) {
+    Hash hash;
+    for (const auto& key : keys) {
+      hash = GetHash(hasher, hash, key);
+    }
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+BENCHMARK(BM_Sha256HashKeyChain)->Range(1, 1 << 10)->Arg(100);
+
+}  // namespace
+}  // namespace carmen::backend::store


### PR DESCRIPTION
Benchmark for computing SHA-256 hashes from varying lengths of byte blocks as well as key chains.

Results measured on personal development PC:
```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
BM_Sha256Hash/1                     203 ns          203 ns      3152158
BM_Sha256Hash/8                     201 ns          201 ns      3396552
BM_Sha256Hash/64                    367 ns          367 ns      1887274
BM_Sha256Hash/512                  1496 ns         1496 ns       454363
BM_Sha256Hash/4096                10544 ns        10543 ns        64573
BM_Sha256Hash/32768               82295 ns        82291 ns         8054
BM_Sha256Hash/262144             656435 ns       656382 ns         1005
BM_Sha256Hash/1048576           2637670 ns      2637425 ns          261
BM_Sha256HashNoReuse/1              273 ns          273 ns      2544183
BM_Sha256HashNoReuse/8              273 ns          273 ns      2520826
BM_Sha256HashNoReuse/64             456 ns          456 ns      1537020
BM_Sha256HashNoReuse/512           1597 ns         1596 ns       422535
BM_Sha256HashNoReuse/4096         10630 ns        10630 ns        61232
BM_Sha256HashNoReuse/32768        82851 ns        82848 ns         8123
BM_Sha256HashNoReuse/262144      661140 ns       661124 ns         1005
BM_Sha256HashNoReuse/1048576    2634288 ns      2634106 ns          261
BM_Sha256HashKeyChain/1             390 ns          390 ns      1734099
BM_Sha256HashKeyChain/8            3047 ns         3047 ns       226413
BM_Sha256HashKeyChain/64          24145 ns        24144 ns        27916
BM_Sha256HashKeyChain/512        193856 ns       193851 ns         3537
BM_Sha256HashKeyChain/1024       388685 ns       388666 ns         1814
BM_Sha256HashKeyChain/100         37946 ns        37944 ns        18265
```