### PR TITLE
Allow temporary files and directories to be move constructible

### DIFF
--- a/cpp/common/file_util.h
+++ b/cpp/common/file_util.h
@@ -14,7 +14,8 @@ class TempFile {
   // Creates a temporary file with a random name prefixed by the provided
   // prefix.
   TempFile(std::string_view prefix = "temp");
-  TempFile(TempFile&&) = delete;
+  TempFile(const TempFile&) = delete;
+  TempFile(TempFile&&) = default;
   ~TempFile();
 
   // Obtains the path of the owned temporary file.
@@ -35,7 +36,8 @@ class TempDir {
   // Creates a temporary directory with a random name prefixed by the provided
   // prefix.
   TempDir(std::string_view prefix = "temp");
-  TempDir(TempDir&&) = delete;
+  TempDir(const TempDir&) = delete;
+  TempDir(TempDir&&) = default;
   ~TempDir();
 
   // Obtains the path of the owned temporary file.

--- a/cpp/common/file_util_test.cc
+++ b/cpp/common/file_util_test.cc
@@ -14,10 +14,10 @@ using ::testing::StartsWith;
 
 TEST(TempFile, TypeTraits) {
   EXPECT_TRUE(std::is_default_constructible_v<TempFile>);
-  EXPECT_FALSE(std::is_copy_constructible_v<TempFile>);
-  EXPECT_FALSE(std::is_move_constructible_v<TempFile>);
-  EXPECT_FALSE(std::is_copy_assignable_v<TempFile>);
+  EXPECT_TRUE(std::is_move_constructible_v<TempFile>);
   EXPECT_FALSE(std::is_move_assignable_v<TempFile>);
+  EXPECT_FALSE(std::is_copy_constructible_v<TempFile>);
+  EXPECT_FALSE(std::is_copy_assignable_v<TempFile>);
 }
 
 TEST(TempFile, MultipleTempFilesHaveDifferentPaths) {
@@ -64,10 +64,10 @@ TEST(TempFile, TheTemporaryFileCanBeRemovedAndRecreatedManually) {
 
 TEST(TempDir, TypeTraits) {
   EXPECT_TRUE(std::is_default_constructible_v<TempDir>);
-  EXPECT_FALSE(std::is_copy_constructible_v<TempDir>);
-  EXPECT_FALSE(std::is_move_constructible_v<TempDir>);
-  EXPECT_FALSE(std::is_copy_assignable_v<TempDir>);
+  EXPECT_TRUE(std::is_move_constructible_v<TempDir>);
   EXPECT_FALSE(std::is_move_assignable_v<TempDir>);
+  EXPECT_FALSE(std::is_copy_constructible_v<TempDir>);
+  EXPECT_FALSE(std::is_copy_assignable_v<TempDir>);
 }
 
 TEST(TempDir, TheTemporaryDirectoryExistsAfterCreation) {


### PR DESCRIPTION
Transferring file/directory ownership won't affect underlying entities.