### PR TITLE
create transactional LevelDB index and benchmark

### DIFF
--- a/go/backend/index/ldb/transactleveldb.go
+++ b/go/backend/index/ldb/transactleveldb.go
@@ -1,0 +1,141 @@
+package ldb
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/hashindex"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
+)
+
+// TransactIndex represents a key-value store for holding the index data.
+type TransactIndex[K comparable, I common.Identifier] struct {
+	tr              *leveldb.Transaction
+	table           common.TableSpace
+	keySerializer   common.Serializer[K]
+	indexSerializer common.Serializer[I]
+	hashIndex       *hashindex.HashIndex[K]
+	lastIndex       I
+	hashSerializer  common.HashSerializer
+}
+
+// NewTransactIndex creates a new instance of the index backed by a persisted database
+func NewTransactIndex[K comparable, I common.Identifier](
+	tr *leveldb.Transaction,
+	table common.TableSpace,
+	keySerializer common.Serializer[K],
+	indexSerializer common.Serializer[I]) (p *TransactIndex[K, I], err error) {
+
+	// read the last hash from the database
+	var hash []byte
+	if hash, err = tr.Get(table.AppendKeyStr(HashKey), nil); err != nil {
+		if err == errors.ErrNotFound {
+			hash = []byte{}
+		} else {
+			return
+		}
+	}
+
+	// read the last index from the database
+	var last []byte
+	if last, err = tr.Get(table.AppendKeyStr(LastIndexKey), nil); err != nil {
+		if err == errors.ErrNotFound {
+			last = make([]byte, 4)
+		} else {
+			return
+		}
+	}
+
+	hashSerializer := common.HashSerializer{}
+	p = &TransactIndex[K, I]{
+		tr:              tr,
+		table:           table,
+		keySerializer:   keySerializer,
+		indexSerializer: indexSerializer,
+		hashIndex:       hashindex.InitHashIndex[K](hashSerializer.FromBytes(hash), keySerializer),
+		lastIndex:       indexSerializer.FromBytes(last),
+		hashSerializer:  hashSerializer,
+	}
+
+	// set err to nil as it can contain an ErrNotFound, which we want to suppress
+	return p, nil
+}
+
+// GetOrAdd returns an index mapping for the key, or creates the new index
+func (m *TransactIndex[K, I]) GetOrAdd(key K) (idx I, err error) {
+	var val []byte
+	if val, err = m.tr.Get(m.convertKey(key), nil); err != nil {
+		// if the error is actually a non-existing key, we assign a new index
+		if err == errors.ErrNotFound {
+
+			// map the input key to the next level as well as storing the next index
+			idx = m.lastIndex
+			idxArr := m.indexSerializer.ToBytes(m.lastIndex)
+
+			m.lastIndex = m.lastIndex + 1
+			nextIdxArr := m.indexSerializer.ToBytes(m.lastIndex)
+
+			batch := new(leveldb.Batch)
+			batch.Put(m.convertKeyStr(LastIndexKey), nextIdxArr)
+			batch.Put(m.convertKey(key), idxArr)
+			if err = m.tr.Write(batch, nil); err != nil {
+				return
+			}
+			m.hashIndex.AddKey(key)
+		} else {
+			return
+		}
+	} else {
+		idx = m.indexSerializer.FromBytes(val)
+	}
+
+	return idx, nil
+}
+
+// Get returns an index mapping for the key, returns index.ErrNotFound if not exists
+func (m *TransactIndex[K, I]) Get(key K) (idx I, err error) {
+	var val []byte
+	if val, err = m.tr.Get(m.convertKey(key), nil); err != nil {
+		if err == errors.ErrNotFound {
+			err = index.ErrNotFound
+		}
+		return
+	}
+
+	idx = m.indexSerializer.FromBytes(val)
+	return idx, nil
+}
+
+// Contains returns whether the key exists in the mapping or not.
+func (m *TransactIndex[K, I]) Contains(key K) bool {
+	exists, _ := m.tr.Has(m.convertKey(key), nil)
+	return exists
+}
+
+// GetStateHash returns the index hash.
+func (m *TransactIndex[K, I]) GetStateHash() (hash common.Hash, err error) {
+	return m.hashIndex.Commit()
+}
+
+func (m *TransactIndex[K, I]) Close() error {
+	// commit and persist the state
+	hash, err := m.GetStateHash()
+	if err != nil {
+		return err
+	}
+	return m.tr.Put(m.convertKeyStr(HashKey), m.hashSerializer.ToBytes(hash), nil)
+}
+
+// convertKey translates the TransactIndex representation of the key into a database key.
+// The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
+// by the key serializer
+func (m *TransactIndex[K, I]) convertKey(key K) []byte {
+	return m.table.AppendKey(m.keySerializer.ToBytes(key))
+}
+
+// convertKeyStr translates the TransactIndex representation of the key into a database key.
+// The database key is prepended with the table space prefix, furthermore the input key is converted to bytes
+// from string
+func (m *TransactIndex[K, I]) convertKeyStr(key string) []byte {
+	return m.table.AppendKeyStr(key)
+}

--- a/go/backend/index/ldb/transactleveldb_test.go
+++ b/go/backend/index/ldb/transactleveldb_test.go
@@ -1,0 +1,258 @@
+package ldb
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"testing"
+)
+
+func TestImplementsTr(t *testing.T) {
+	var persistent TransactIndex[*common.Address, uint32]
+	var _ index.Index[*common.Address, uint32] = &persistent
+}
+
+func TestTransactLevelGetSet(t *testing.T) {
+	_, tr, _ := openTransactIndexTempDb(t)
+	idx := createTransactIndex(t, tr)
+
+	indexA, err := idx.GetOrAdd(A)
+	if err != nil {
+		t.Errorf("failed add of address A; %s", err)
+		return
+	}
+	if indexA != 0 {
+		t.Errorf("first inserted is not 0")
+		return
+	}
+	indexB, err := idx.GetOrAdd(B)
+	if err != nil {
+		t.Errorf("failed add of address B; %s", err)
+		return
+	}
+	if indexB != 1 {
+		t.Errorf("second inserted is not 1")
+		return
+	}
+
+	if !idx.Contains(A) {
+		t.Errorf("persistent does not contains inserted A")
+		return
+	}
+	if !idx.Contains(B) {
+		t.Errorf("persistent does not contains inserted B")
+		return
+	}
+	if idx.Contains(C) {
+		t.Errorf("persistent claims it contains non-existing C")
+		return
+	}
+	if _, err := idx.Get(C); err != index.ErrNotFound {
+		t.Errorf("persistent returns wrong error when getting non-existing")
+		return
+	}
+}
+
+func TestTransactGet(t *testing.T) {
+	_, tr, _ := openTransactIndexTempDb(t)
+	idx := createTransactIndex(t, tr)
+
+	indexA, err := idx.GetOrAdd(A)
+	if err != nil {
+		t.Errorf("failed adding of address A1; %s", err)
+		return
+	}
+
+	indexA2, err := idx.GetOrAdd(A)
+	if err != nil {
+		t.Errorf("failed adding of address A2; %s", err)
+		return
+	}
+	if indexA != indexA2 {
+		t.Errorf("assigned two different indexes for the same address")
+		return
+	}
+
+	indexA3, err := idx.Get(A)
+	if err != nil {
+		t.Errorf("failed get id of address A3; %s", err)
+		return
+	}
+	if indexA2 != indexA3 {
+		t.Errorf("Get returns different value than GetOrAdd")
+		return
+	}
+}
+
+func TestTransactDataPersisted(t *testing.T) {
+	db, tr, path := openTransactIndexTempDb(t)
+	idx1 := createTransactIndex(t, tr)
+
+	_, _ = idx1.GetOrAdd(A)
+	_, _ = idx1.GetOrAdd(B)
+
+	if !idx1.Contains(A) {
+		t.Errorf("persistent does not contains inserted A")
+		return
+	}
+	if !idx1.Contains(B) {
+		t.Errorf("idx1 does not contains inserted B")
+		return
+	}
+
+	// close and reopen
+	_, tr = reopenTransactIndexDb(t, idx1, db, tr, path)
+	idx2 := createTransactIndex(t, tr)
+
+	// check the values are still there
+	if !idx2.Contains(A) {
+		t.Errorf("idx1 does not contains inserted A")
+		return
+	}
+	if !idx2.Contains(B) {
+		t.Errorf("idx1 does not contains inserted B")
+		return
+	}
+
+	// third item gets ID = 3
+	indexC, err := idx2.GetOrAdd(C)
+	if err != nil {
+		t.Errorf("failed add of address A; %s", err)
+		return
+	}
+	if indexC != 2 {
+		t.Errorf("third inserted is not 2")
+		return
+	}
+}
+
+func TestTransactHash(t *testing.T) {
+	_, tr, _ := openTransactIndexTempDb(t)
+	idx := createTransactIndex(t, tr)
+
+	// the hash is the default one first
+	h0, _ := idx.GetStateHash()
+
+	if (h0 != common.Hash{}) {
+		t.Errorf("The hash does not match the default one")
+	}
+
+	// the hash must change when adding a new item
+	_, _ = idx.GetOrAdd(A)
+	ha1, _ := idx.GetStateHash()
+
+	if h0 == ha1 {
+		t.Errorf("The hash has not changed")
+	}
+
+	// the hash remains the same when getting an existing item
+	_, _ = idx.GetOrAdd(A)
+	ha2, _ := idx.GetStateHash()
+
+	if ha1 != ha2 {
+		t.Errorf("The hash has changed")
+	}
+
+	// try recursive hash with B and already indexed A
+	_, _ = idx.GetOrAdd(B)
+	hb1, _ := idx.GetStateHash()
+
+	// The hash must remain the same when adding still the same key
+	_, _ = idx.GetOrAdd(B)
+	hb2, _ := idx.GetStateHash()
+
+	if hb1 != hb2 {
+		t.Errorf("The hash has changed")
+	}
+}
+
+func TestTransactHashPersisted(t *testing.T) {
+	db, tr, path := openTransactIndexTempDb(t)
+	idx1 := createTransactIndex(t, tr)
+
+	_, _ = idx1.GetOrAdd(A)
+	_, _ = idx1.GetOrAdd(B)
+
+	// close and reopen
+	_, tr = reopenTransactIndexDb(t, idx1, db, tr, path)
+	idx2 := createTransactIndex(t, tr)
+
+	// hash must be still there
+	h, _ := idx2.GetStateHash()
+
+	if fmt.Sprintf("%x", h) != HashAB {
+		t.Errorf("Hash is %x and not %s", h, HashAB)
+	}
+}
+
+func TestTransactHashPersistedAndAdded(t *testing.T) {
+	db, tr, path := openTransactIndexTempDb(t)
+	idx1 := createTransactIndex(t, tr)
+
+	_, _ = idx1.GetOrAdd(A)
+
+	// close and reopen
+	_, tr = reopenTransactIndexDb(t, idx1, db, tr, path)
+	idx2 := createTransactIndex(t, tr)
+
+	// hash must be still there even when adding A and B in different sessions
+	_, _ = idx2.GetOrAdd(B)
+	h, _ := idx2.GetStateHash()
+
+	if fmt.Sprintf("%x", h) != HashAB {
+		t.Errorf("Hash is %x and not %s", h, HashAB)
+	}
+}
+
+// openIndexTempDb creates a new database on a new temp file
+func openTransactIndexTempDb(t *testing.T) (*leveldb.DB, *leveldb.Transaction, string) {
+	path := t.TempDir()
+	db, tr := openTransactIndexDb(t, path)
+	return db, tr, path
+}
+
+// openIndexDb opends LevelDB on the input directory path
+func openTransactIndexDb(t *testing.T, path string) (*leveldb.DB, *leveldb.Transaction) {
+	db, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		t.Fatalf("Cannot open Db, err: %s", err)
+	}
+
+	tr, err := db.OpenTransaction()
+	if err != nil {
+		t.Fatalf("Cannot open Db transaction, err: %s", err)
+	}
+
+	t.Cleanup(func() {
+		_ = tr.Commit()
+	})
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db, tr
+}
+
+// reopenIndexDb closes database and the index from thw input index wrapper,
+// and creates a new  database pointing to the same location
+func reopenTransactIndexDb(t *testing.T, idx index.Index[common.Address, uint32], db *leveldb.DB, tr *leveldb.Transaction, path string) (*leveldb.DB, *leveldb.Transaction) {
+	if err := idx.Close(); err != nil {
+		t.Errorf("Cannot close TransactIndex, err? %s", err)
+	}
+	_ = tr.Commit()
+	if err := db.Close(); err != nil {
+		t.Errorf("Cannot close DB, err? %s", err)
+	}
+	return openTransactIndexDb(t, path)
+}
+
+// createIndex creates a new instance of the index using the input database
+func createTransactIndex(t *testing.T, tr *leveldb.Transaction) index.Index[common.Address, uint32] {
+	idx, err := NewTransactIndex[common.Address, uint32](tr, common.BalanceKey, common.AddressSerializer{}, common.Identifier32Serializer{})
+	if err != nil {
+		t.Fatalf("Cannot open TransactIndex, err: %s", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	return idx
+}


### PR DESCRIPTION
This creates a LevelDB index that works in transaction. This is a bit copy+paste of the index we already have, but its purpose is to create benchmark 