### PR TITLE
Reduce page size of C++ store from 16 KiB to 4 KiB

### DIFF
--- a/cpp/backend/store/store_benchmark.cc
+++ b/cpp/backend/store/store_benchmark.cc
@@ -6,7 +6,7 @@
 namespace carmen::backend::store {
 namespace {
 
-constexpr const std::size_t kPageSize = 1 << 14;  // = 16 KiB
+constexpr const std::size_t kPageSize = 1 << 12;  // = 4 KiB
 constexpr const std::size_t kBranchFactor = 32;
 
 // To run benchmarks, use the following command:


### PR DESCRIPTION
4 KiB is the [native](https://unix.stackexchange.com/questions/128213/how-is-page-size-determined-in-virtual-address-space#:~:text=Linux%20supports%20two%20page%20sizes,(what%20Linux%20calls%20PTE).) page size of Linux file systems

This speeds up uniform and random write operations by a factor of 2.6x-3x (see #110)

  | 16 KiB page | 4 KiB page
-- | -- | --
BM_SequentialWrite<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 22 | 38.2
BM_UniformRandomWrite<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 51183 | 16700
BM_ExponentialRandomWrite<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 44062 | 16715
BM_SequentialWriteAndHash<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 78852 | 50523
BM_UniformWriteAndHash<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 8185839 | 2715264
BM_ExponentialWriteAndHash<StoreHandler< FileStore<int, Value, SingleFile, kPageSize>, kBranchFactor>>/1048576 | 7261854 | 2784060

