### PR TITLE
Enforce page alignment constraints

### DIFF
--- a/cpp/backend/common/file.h
+++ b/cpp/backend/common/file.h
@@ -46,7 +46,7 @@ concept File = requires(F a) {
 // An InMemoryFile implement is provided to for testing purposes, where actual
 // file operations are not relevant. It may also serve as a reference
 // implementation to compare other implementations to in unit testing.
-template <typename Page>
+template <Page Page>
 class InMemoryFile {
  public:
   using page_type = Page;
@@ -107,7 +107,7 @@ class RawFile {
 
 // An implementation of the File concept using a single file as a persistent
 // storage solution.
-template <typename Page>
+template <Page Page>
 class SingleFile {
  public:
   using page_type = Page;
@@ -132,14 +132,14 @@ class SingleFile {
 
 // ------------------------------- Definitions --------------------------------
 
-template <typename Page>
+template <Page Page>
 void InMemoryFile<Page>::LoadPage(PageId id, Page& trg) const {
   static const Block zero{};
   auto src = id >= data_.size() ? &zero : &data_[id];
   std::memcpy(&trg, src, sizeof(Page));
 }
 
-template <typename Page>
+template <Page Page>
 void InMemoryFile<Page>::StorePage(PageId id, const Page& src) {
   while (data_.size() <= id) {
     data_.resize(id + 1);

--- a/cpp/backend/common/file_test.cc
+++ b/cpp/backend/common/file_test.cc
@@ -12,10 +12,14 @@ namespace {
 
 // A page format used for the tests.
 template <std::size_t page_size>
-class Page : public std::array<std::byte, page_size> {
+class alignas(kFileSystemPageSize) Page
+    : public std::array<std::byte, GetRequiredPageSize(page_size)> {
  public:
-  std::span<const std::byte, page_size> AsRawData() const { return *this; };
-  std::span<std::byte, page_size> AsRawData() { return *this; };
+  constexpr static const auto true_page_size = GetRequiredPageSize(page_size);
+  std::span<const std::byte, true_page_size> AsRawData() const {
+    return *this;
+  };
+  std::span<std::byte, true_page_size> AsRawData() { return *this; };
 };
 
 TEST(TestPageTest, IsPage) { EXPECT_TRUE(carmen::backend::Page<Page<12>>); }

--- a/cpp/backend/common/page.h
+++ b/cpp/backend/common/page.h
@@ -8,10 +8,16 @@
 
 namespace carmen::backend {
 
+// A constant defining the file system's page size.
+constexpr static const std::size_t kFileSystemPageSize = 1 << 12;  // 4 KiB
+
 // A Page is a fixed-size memory object that has a raw byte representation that
 // can be used for loading and storing data in paged files.
 template <typename P>
-concept Page = requires(const P a, P b) {
+concept Page =
+    // Pages must be aligned to a multiple of a file system page.
+    alignof(P) >= kFileSystemPageSize &&
+    alignof(P) % kFileSystemPageSize == 0 && requires(const P a, P b) {
   // Pages must support immutable and mutable raw data access.
   { a.AsRawData() } -> std::same_as<std::span<const std::byte, sizeof(P)>>;
   { b.AsRawData() } -> std::same_as<std::span<std::byte, sizeof(P)>>;
@@ -21,6 +27,22 @@ concept Page = requires(const P a, P b) {
   std::is_destructible_v<P>;
 };
 
+// Computes the required page size based on a use case specific needed page
+// size. The required page size is the smallest multiple of the file system's
+// page size that can fit the provided needed page size.
+constexpr std::size_t GetRequiredPageSize(std::size_t needed_page_size) {
+  // If the needed size is negative, zero, or less than a single file system
+  // page, a single page is used.
+  if (needed_page_size <= kFileSystemPageSize) {
+    return kFileSystemPageSize;
+  }
+  // Otherwise, the size requirement is rounded up to the next full page.
+  return needed_page_size % kFileSystemPageSize == 0
+             ? needed_page_size
+             : (((needed_page_size / kFileSystemPageSize) + 1) *
+                kFileSystemPageSize);
+}
+
 // A page containing an array of trivial values. As such, it is the in-memory,
 // typed version of a page in a file containing a fixed length array of trivial
 // elements. Furthermore, it provides index based access to the contained data.
@@ -29,39 +51,49 @@ concept Page = requires(const P a, P b) {
 // array. The provided pages_size_in_byte is the number of bytes each page is
 // comprising. Note that, if page_size_in_byte is not a multiple of sizeof(V)
 // some extra bytes per page may be kept in memory and on disk.
-template <Trivial V, std::size_t page_size_in_byte>
-class ArrayPage final {
+template <Trivial V, std::size_t page_size_in_byte = kFileSystemPageSize>
+class alignas(kFileSystemPageSize) ArrayPage final {
  public:
+  // A constant providing the full size of this page in memory and on disk.
+  // Note that due to alignment constraints, this may exceed the specified
+  // page_size_in_byte.
+  constexpr static std::size_t full_page_size_in_byte =
+      GetRequiredPageSize(page_size_in_byte);
+
   // A constant defining the number of elements stored in each page of this
   // type.
   constexpr static std::size_t kNumElementsPerPage =
       page_size_in_byte / sizeof(V);
 
   // Provides read-only indexed access to a value in this page.
-  const V& operator[](std::size_t pos) const {
-    const V* data = reinterpret_cast<const V*>(&data_[0]);
-    return data[pos];
-  }
+  const V& operator[](std::size_t pos) const { return AsArray()[pos]; }
 
   // Provides mutable indexed access to a value in this page.
-  V& operator[](std::size_t pos) {
-    V* data = reinterpret_cast<V*>(&data_[0]);
-    return data[pos];
+  V& operator[](std::size_t pos) { return AsArray()[pos]; }
+
+  // Provides direct access to the stored array.
+  const std::array<V, kNumElementsPerPage>& AsArray() const {
+    return *reinterpret_cast<const std::array<V, kNumElementsPerPage>*>(&data_);
+  }
+
+  // Provides direct const access to the stored array.
+  std::array<V, kNumElementsPerPage>& AsArray() {
+    return *reinterpret_cast<std::array<V, kNumElementsPerPage>*>(&data_);
   }
 
   // Provides read-only access to the raw data stored in this page. The intended
-  // use is for storing data to disk and hashing the page's content.
-  std::span<const std::byte, page_size_in_byte> AsRawData() const {
+  // use is for storing data to disk.
+  std::span<const std::byte, full_page_size_in_byte> AsRawData() const {
     return data_;
   }
 
   // Provides a mutable raw view of the data stored in this page. The main
   // intended use case is to replace the content when loading a page from disk.
-  std::span<std::byte, page_size_in_byte> AsRawData() { return data_; }
+  std::span<std::byte, full_page_size_in_byte> AsRawData() { return data_; }
 
  private:
   // Stores element's data in serialized form.
-  std::array<std::byte, page_size_in_byte> data_;
+  std::array<std::byte, full_page_size_in_byte> data_;
 };
 
 }  // namespace carmen::backend

--- a/cpp/backend/common/page_test.cc
+++ b/cpp/backend/common/page_test.cc
@@ -6,19 +6,38 @@
 namespace carmen::backend {
 namespace {
 
+constexpr auto FsPageSize = kFileSystemPageSize;
+
+TEST(GetRequiredPageSizeTest, RoundsUpUsage) {
+  EXPECT_EQ(FsPageSize, GetRequiredPageSize(0));
+  EXPECT_EQ(FsPageSize, GetRequiredPageSize(1));
+  EXPECT_EQ(FsPageSize, GetRequiredPageSize(FsPageSize - 1));
+  EXPECT_EQ(FsPageSize, GetRequiredPageSize(FsPageSize));
+  EXPECT_EQ(2 * FsPageSize, GetRequiredPageSize(FsPageSize + 1));
+  EXPECT_EQ(2 * FsPageSize, GetRequiredPageSize(2 * FsPageSize - 1));
+  EXPECT_EQ(2 * FsPageSize, GetRequiredPageSize(2 * FsPageSize));
+  EXPECT_EQ(3 * FsPageSize, GetRequiredPageSize(2 * FsPageSize + 1));
+}
+
 TEST(ArrayPageTest, ArePages) {
+  EXPECT_TRUE((Page<ArrayPage<int>>));
+  EXPECT_TRUE((Page<ArrayPage<float>>));
   EXPECT_TRUE((Page<ArrayPage<int, 12>>));
   EXPECT_TRUE((Page<ArrayPage<float, 73>>));
+  EXPECT_TRUE((Page<ArrayPage<int, FsPageSize * 4>>));
 }
 
 TEST(ArrayPageTest, PageSize) {
-  EXPECT_EQ(10, sizeof(ArrayPage<int, 10>));
-  EXPECT_EQ(50, sizeof(ArrayPage<int, 50>));
-  EXPECT_EQ(4092, sizeof(ArrayPage<int, 4092>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<int, 10>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<int, 50>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<int, FsPageSize>));
+  EXPECT_EQ(FsPageSize * 2, sizeof(ArrayPage<int, FsPageSize + 1>));
+  EXPECT_EQ(FsPageSize * 2, sizeof(ArrayPage<int, FsPageSize * 2>));
 
-  EXPECT_EQ(10, sizeof(ArrayPage<Value, 10>));
-  EXPECT_EQ(50, sizeof(ArrayPage<Value, 50>));
-  EXPECT_EQ(4092, sizeof(ArrayPage<Value, 4092>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<Value, 10>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<Value, 50>));
+  EXPECT_EQ(FsPageSize, sizeof(ArrayPage<Value, 4092>));
+  EXPECT_EQ(FsPageSize * 2, sizeof(ArrayPage<Value, FsPageSize + 1>));
 }
 
 TEST(ArrayPageTest, NumberOfElements) {
@@ -49,6 +68,10 @@ TEST(ArrayPageTest, ElementsCanBeAccessedAndAreDifferentiated) {
 
   for (std::size_t i = 0; i < kSize; i++) {
     EXPECT_EQ(i, page[i]);
+  }
+
+  for (std::size_t i = 0; i < kSize; i++) {
+    EXPECT_EQ(i, page.AsArray()[i]);
   }
 }
 

--- a/cpp/backend/index/file/hash_page_test.cc
+++ b/cpp/backend/index/file/hash_page_test.cc
@@ -16,10 +16,10 @@ TEST(HashPageTest, IsPage) {
   EXPECT_TRUE((Page<HashPage<int, int, long, 128>>));
 }
 
-TEST(HashPageTest, SizeOfIsAsAdvertised) {
-  EXPECT_EQ(64, sizeof(HashPage<int, int, int, 64>));
-  EXPECT_EQ(128, sizeof(HashPage<int, int, int, 128>));
-  EXPECT_EQ(128, sizeof(HashPage<int, int, long, 128>));
+TEST(HashPageTest, SizeOfFitsPageConstraints) {
+  EXPECT_EQ(kFileSystemPageSize, sizeof(HashPage<int, int, int, 64>));
+  EXPECT_EQ(kFileSystemPageSize, sizeof(HashPage<int, int, int, 128>));
+  EXPECT_EQ(kFileSystemPageSize, sizeof(HashPage<int, int, long, 128>));
   EXPECT_EQ(1 << 14, sizeof(HashPage<int, int, long, 1 << 14>));
 }
 

--- a/cpp/backend/index/file/index.h
+++ b/cpp/backend/index/file/index.h
@@ -35,7 +35,7 @@ namespace carmen::backend::index {
 //
 // see: https://en.wikipedia.org/wiki/Linear_hashing
 template <Trivial K, std::integral I, template <typename> class F,
-          std::size_t page_size = 1 << 14>
+          std::size_t page_size = kFileSystemPageSize>
 class FileIndex {
  public:
   using hash_t = std::size_t;

--- a/cpp/backend/store/file/store.h
+++ b/cpp/backend/store/file/store.h
@@ -61,7 +61,7 @@ class FileStore {
       // Before we throw away a dirty page to make space for something else we
       // update the hash to avoid having to reload it again later.
       if (is_dirty) {
-        hashes_.UpdateHash(id, page.AsRawData());
+        hashes_.UpdateHash(id, std::as_bytes(std::span(page.AsArray())));
       }
     }
 
@@ -76,7 +76,7 @@ class FileStore {
     PageProvider(PagePool& pool) : pool_(pool) {}
 
     std::span<const std::byte> GetPageData(PageId id) override {
-      return pool_.Get(id).AsRawData();
+      return std::as_bytes(std::span(pool_.Get(id).AsArray()));
     }
 
    private:


### PR DESCRIPTION
Aligning pages reduces the latency of read/write operations by 25-50%

![chart (2)](https://user-images.githubusercontent.com/4097849/197185320-ae03b727-acb0-4f9b-aa06-fb5ed967b82d.svg)

The slight increase hash times is going to be further investigated.