### PR TITLE
Fix Go hash benchmark and align C++ benchmark with Go problem sizes

### DIFF
--- a/cpp/common/hash_benchmark.cc
+++ b/cpp/common/hash_benchmark.cc
@@ -22,7 +22,7 @@ void BM_Sha256Hash(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Sha256Hash)->Range(1, 1 << 20);
+BENCHMARK(BM_Sha256Hash)->Range(1, 1 << 21);
 
 // Same as above, but uses a new Sha256 context every time.
 void BM_Sha256HashNoReuse(benchmark::State& state) {
@@ -35,7 +35,7 @@ void BM_Sha256HashNoReuse(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Sha256HashNoReuse)->Range(1, 1 << 20);
+BENCHMARK(BM_Sha256HashNoReuse)->Range(1, 1 << 21);
 
 // Benchmarks the computation of a chain of hashes from 32 byte keys.
 void BM_Sha256HashKeyChain(benchmark::State& state) {
@@ -51,7 +51,7 @@ void BM_Sha256HashKeyChain(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Sha256HashKeyChain)->Range(1, 1 << 10)->Arg(100);
+BENCHMARK(BM_Sha256HashKeyChain)->Range(1, 1 << 12)->Arg(100);
 
 }  // namespace
 }  // namespace carmen::backend::store

--- a/go/common/benchmarkhasher_test.go
+++ b/go/common/benchmarkhasher_test.go
@@ -23,14 +23,13 @@ const step = 3
 // BenchmarkNewHashEveryLoop hashes a number of bytes and creates a new hash every loop
 func BenchmarkNewHashEveryLoop(b *testing.B) {
 	for i := 1; i <= numBytes; i = i << step {
-		hash := make([]byte, i)
+		data := make([]byte, i)
 		b.Run(fmt.Sprintf("NewHashEveryLoop n %d", i), func(b *testing.B) {
 			for i := 1; i <= b.N; i++ {
 				h := sha256.New()
-				h.Write(hash)
-				hash = h.Sum(nil)
+				h.Write(data)
+				sink = h.Sum(nil)
 			}
-			sink = hash
 		})
 	}
 }
@@ -38,15 +37,14 @@ func BenchmarkNewHashEveryLoop(b *testing.B) {
 // BenchmarkOneHashAllLoops hashes a number of bytes and creates one local hasher for all loops
 func BenchmarkOneHashAllLoops(b *testing.B) {
 	for i := 1; i <= numBytes; i = i << step {
-		hash := make([]byte, i)
+		data := make([]byte, i)
 		localHash := sha256.New()
 		b.Run(fmt.Sprintf("OneHashAllLoops n %d", i), func(b *testing.B) {
 			for i := 1; i <= b.N; i++ {
 				localHash.Reset()
-				localHash.Write(hash)
-				hash = localHash.Sum(nil)
+				localHash.Write(data)
+				sink = localHash.Sum(nil)
 			}
-			sink = hash
 		})
 	}
 }
@@ -54,14 +52,13 @@ func BenchmarkOneHashAllLoops(b *testing.B) {
 // BenchmarkOneGlobalHash hashes a number of bytes and uses a global variable hasher
 func BenchmarkOneGlobalHash(b *testing.B) {
 	for i := 1; i <= numBytes; i = i << step {
-		hash := make([]byte, i)
+		data := make([]byte, i)
 		b.Run(fmt.Sprintf("OneGlobalHash n %d", i), func(b *testing.B) {
 			for i := 1; i <= b.N; i++ {
 				globalHash.Reset()
-				globalHash.Write(hash)
-				hash = globalHash.Sum(nil)
+				globalHash.Write(data)
+				sink = globalHash.Sum(nil)
 			}
-			sink = hash
 		})
 	}
 }


### PR DESCRIPTION
The Go version of the benchmarks was not enforcing the required input sizes. This got fixed. Also, the input problem sizes got aligned.

The following tables show benchmark results as obtained on the reference node `profiling5`:

Go results obtained by running `go test --bench . ./common`:
```
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_1-32                6194990               327.1 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_8-32                3587617               280.4 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_64-32               3273531               421.6 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_512-32              1000000              1145 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_4096-32              177586              6893 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_32768-32              21364             53782 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_262144-32              2682            432586 ns/op
BenchmarkNewHashEveryLoop/NewHashEveryLoop_n_2097152-32              340           3379625 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_1-32                  4448618               333.9 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_8-32                  3569887               323.1 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_64-32                 2571310               397.2 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_512-32                1081084              1144 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_4096-32                179589              7061 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_32768-32                22416             54741 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_262144-32                2827            419200 ns/op
BenchmarkOneHashAllLoops/OneHashAllLoops_n_2097152-32                337           3366389 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_1-32                      4495496               280.9 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_8-32                      4541985               319.8 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_64-32                     2685727               446.7 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_512-32                    1038166              1128 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_4096-32                    171910              7041 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_32768-32                    21340             53844 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_262144-32                    2726            430662 ns/op
BenchmarkOneGlobalHash/OneGlobalHash_n_2097152-32                    332           3545876 ns/op
BenchmarkHashKeyChain/HashKeyChain_n_1-32                        2087319               541.9 ns/op
BenchmarkHashKeyChain/HashKeyChain_n_8-32                         350406              3237 ns/op
BenchmarkHashKeyChain/HashKeyChain_n_64-32                         48805             25110 ns/op
BenchmarkHashKeyChain/HashKeyChain_n_512-32                         6130            209403 ns/op
BenchmarkHashKeyChain/HashKeyChain_n_4096-32                         835           1736514 ns/op
```

C++ results obtained by running `bazel run -c opt //common:hash_benchmark`
```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
BM_Sha256Hash/1                    50.0 ns         50.0 ns     14134645
BM_Sha256Hash/8                    48.4 ns         48.4 ns     14353608
BM_Sha256Hash/64                   74.9 ns         74.9 ns      9317696
BM_Sha256Hash/512                   268 ns          268 ns      2636326
BM_Sha256Hash/4096                 1809 ns         1809 ns       386372
BM_Sha256Hash/32768               14129 ns        14129 ns        49491
BM_Sha256Hash/262144             112855 ns       112852 ns         6189
BM_Sha256Hash/2097152            900092 ns       900077 ns          774
BM_Sha256HashNoReuse/1             89.7 ns         89.7 ns      7981152
BM_Sha256HashNoReuse/8             89.0 ns         89.0 ns      7822132
BM_Sha256HashNoReuse/64             116 ns          116 ns      6097789
BM_Sha256HashNoReuse/512            309 ns          309 ns      2267287
BM_Sha256HashNoReuse/4096          1858 ns         1858 ns       375876
BM_Sha256HashNoReuse/32768        14194 ns        14194 ns        49134
BM_Sha256HashNoReuse/262144      112817 ns       112816 ns         6196
BM_Sha256HashNoReuse/2097152     901476 ns       901457 ns          776
BM_Sha256HashKeyChain/1            84.0 ns         84.0 ns      8284939
BM_Sha256HashKeyChain/8             661 ns          661 ns      1055565
BM_Sha256HashKeyChain/64           5277 ns         5276 ns       131961
BM_Sha256HashKeyChain/512         42261 ns        42260 ns        16601
BM_Sha256HashKeyChain/4096       345336 ns       345330 ns         2029
BM_Sha256HashKeyChain/100          8428 ns         8428 ns        82437
```