### PR TITLE
Renames build target for C++ library to avoid name collisions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Build C++ libraries
       working-directory: ./go/lib
-      run: ./build_libstate.sh
+      run: ./build_libcarmen.sh
 
     - name: Build
       working-directory: ./go

--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -44,7 +44,7 @@ cc_test(
 )
 
 cc_binary(
-  name = "libstate.so",
+  name = "libcarmen.so",
   linkshared = True,
   deps = [
      ":c_state",

--- a/go/lib/build_libcarmen.sh
+++ b/go/lib/build_libcarmen.sh
@@ -11,7 +11,7 @@
 #
 set -e
 cd ../../cpp
-bazel build -c opt //state:libstate.so
+bazel build -c opt //state:libcarmen.so
 mkdir -p ../go/lib
-rm -f ../go/lib/libstate.so
-cp ./bazel-bin/state/libstate.so ../go/lib
+rm -f ../go/lib/libcarmen.so
+cp ./bazel-bin/state/libcarmen.so ../go/lib

--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -1,10 +1,10 @@
 package state
 
-//go:generate sh ../lib/build_libstate.sh
+//go:generate sh ../lib/build_libcarmen.sh
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../cpp
-#cgo LDFLAGS: -L${SRCDIR}/../lib -lstate
+#cgo LDFLAGS: -L${SRCDIR}/../lib -lcarmen
 #cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../lib
 #include <stdlib.h>
 #include "state/c_state.h"


### PR DESCRIPTION
The state library and the libstate.so binary may on systems using shared library produce the same build artefacts.