### PR TITLE
Use single data file for all pages in File store

### DIFF
--- a/go/backend/store/file/file.go
+++ b/go/backend/store/file/file.go
@@ -122,5 +122,5 @@ func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
 
 // Close the store
 func (m *Store[I, V]) Close() error {
-	return nil // no-op - we are not keeping any files open
+	return m.file.Close()
 }


### PR DESCRIPTION
Optimalization of File store - instead of using one file for each page, one file for the whole store (except hashes) is used.

Benchmark before: (one file per page)
```
go test -bench=. ./backend/store
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Carmen/go/backend/store
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkInsert/Store_File_initialSize_4194304-32          	 		  424260	      2586 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Sequential-32         	  454004	      2371 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Uniform-32            	  424892	      2745 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Exponential-32        	  447499	      2469 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Sequential-32        	  410487	      2540 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Uniform-32           	  280626	      3943 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Exponential-32       	  339963	      3595 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Sequential-32	   20000	     50164 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Uniform-32	     603	   1885933 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Exponential-32	     651	   1810951 ns/op
PASS
ok  	github.com/Fantom-foundation/Carmen/go/backend/store	69.722s
```

Benchmark after: (one big file for all pages)
```
go test -bench=. ./backend/store
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Carmen/go/backend/store
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkInsert/Store_File_initialSize_4194304-32         		  	 2071924	       555.8 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Sequential-32         	 2633032	       446.7 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Uniform-32            	 1972692	       576.0 ns/op
BenchmarkRead/Store_File_initialSize_4194304_dist_Exponential-32        	 2272992	       536.6 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Sequential-32        	 2238331	       555.7 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Uniform-32           	 1750489	       698.6 ns/op
BenchmarkWrite/Store_File_initialSize_4194304_dist_Exponential-32       	 1818054	       661.8 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Sequential-32	   28105	     42437 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Uniform-32	     702	   1671854 ns/op
BenchmarkHash/Store_File_initialSize_4194304_updateSize_100_dist_Exponential-32	     775	   1603819 ns/op
PASS
ok  	github.com/Fantom-foundation/Carmen/go/backend/store	35.986s
```