### PR TITLE
Kjezek/improve convert key performance

### DIFF
--- a/go/backend/hashtree/htldb/hashtree.go
+++ b/go/backend/hashtree/htldb/hashtree.go
@@ -77,7 +77,9 @@ func (ht *HashTree) childrenOfNode(layer, node int) (data []byte, err error) {
 	// use iterator to read nodes for the current branching factor
 	firstNode := ht.firstChildOf(node)
 	lastNode := firstNode + ht.factor
-	r := util.Range{Start: ht.convertKey(layer-1, firstNode), Limit: ht.convertKey(layer-1, lastNode)}
+	dbStartKey := ht.convertKey(layer-1, firstNode).ToBytes()
+	dbEndKey := ht.convertKey(layer-1, lastNode).ToBytes()
+	r := util.Range{Start: dbStartKey, Limit: dbEndKey}
 	iter := ht.db.NewIterator(&r, nil)
 	defer iter.Release()
 
@@ -99,8 +101,8 @@ func (ht *HashTree) childrenOfNode(layer, node int) (data []byte, err error) {
 // layerLength returns index of last nodes in this layer, which is the length of this layer
 func (ht *HashTree) layerLength(layer int) (length int, err error) {
 	// set the range for full layer
-	firstNode := ht.convertKey(layer, 0)
-	lastNode := ht.convertKey(layer, 0xFFFF)
+	firstNode := ht.convertKey(layer, 0).ToBytes()
+	lastNode := ht.convertKey(layer, 0xFFFF).ToBytes()
 	r := util.Range{Start: firstNode, Limit: lastNode}
 	iter := ht.db.NewIterator(&r, nil)
 	defer iter.Release()
@@ -116,8 +118,8 @@ func (ht *HashTree) layerLength(layer int) (length int, err error) {
 // getRootHash reads the root hash from the database
 func (ht *HashTree) getRootHash() (hash []byte, err error) {
 	// set the range for full layers
-	firstNode := ht.convertKey(0, 0)
-	lastNode := ht.convertKey(0xFF, 0)
+	firstNode := ht.convertKey(0, 0).ToBytes()
+	lastNode := ht.convertKey(0xFF, 0).ToBytes()
 	r := util.Range{Start: firstNode, Limit: lastNode}
 	iter := ht.db.NewIterator(&r, nil)
 	defer iter.Release()
@@ -131,7 +133,8 @@ func (ht *HashTree) getRootHash() (hash []byte, err error) {
 
 // updateNode updates the hash-node value to the given value
 func (ht *HashTree) updateNode(layer, node int, nodeHash []byte) error {
-	return ht.db.Put(ht.convertKey(layer, node), nodeHash, nil)
+	dbKey := ht.convertKey(layer, node).ToBytes()
+	return ht.db.Put(dbKey, nodeHash, nil)
 }
 
 // parentOf provides an index of a parent node, by the child index
@@ -157,7 +160,7 @@ func (ht *HashTree) calculateHash(hasher hash.Hash, content []byte) (hash []byte
 // updateDirtyNodes updates parent nodes marked as dirty with a hash of its children
 func (ht *HashTree) updateDirtyNodes(layer int, dirtyNodes map[int]bool, hasher hash.Hash) (newDirtyNodes map[int]bool, nodeHash []byte, err error) {
 	newDirtyNodes = make(map[int]bool)
-	for node, _ := range dirtyNodes {
+	for node := range dirtyNodes {
 		var content []byte
 		if layer == 0 {
 			// hash the data of the page
@@ -221,11 +224,11 @@ func (ht *HashTree) commit() (hash []byte, err error) {
 	return
 }
 
-func (ht *HashTree) convertKey(layer, node int) []byte {
+func (ht *HashTree) convertKey(layer, node int) common.DbKey {
 	//  the key is: [tableSpace]H[layer][node]
 	// layer is 8bit (256 layers Max)
 	// node is 16bit
-	return ht.table.AppendKey(
-		common.HashKey.AppendKey(
+	return ht.table.DBToDBKey(
+		common.HashKey.ToDBKey(
 			binary.BigEndian.AppendUint16([]byte{uint8(layer)}, uint16(node))))
 }

--- a/go/backend/index/ldb/leveldb.go
+++ b/go/backend/index/ldb/leveldb.go
@@ -33,7 +33,8 @@ func NewIndex[K comparable, I common.Identifier](
 
 	// read the last hash from the database
 	var hash []byte
-	if hash, err = db.Get(table.AppendKeyStr(HashKey), nil); err != nil {
+	hashDbKey := table.StrToDBKey(HashKey).ToBytes()
+	if hash, err = db.Get(hashDbKey, nil); err != nil {
 		if err == errors.ErrNotFound {
 			hash = []byte{}
 		} else {
@@ -43,7 +44,8 @@ func NewIndex[K comparable, I common.Identifier](
 
 	// read the last index from the database
 	var last []byte
-	if last, err = db.Get(table.AppendKeyStr(LastIndexKey), nil); err != nil {
+	lastDbKey := table.StrToDBKey(LastIndexKey).ToBytes()
+	if last, err = db.Get(lastDbKey, nil); err != nil {
 		if err == errors.ErrNotFound {
 			last = make([]byte, 4)
 		} else {
@@ -69,7 +71,8 @@ func NewIndex[K comparable, I common.Identifier](
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *Index[K, I]) GetOrAdd(key K) (idx I, err error) {
 	var val []byte
-	if val, err = m.db.Get(m.convertKey(key), nil); err != nil {
+	dbKey := m.convertKey(key).ToBytes()
+	if val, err = m.db.Get(dbKey, nil); err != nil {
 		// if the error is actually a non-existing key, we assign a new index
 		if err == errors.ErrNotFound {
 
@@ -80,9 +83,10 @@ func (m *Index[K, I]) GetOrAdd(key K) (idx I, err error) {
 			m.lastIndex = m.lastIndex + 1
 			nextIdxArr := m.indexSerializer.ToBytes(m.lastIndex)
 
+			lastIndexDbKey := m.convertKeyStr(LastIndexKey).ToBytes()
 			batch := new(leveldb.Batch)
-			batch.Put(m.convertKeyStr(LastIndexKey), nextIdxArr)
-			batch.Put(m.convertKey(key), idxArr)
+			batch.Put(lastIndexDbKey, nextIdxArr)
+			batch.Put(dbKey, idxArr)
 			if err = m.db.Write(batch, nil); err != nil {
 				return
 			}
@@ -100,7 +104,8 @@ func (m *Index[K, I]) GetOrAdd(key K) (idx I, err error) {
 // Get returns an index mapping for the key, returns index.ErrNotFound if not exists
 func (m *Index[K, I]) Get(key K) (idx I, err error) {
 	var val []byte
-	if val, err = m.db.Get(m.convertKey(key), nil); err != nil {
+	dbKey := m.convertKey(key).ToBytes()
+	if val, err = m.db.Get(dbKey, nil); err != nil {
 		if err == errors.ErrNotFound {
 			err = index.ErrNotFound
 		}
@@ -113,7 +118,8 @@ func (m *Index[K, I]) Get(key K) (idx I, err error) {
 
 // Contains returns whether the key exists in the mapping or not.
 func (m *Index[K, I]) Contains(key K) bool {
-	exists, _ := m.db.Has(m.convertKey(key), nil)
+	dbKey := m.convertKey(key).ToBytes()
+	exists, _ := m.db.Has(dbKey, nil)
 	return exists
 }
 
@@ -128,19 +134,21 @@ func (m *Index[K, I]) Close() error {
 	if err != nil {
 		return err
 	}
-	return m.db.Put(m.convertKeyStr(HashKey), m.hashSerializer.ToBytes(hash), nil)
+
+	dbKey := m.convertKeyStr(HashKey).ToBytes()
+	return m.db.Put(dbKey, m.hashSerializer.ToBytes(hash), nil)
 }
 
 // convertKey translates the Index representation of the key into a database key.
 // The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
 // by the key serializer
-func (m *Index[K, I]) convertKey(key K) []byte {
-	return m.table.AppendKey(m.keySerializer.ToBytes(key))
+func (m *Index[K, I]) convertKey(key K) common.DbKey {
+	return m.table.ToDBKey(m.keySerializer.ToBytes(key))
 }
 
 // convertKeyStr translates the Index representation of the key into a database key.
 // The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
 // from string
-func (m *Index[K, I]) convertKeyStr(key string) []byte {
-	return m.table.AppendKeyStr(key)
+func (m *Index[K, I]) convertKeyStr(key string) common.DbKey {
+	return m.table.StrToDBKey(key)
 }

--- a/go/backend/index/ldb/transactleveldb.go
+++ b/go/backend/index/ldb/transactleveldb.go
@@ -28,7 +28,7 @@ func NewTransactIndex[K comparable, I common.Identifier](
 
 	// read the last hash from the database
 	var hash []byte
-	if hash, err = tr.Get(table.AppendKeyStr(HashKey), nil); err != nil {
+	if hash, err = tr.Get(table.StrToDBKey(HashKey).ToBytes(), nil); err != nil {
 		if err == errors.ErrNotFound {
 			hash = []byte{}
 		} else {
@@ -38,7 +38,7 @@ func NewTransactIndex[K comparable, I common.Identifier](
 
 	// read the last index from the database
 	var last []byte
-	if last, err = tr.Get(table.AppendKeyStr(LastIndexKey), nil); err != nil {
+	if last, err = tr.Get(table.StrToDBKey(LastIndexKey).ToBytes(), nil); err != nil {
 		if err == errors.ErrNotFound {
 			last = make([]byte, 4)
 		} else {
@@ -64,7 +64,7 @@ func NewTransactIndex[K comparable, I common.Identifier](
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *TransactIndex[K, I]) GetOrAdd(key K) (idx I, err error) {
 	var val []byte
-	if val, err = m.tr.Get(m.convertKey(key), nil); err != nil {
+	if val, err = m.tr.Get(m.convertKey(key).ToBytes(), nil); err != nil {
 		// if the error is actually a non-existing key, we assign a new index
 		if err == errors.ErrNotFound {
 
@@ -76,8 +76,8 @@ func (m *TransactIndex[K, I]) GetOrAdd(key K) (idx I, err error) {
 			nextIdxArr := m.indexSerializer.ToBytes(m.lastIndex)
 
 			batch := new(leveldb.Batch)
-			batch.Put(m.convertKeyStr(LastIndexKey), nextIdxArr)
-			batch.Put(m.convertKey(key), idxArr)
+			batch.Put(m.convertKeyStr(LastIndexKey).ToBytes(), nextIdxArr)
+			batch.Put(m.convertKey(key).ToBytes(), idxArr)
 			if err = m.tr.Write(batch, nil); err != nil {
 				return
 			}
@@ -95,7 +95,7 @@ func (m *TransactIndex[K, I]) GetOrAdd(key K) (idx I, err error) {
 // Get returns an index mapping for the key, returns index.ErrNotFound if not exists
 func (m *TransactIndex[K, I]) Get(key K) (idx I, err error) {
 	var val []byte
-	if val, err = m.tr.Get(m.convertKey(key), nil); err != nil {
+	if val, err = m.tr.Get(m.convertKey(key).ToBytes(), nil); err != nil {
 		if err == errors.ErrNotFound {
 			err = index.ErrNotFound
 		}
@@ -108,7 +108,7 @@ func (m *TransactIndex[K, I]) Get(key K) (idx I, err error) {
 
 // Contains returns whether the key exists in the mapping or not.
 func (m *TransactIndex[K, I]) Contains(key K) bool {
-	exists, _ := m.tr.Has(m.convertKey(key), nil)
+	exists, _ := m.tr.Has(m.convertKey(key).ToBytes(), nil)
 	return exists
 }
 
@@ -123,19 +123,19 @@ func (m *TransactIndex[K, I]) Close() error {
 	if err != nil {
 		return err
 	}
-	return m.tr.Put(m.convertKeyStr(HashKey), m.hashSerializer.ToBytes(hash), nil)
+	return m.tr.Put(m.convertKeyStr(HashKey).ToBytes(), m.hashSerializer.ToBytes(hash), nil)
 }
 
 // convertKey translates the TransactIndex representation of the key into a database key.
 // The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
 // by the key serializer
-func (m *TransactIndex[K, I]) convertKey(key K) []byte {
-	return m.table.AppendKey(m.keySerializer.ToBytes(key))
+func (m *TransactIndex[K, I]) convertKey(key K) common.DbKey {
+	return m.table.ToDBKey(m.keySerializer.ToBytes(key))
 }
 
 // convertKeyStr translates the TransactIndex representation of the key into a database key.
 // The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
 // from string
-func (m *TransactIndex[K, I]) convertKeyStr(key string) []byte {
-	return m.table.AppendKeyStr(key)
+func (m *TransactIndex[K, I]) convertKeyStr(key string) common.DbKey {
+	return m.table.StrToDBKey(key)
 }

--- a/go/common/benchmarkscheme_test.go
+++ b/go/common/benchmarkscheme_test.go
@@ -1,0 +1,16 @@
+package common
+
+import "testing"
+
+var dbKeySink DbKey
+
+func BenchmarkConvertTableSpaceSerializer(b *testing.B) {
+	serializer := KeySerializer{}
+	prefix := BalanceKey
+	key := Key{}
+	for i := 1; i <= b.N; i++ {
+		key[0] = byte(i)
+		bytes := serializer.ToBytes(key) // convert within the benchmark
+		dbKeySink = prefix.ToDBKey(bytes)
+	}
+}

--- a/go/common/scheme.go
+++ b/go/common/scheme.go
@@ -16,14 +16,34 @@ const (
 	HashKey TableSpace = 'H'
 )
 
-// AppendKey converts the input key to its respective table space
-func (t TableSpace) AppendKey(key []byte) []byte {
-	b := []byte{byte(t)}
-	return append(b, key...)
+// DbKey expects max size of the 32B key plus at most two bytes
+// for the table prefix (e.g. balance, nonce, slot, ...) and the domain (e.g. data, hash, ...)
+type DbKey [34]byte
+
+func (d DbKey) ToBytes() []byte {
+	return d[:]
 }
 
-// AppendKeyStr converts the input key to its respective table space
-func (t TableSpace) AppendKeyStr(key string) []byte {
-	b := []byte{byte(t)}
-	return append(b, key...)
+// ToDBKey converts the input key to its respective table space key
+func (t TableSpace) ToDBKey(key []byte) DbKey {
+	var dbKey DbKey
+	dbKey[0] = byte(t)
+	copy(dbKey[1:], key)
+	return dbKey
+}
+
+// DBToDBKey converts the input key to its respective table space key
+func (t TableSpace) DBToDBKey(key DbKey) DbKey {
+	var dbKey DbKey
+	dbKey[0] = byte(t)
+	copy(dbKey[1:], key[:])
+	return dbKey
+}
+
+// StrToDBKey converts the input key to its respective table space key
+func (t TableSpace) StrToDBKey(key string) DbKey {
+	var dbKey DbKey
+	dbKey[0] = byte(t)
+	copy(dbKey[1:], key)
+	return dbKey
 }


### PR DESCRIPTION
This PR improves performance of converting the database Key. The original performance was: 

`BenchmarkAppendKey-8   	46268896	        25.40 ns/op`

Following improvement gave following speed-up:
```
// pre-init capacity of array

	b := make([]byte, 1, len(key)+1)
	b[0] = byte(t)
	return append(b, key...)


BenchmarkAppendKey-8   	66591844	        17.05 ns/op
```

This PR converts into an array instead of a slice, which brings even more speed-up

`BenchmarkConvertTableSpaceSerializer-8   	282529633	         4.107 ns/op`
