### PR TITLE
Optimize `ToDBKey` leveldb index method

### DIFF
--- a/cpp/backend/index/leveldb/index.h
+++ b/cpp/backend/index/leveldb/index.h
@@ -22,7 +22,7 @@ std::string ToDBKey(char key_space, const K& key) {
   std::array<char, sizeof(key) + 1> buffer;
   buffer[0] = key_space;
   memcpy(buffer.data() + 1, &key, sizeof(key));
-  return std::string(buffer.data(), buffer.size());
+  return {buffer.data(), buffer.size()};
 }
 
 // Converts given value into leveldb value.


### PR DESCRIPTION
Previous results:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
BM_ToDBKey<int>          0.570 ns        0.570 ns   1000000000
BM_ToDBKey<Balance>       13.3 ns         13.3 ns     52473534
BM_ToDBKey<Address>       13.3 ns         13.3 ns     52612377
BM_ToDBKey<Hash>          13.4 ns         13.4 ns     52072995
```
New results:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
BM_ToDBKey<int>          0.566 ns        0.566 ns   1000000000
BM_ToDBKey<Balance>       9.50 ns         9.50 ns     74275224
BM_ToDBKey<Address>       9.49 ns         9.49 ns     73479197
BM_ToDBKey<Hash>          9.57 ns         9.57 ns     73607964
```