### PR TITLE
Add utilities to simplify the absl::Status based error handling

### DIFF
--- a/cpp/common/BUILD
+++ b/cpp/common/BUILD
@@ -113,3 +113,51 @@ cc_binary(
         "//third_party/gperftools:profiler",
     ],
 )
+
+cc_library(
+    name="status_util",
+    hdrs=["status_util.h"],
+    deps=[
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status:statusor"
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "status_util_test",
+    srcs = ["status_util_test.cc"],
+    deps = [
+        ":status_util",
+        ":status_test_util",
+        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name="status_test_util",
+    hdrs=["status_test_util.h"],
+    deps=[
+        ":status_util",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status:statusor"
+    ],
+    visibility = ["//visibility:public"],
+    testonly = True,
+)
+
+cc_test(
+    name = "status_test_util_test",
+    srcs = ["status_test_util_test.cc"],
+    deps = [
+        ":status_test_util",
+        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/cpp/common/status_test_util.h
+++ b/cpp/common/status_test_util.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "absl/strings/str_cat.h"
+#include "common/status_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// A few additional gtest expectations and assertions.
+#define EXPECT_OK(expr) EXPECT_TRUE((expr).ok())
+#define ASSERT_OK(expr) ASSERT_TRUE((expr).ok())
+
+// The implementation of ASSERT_OK_AND_ASSIGN below, more compact as if it would
+// be if it would be written inline.
+#define INTERNAL_ASSERT_OK_AND_ASSIGN_IMPL(lhs, expr, var) \
+  auto var = (expr);                                       \
+  ASSERT_THAT(var, ::testing::IsOk());                     \
+  lhs = *var;
+
+// The ASSERT_OK_AND_ASSIGN macro can be used in test cases where the OK status
+// of a StatusOr value should be asserted and the status part stripped.
+//
+// Example: instead of writing
+//
+//    auto status_or_value = <expr>;
+//    ASSERT_OK(status_or_value);
+//    lhs = *status_or_value;
+//
+// this macro can be used to write
+//
+//    ASSERT_OK_AND_ASSIGN(lhs, <expr>);
+//
+// instead. The macro also works with declarations, such that one could write
+//
+//    ASSERT_OK_AND_ASSIGN(auto x, <expr>);
+//
+// to declare and initialize a new variable x in the current scope. The variable
+// X will be of the value type stored inside the StatusOr type.
+#define ASSERT_OK_AND_ASSIGN(lhs, expr) \
+  INTERNAL_ASSERT_OK_AND_ASSIGN_IMPL(lhs, expr, CONCAT(_status_, __LINE__))
+
+namespace testing {
+
+namespace internal {
+
+absl::StatusCode GetCode(const absl::Status& status) { return status.code(); }
+
+template <typename T>
+absl::StatusCode GetCode(const absl::StatusOr<T>& status) {
+  return GetCode(status.status());
+}
+
+absl::string_view GetMessage(const absl::Status& status) {
+  return status.message();
+}
+
+template <typename T>
+absl::string_view GetMessage(const absl::StatusOr<T>& status) {
+  return GetMessage(status.status());
+}
+
+}  // namespace internal
+
+// Defines a IsOk matcher for matching Status or StatusOr using EXPECT_THAT.
+// Example use:
+//   EXPECT_THAT(<expr>, IsOk());
+MATCHER(IsOk, absl::StrCat(negation ? "isn't" : "is", " OK status")) {
+  *result_listener << "where status code is "
+                   << ::testing::internal::GetCode(arg);
+  return arg.ok();
+}
+
+// Defines a StatusIs matcher for matching the value Status or StatusOr values.
+// Example uses:
+//   EXPECT_THAT(<expr>, StatusIs(absl::StatusCode::kInvalidArgument,_));
+//   EXPECT_THAT(<expr>, StatusIs(_,StrEq("File does not exist.")));
+MATCHER_P2(StatusIs, code, msg,
+           absl::StrCat(
+               "status code ",
+               ::testing::DescribeMatcher<absl::StatusCode>(code, negation),
+               " and message ",
+               ::testing::DescribeMatcher<absl::string_view>(msg, negation))) {
+  return ExplainMatchResult(code, ::testing::internal::GetCode(arg),
+                            result_listener) &&
+         ExplainMatchResult(msg, ::testing::internal::GetMessage(arg),
+                            result_listener);
+}
+
+}  // namespace testing

--- a/cpp/common/status_test_util_test.cc
+++ b/cpp/common/status_test_util_test.cc
@@ -1,0 +1,56 @@
+#include "common/status_test_util.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+using ::testing::_;
+using ::testing::IsOk;
+using ::testing::Not;
+using ::testing::StatusIs;
+using ::testing::StrEq;
+
+TEST(StatusTestUtilTest, ExpectOkWorks) { EXPECT_OK(absl::OkStatus()); }
+
+TEST(StatusTestUtilTest, AssertOkWorks) { ASSERT_OK(absl::OkStatus()); }
+
+TEST(StatusTestUtilTest, IsOkMatcherWorksOnStatus) {
+  auto ok = absl::OkStatus();
+  auto err = absl::InvalidArgumentError("test");
+  EXPECT_THAT(ok, IsOk());
+  EXPECT_THAT(err, Not(IsOk()));
+}
+
+TEST(StatusTestUtilTest, IsOkMatcherWorksOnStatusOr) {
+  absl::StatusOr<int> ok = 12;
+  absl::StatusOr<int> err = absl::InvalidArgumentError("test");
+  EXPECT_THAT(ok, IsOk());
+  EXPECT_THAT(err, Not(IsOk()));
+}
+
+TEST(StatusTestUtilTest, StatusIsMatcherWorks) {
+  auto ok = absl::OkStatus();
+  auto err = absl::InvalidArgumentError("test");
+  EXPECT_THAT(ok, StatusIs(absl::StatusCode::kOk, _));
+  EXPECT_THAT(err, StatusIs(absl::StatusCode::kInvalidArgument, _));
+  EXPECT_THAT(err, StatusIs(_, StrEq("test")));
+}
+
+TEST(StatusTestUtilTest, StatusIsMatcherWorksOnStatusOr) {
+  absl::StatusOr<int> ok = 12;
+  absl::StatusOr<int> err = absl::InvalidArgumentError("test");
+  EXPECT_THAT(ok, StatusIs(absl::StatusCode::kOk, _));
+  EXPECT_THAT(err, StatusIs(absl::StatusCode::kInvalidArgument, _));
+  EXPECT_THAT(err, StatusIs(_, StrEq("test")));
+}
+
+TEST(StatusTestUtilTest, AssertOkAndAssingWorks) {
+  ASSERT_OK_AND_ASSIGN(auto x, absl::StatusOr<int>(12));
+  EXPECT_EQ(x, 12);
+  ASSERT_OK_AND_ASSIGN(x, absl::StatusOr<int>(14));
+  EXPECT_EQ(x, 14);
+}
+
+}  // namespace

--- a/cpp/common/status_util.h
+++ b/cpp/common/status_util.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <utility>
+
+#include "absl/base/optimization.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+// This header provides a few utility macros for dealing with absl::Status and
+// absl::StatusOr values. The main intention is to make code using Status codes
+// more concise and readable.
+//
+// Additional utilities for writing unit tests using Status values can be found
+// in status_util_test.h
+//
+// Additional links:
+//  - Error code selection guides:
+//  https://abseil.io/docs/cpp/guides/status-codes
+//
+// Note: this header may in the future be replaced by a solution provided by
+// googletest.
+
+// Concatenates the provided arguments into a single token.
+#define CONCAT(a, b) CONCAT_INNER(a, b)
+#define CONCAT_INNER(a, b) a##b
+
+namespace testing::internal {
+
+absl::Status GetStatus(absl::Status status) { return status; }
+
+template <typename T>
+absl::Status GetStatus(absl::StatusOr<T> status) {
+  return status.status();
+}
+
+}  // namespace testing::internal
+
+// The implementation of RETURN_IF_ERROR below, more compact as if it would be
+// if it would be written inline.
+#define INTERNAL_RETURN_IF_ERROR_IMPL(expr, var) \
+  auto var = (expr);                             \
+  if (ABSL_PREDICT_FALSE(!var.ok()))             \
+    return ::testing::internal::GetStatus(std::move(var));
+
+// A macro to evaluate a given expression returning a Status or a StatusOr
+// value and returning an error if the expression failed. Thus, instead of
+// writing
+//
+//   auto status = <expr>;
+//   if (!status.ok()) return status;
+//
+// one can use this macro to write
+//
+//   RETURN_IF_ERROR(<expr>);
+//
+// Note, for this to work, the enclosing function must return a Status or a
+// StatusOr.
+#define RETURN_IF_ERROR(expr) \
+  INTERNAL_RETURN_IF_ERROR_IMPL(expr, CONCAT(_status_, __LINE__))
+
+// The implementation of ASSIGN_OR_RETURN below, more compact as if it would be
+// if it would be written inline.
+#define INTERNAL_ASSIGN_OR_RETURN_IMPL(lhs, expr, var)    \
+  auto var = (expr);                                      \
+  if (ABSL_PREDICT_FALSE(!var.ok())) return var.status(); \
+  lhs = *var;
+
+// A macro to evaluate a given expression returning a StatusOr value and
+// returning from the current function scope if the value could not be obtained.
+// Thus, instead of writing
+//
+//   auto status_or = <expr>;
+//   if (!status_or.ok()) return status_or.status;
+//   lhs = *status_or;
+//
+// one can use this macro to write
+//
+//   ASSIGN_OR_RETURN(lhs, <expr>);
+//
+// The <lhs> can also be a variable declaration.
+//
+// Note, for this to work, the enclosing function must return a Status or a
+// StatusOr.
+#define ASSIGN_OR_RETURN(lhs, expr) \
+  INTERNAL_ASSIGN_OR_RETURN_IMPL(lhs, expr, CONCAT(_status_, __LINE__))

--- a/cpp/common/status_util_test.cc
+++ b/cpp/common/status_util_test.cc
@@ -1,0 +1,92 @@
+#include "common/status_util.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "common/status_test_util.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+using ::testing::_;
+using ::testing::IsOk;
+using ::testing::Not;
+using ::testing::StatusIs;
+
+absl::Status Ok() { return absl::OkStatus(); }
+
+absl::Status Fail() { return absl::UnknownError("fail"); }
+
+absl::Status Process() { return Ok(); }
+
+template <typename First, typename... Rest>
+absl::Status Process(First&& op, Rest&&... rest) {
+  RETURN_IF_ERROR(op());
+  return Process(std::forward<Rest>(rest)...);
+}
+
+TEST(StatusMacroTest, ReturnIfErrorWorks) {
+  EXPECT_TRUE(Process(&Ok, &Ok).ok());
+  EXPECT_FALSE(Process(&Ok, &Fail).ok());
+  EXPECT_FALSE(Process(&Fail, &Ok).ok());
+}
+
+template <typename A, typename B, typename C>
+absl::Status DoAll(A&& a, B&& b, C&& c) {
+  RETURN_IF_ERROR(a());
+  RETURN_IF_ERROR(b());
+  return c();
+}
+
+TEST(StatusMacroTest, MultipleReturnIfWorkInOneFunction) {
+  EXPECT_TRUE(DoAll(&Ok, &Ok, &Ok).ok());
+  EXPECT_FALSE(DoAll(&Fail, &Ok, &Ok).ok());
+  EXPECT_FALSE(DoAll(&Ok, &Fail, &Ok).ok());
+  EXPECT_FALSE(DoAll(&Ok, &Ok, &Fail).ok());
+}
+
+absl::StatusOr<int> Get(int i) { return i; }
+
+absl::StatusOr<int> Fail(int) { return absl::InternalError("triggered fail"); }
+
+TEST(StatusMacroTest, ReturnIfErrorWorksWithStatusAndStatusOr) {
+  EXPECT_OK(Process(&Ok, [] { return Get(12); }));
+  EXPECT_THAT(Process(&Ok, [] { return Fail(12); }), Not(IsOk()));
+}
+
+absl::StatusOr<int> IncWithAssignment(int x) {
+  // A variable can be assigned as part of the macro.
+  int y = -1;
+  ASSIGN_OR_RETURN(y, Get(x));
+  return y + 1;
+}
+
+absl::StatusOr<int> IncWithDeclaration(int x) {
+  // A variable can be declared as part of the macro.
+  ASSIGN_OR_RETURN(auto y, Get(x));
+  return y + 1;
+}
+
+TEST(StatusMacroTest, AssignOrReturnWorks) {
+  ASSERT_OK_AND_ASSIGN(int x, IncWithAssignment(10));
+  EXPECT_EQ(x, 11);
+  ASSERT_OK_AND_ASSIGN(x, IncWithDeclaration(15));
+  EXPECT_EQ(x, 16);
+}
+
+template <typename Source>
+absl::Status AssignAndReturnError(Source src) {
+  ASSIGN_OR_RETURN(auto y, src());
+  if (y > 0) {
+    return absl::InternalError("y should be zero");
+  }
+  return absl::OkStatus();
+}
+
+TEST(StatusMacroTest, AssignOrReturnCanReturnPlainStatus) {
+  EXPECT_OK(AssignAndReturnError([] { return Get(0); }));
+  EXPECT_THAT(AssignAndReturnError([] { return Fail(0); }), Not(IsOk()));
+  EXPECT_THAT(AssignAndReturnError([] { return Get(1); }),
+              StatusIs(absl::StatusCode::kInternal, _));
+}
+
+}  // namespace


### PR DESCRIPTION
This PR adds utilities to simplify the usage of absl::Status and absl::StatusOr values in code.

For regular code, the following macros are added:
 - RETURN_IF_ERROR(\<expr\>)
 - ASSIGN_OR_RETURN(\<lhs\>, \<expr\>)

Furthermore, for testing in unit tests, the following utilities are provided
 - EXPECT_OK(..)
 - ASSERT_OK(..)
 - IsOk() matcher for use in EXPECT_THAT or ASSERT_THAT
 - StatusIs() matcher for use in EXPECT_THAT or ASSERT_THAT


Note: some of the definitions may become redundant once these are introduced in the google test library upstream (see [here](https://github.com/abseil/abseil-cpp/issues/951))