### PR TITLE
Export in-memory and LevelDB based Go state factories

### DIFF
--- a/go/backend/depot/depot.go
+++ b/go/backend/depot/depot.go
@@ -17,6 +17,6 @@ type Depot[I common.Identifier] interface {
 	// GetStateHash computes and returns a cryptographical hash of the stored data
 	GetStateHash() (common.Hash, error)
 
-	// Close the depot
-	Close() error
+	// Also, depots need to be flush and closable.
+	common.FlushAndCloser
 }

--- a/go/backend/depot/memory/memory.go
+++ b/go/backend/depot/memory/memory.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
@@ -80,7 +81,12 @@ func (m *Depot[I]) GetStateHash() (common.Hash, error) {
 	return m.hashTree.HashRoot()
 }
 
-// Close the store
+// Flush the depot
+func (m *Depot[I]) Flush() error {
+	return nil // no-op for in-memory database
+}
+
+// Close the depot
 func (m *Depot[I]) Close() error {
 	return nil // no-op for in-memory database
 }

--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -53,7 +53,12 @@ func (m *Index[K, I]) GetStateHash() (common.Hash, error) {
 	return m.wrapped.GetStateHash()
 }
 
-// Close closes the storage and clean-ups all possible dirty values
+// Flush pushes buffered write operations to disk.
+func (m *Index[K, I]) Flush() error {
+	return m.wrapped.Flush()
+}
+
+// Close closes the storage and clean-ups all possible dirty values.
 func (m *Index[K, I]) Close() error {
 	return m.wrapped.Close()
 }

--- a/go/backend/index/index.go
+++ b/go/backend/index/index.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"errors"
+
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -25,8 +26,8 @@ type Index[K comparable, I common.Identifier] interface {
 	// GetStateHash returns the index hash.
 	GetStateHash() (common.Hash, error)
 
-	// Close closes the storage and clean-ups all possible dirty values
-	Close() error
+	// Also, indexes need to be flush and closable.
+	common.FlushAndCloser
 }
 
 var (

--- a/go/backend/index/indexarray.go
+++ b/go/backend/index/indexarray.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -80,6 +81,18 @@ func (m *Array[K, I]) GetStateHash() (common.Hash, error) {
 		}
 	}
 	return res, nil
+}
+
+// Flush clean-ups all possible dirty values
+func (m *Array[K, I]) Flush() error {
+	var resErr error
+	for _, idx := range m.indexes {
+		if err := idx.Flush(); err != nil {
+			resErr = err
+		}
+	}
+
+	return resErr
 }
 
 // Close closes the storage and clean-ups all possible dirty values

--- a/go/backend/index/ldb/leveldb.go
+++ b/go/backend/index/ldb/leveldb.go
@@ -128,7 +128,7 @@ func (m *Index[K, I]) GetStateHash() (hash common.Hash, err error) {
 	return m.hashIndex.Commit()
 }
 
-func (m *Index[K, I]) Close() error {
+func (m *Index[K, I]) Flush() error {
 	// commit and persist the state
 	hash, err := m.GetStateHash()
 	if err != nil {
@@ -137,6 +137,10 @@ func (m *Index[K, I]) Close() error {
 
 	dbKey := m.convertKeyStr(HashKey).ToBytes()
 	return m.db.Put(dbKey, m.hashSerializer.ToBytes(hash), nil)
+}
+
+func (m *Index[K, I]) Close() error {
+	return m.Flush()
 }
 
 // convertKey translates the Index representation of the key into a database key.

--- a/go/backend/index/ldb/transactleveldb.go
+++ b/go/backend/index/ldb/transactleveldb.go
@@ -117,13 +117,17 @@ func (m *TransactIndex[K, I]) GetStateHash() (hash common.Hash, err error) {
 	return m.hashIndex.Commit()
 }
 
-func (m *TransactIndex[K, I]) Close() error {
+func (m *TransactIndex[K, I]) Flush() error {
 	// commit and persist the state
 	hash, err := m.GetStateHash()
 	if err != nil {
 		return err
 	}
 	return m.tr.Put(m.convertKeyStr(HashKey).ToBytes(), m.hashSerializer.ToBytes(hash), nil)
+}
+
+func (m *TransactIndex[K, I]) Close() error {
+	return m.Flush()
 }
 
 // convertKey translates the TransactIndex representation of the key into a database key.

--- a/go/backend/index/memory/memory.go
+++ b/go/backend/index/memory/memory.go
@@ -54,6 +54,11 @@ func (m *Index[K, I]) GetStateHash() (common.Hash, error) {
 	return m.hashIndex.Commit()
 }
 
+// Flush does nothing.
+func (m *Index[K, I]) Flush() error {
+	return nil
+}
+
 // Close closes the storage and clean-ups all possible dirty values
 func (m *Index[K, I]) Close() error {
 	return nil

--- a/go/backend/store/file/file.go
+++ b/go/backend/store/file/file.go
@@ -3,10 +3,11 @@ package file
 import (
 	"errors"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
-	"github.com/Fantom-foundation/Carmen/go/common"
 	"io"
 	"os"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
+	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
 // Store is a filesystem-based store.Store implementation - it stores mapping of ID to value in binary files.
@@ -111,6 +112,11 @@ func (m *Store[I, V]) Get(id I) (value V, err error) {
 // GetStateHash computes and returns a cryptographical hash of the stored data
 func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
 	return m.hashTree.HashRoot()
+}
+
+// Flush the store
+func (m *Store[I, V]) Flush() error {
+	return m.file.Sync()
 }
 
 // Close the store

--- a/go/backend/store/ldb/leveldb.go
+++ b/go/backend/store/ldb/leveldb.go
@@ -2,6 +2,7 @@ package ldb
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -101,10 +102,14 @@ func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
 	return m.hashTree.HashRoot()
 }
 
-func (m *Store[I, V]) Close() error {
-	// commit state hash root before closing
+func (m *Store[I, V]) Flush() error {
+	// commit state hash root
 	_, err := m.GetStateHash()
 	return err
+}
+
+func (m *Store[I, V]) Close() error {
+	return m.Flush()
 }
 
 // convertKey translates the Index representation of the key into a database key.

--- a/go/backend/store/memory/memory.go
+++ b/go/backend/store/memory/memory.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
@@ -67,6 +68,11 @@ func (m *Store[I, V]) Get(id I) (item V, err error) {
 // GetStateHash computes and returns a cryptographical hash of the stored data
 func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
 	return m.hashTree.HashRoot()
+}
+
+// Flush the store
+func (m *Store[I, V]) Flush() error {
+	return nil // no-op for in-memory database
 }
 
 // Close the store

--- a/go/backend/store/store.go
+++ b/go/backend/store/store.go
@@ -19,6 +19,6 @@ type Store[I common.Identifier, V any] interface {
 	// GetStateHash computes and returns a cryptographical hash of the stored data
 	GetStateHash() (common.Hash, error)
 
-	// Close the store
-	Close() error
+	// Also, stores need to be flush and closable.
+	common.FlushAndCloser
 }

--- a/go/common/interfaces.go
+++ b/go/common/interfaces.go
@@ -1,0 +1,13 @@
+package common
+
+import "io"
+
+// Flusher is any type that can be flushed.
+type Flusher interface {
+	Flush() error
+}
+
+type FlushAndCloser interface {
+	Flusher
+	io.Closer
+}

--- a/go/common/scheme.go
+++ b/go/common/scheme.go
@@ -4,6 +4,12 @@ package common
 type TableSpace byte
 
 const (
+	// AddressKey is a respective "table space"
+	AddressKey TableSpace = 'A'
+	// KeyKey is a respective "table space"
+	KeyKey TableSpace = 'K'
+	// AccountKey is a respective "table space"
+	AccountKey TableSpace = 'C'
 	// BalanceKey is a respective "table space"
 	BalanceKey TableSpace = 'B'
 	// NonceKey is a respective "table space"

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -2,11 +2,24 @@ package state
 
 import (
 	"crypto/sha256"
+	"io"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/depot"
+	"github.com/Fantom-foundation/Carmen/go/backend/depot/memory"
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree/htmemory"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	indexldb "github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
+	indexmem "github.com/Fantom-foundation/Carmen/go/backend/index/memory"
 	"github.com/Fantom-foundation/Carmen/go/backend/store"
+	storeldb "github.com/Fantom-foundation/Carmen/go/backend/store/ldb"
+	storemem "github.com/Fantom-foundation/Carmen/go/backend/store/memory"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+const (
+	HashTreeFactor = 3
+	PageSize       = 32 * 32
 )
 
 // GoState manages dependencies to other interfaces to build this service
@@ -19,20 +32,77 @@ type GoState struct {
 	balancesStore store.Store[uint32, common.Balance]
 	valuesStore   store.Store[uint32, common.Value]
 	codesDepot    depot.Depot[uint32]
+	cleanup       []func()
 }
 
-// NewGoState creates a new instance of this service
-func NewGoState(
-	addressIndex index.Index[common.Address, uint32],
-	keyIndex index.Index[common.Key, uint32],
-	slotIndex index.Index[common.SlotIdx[uint32], uint32],
-	accountsStore store.Store[uint32, common.AccountState],
-	noncesStore store.Store[uint32, common.Nonce],
-	balancesStore store.Store[uint32, common.Balance],
-	valuesStore store.Store[uint32, common.Value],
-	codesDepot depot.Depot[uint32]) *GoState {
+func NewGoInMemoryState() (State, error) {
+	var addressIndex index.Index[common.Address, uint32] = indexmem.NewIndex[common.Address, uint32](common.AddressSerializer{})
+	var keyIndex index.Index[common.Key, uint32] = indexmem.NewIndex[common.Key, uint32](common.KeySerializer{})
+	var slotIndex index.Index[common.SlotIdx[uint32], uint32] = indexmem.NewIndex[common.SlotIdx[uint32], uint32](common.SlotIdxSerializer32{})
+	accountsStore, err := storemem.NewStore[uint32, common.AccountState](common.AccountStateSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	noncesStore, err := storemem.NewStore[uint32, common.Nonce](common.NonceSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	balancesStore, err := storemem.NewStore[uint32, common.Balance](common.BalanceSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	valuesStore, err := storemem.NewStore[uint32, common.Value](common.ValueSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	codesDepot, err := memory.NewDepot[uint32](PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	return &GoState{addressIndex, keyIndex, slotIndex, accountsStore, noncesStore, balancesStore, valuesStore, codesDepot, nil}, nil
+}
 
-	return &GoState{addressIndex, keyIndex, slotIndex, accountsStore, noncesStore, balancesStore, valuesStore, codesDepot}
+func NewGoLevelDbState(directory string) (State, error) {
+	db, err := leveldb.OpenFile(directory, nil)
+	if err != nil {
+		return nil, err
+	}
+	addressIndex, err := indexldb.NewIndex[common.Address, uint32](db, common.AddressKey, common.AddressSerializer{}, common.Identifier32Serializer{})
+	if err != nil {
+		return nil, err
+	}
+	keyIndex, err := indexldb.NewIndex[common.Key, uint32](db, common.KeyKey, common.KeySerializer{}, common.Identifier32Serializer{})
+	if err != nil {
+		return nil, err
+	}
+	slotIndex, err := indexldb.NewIndex[common.SlotIdx[uint32], uint32](db, common.SlotKey, common.SlotIdxSerializer32{}, common.Identifier32Serializer{})
+	if err != nil {
+		return nil, err
+	}
+	accountsStore, err := storeldb.NewStore[uint32, common.AccountState](db, common.AccountKey, common.AccountStateSerializer{}, common.Identifier32Serializer{}, htmemory.CreateHashTreeFactory(HashTreeFactor), PageSize)
+	if err != nil {
+		return nil, err
+	}
+	noncesStore, err := storeldb.NewStore[uint32, common.Nonce](db, common.NonceKey, common.NonceSerializer{}, common.Identifier32Serializer{}, htmemory.CreateHashTreeFactory(HashTreeFactor), PageSize)
+	if err != nil {
+		return nil, err
+	}
+	balancesStore, err := storeldb.NewStore[uint32, common.Balance](db, common.BalanceKey, common.BalanceSerializer{}, common.Identifier32Serializer{}, htmemory.CreateHashTreeFactory(HashTreeFactor), PageSize)
+	if err != nil {
+		return nil, err
+	}
+	valuesStore, err := storeldb.NewStore[uint32, common.Value](db, common.ValueKey, common.ValueSerializer{}, common.Identifier32Serializer{}, htmemory.CreateHashTreeFactory(HashTreeFactor), PageSize)
+	if err != nil {
+		return nil, err
+	}
+	codesDepot, err := memory.NewDepot[uint32](PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
+	if err != nil {
+		return nil, err
+	}
+	cleanup := []func(){
+		func() { db.Close() },
+	}
+	return &GoState{addressIndex, keyIndex, slotIndex, accountsStore, noncesStore, balancesStore, valuesStore, codesDepot, cleanup}, nil
 }
 
 func (s *GoState) CreateAccount(address common.Address) (err error) {
@@ -186,9 +256,49 @@ func (s *GoState) GetHash() (hash common.Hash, err error) {
 }
 
 func (s *GoState) Flush() error {
-	return s.Flush()
+	flushables := []common.Flusher{
+		s.addressIndex,
+		s.keyIndex,
+		s.slotIndex,
+		s.accountsStore,
+		s.noncesStore,
+		s.balancesStore,
+		s.valuesStore,
+		s.codesDepot,
+	}
+
+	var last error = nil
+	for _, flushable := range flushables {
+		if err := flushable.Flush(); err != nil {
+			last = err
+		}
+	}
+	return last
 }
 
 func (s *GoState) Close() error {
-	return s.Close()
+	closeables := []io.Closer{
+		s.addressIndex,
+		s.keyIndex,
+		s.slotIndex,
+		s.accountsStore,
+		s.noncesStore,
+		s.balancesStore,
+		s.valuesStore,
+		s.codesDepot,
+	}
+
+	var last error = nil
+	for _, closeable := range closeables {
+		if err := closeable.Close(); err != nil {
+			last = err
+		}
+	}
+
+	if s.cleanup != nil {
+		for _, clean := range s.cleanup {
+			clean()
+		}
+	}
+	return last
 }

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -3,20 +3,11 @@ package state
 import (
 	"bytes"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/backend/depot/memory"
-	"github.com/Fantom-foundation/Carmen/go/backend/hashtree/htmemory"
 	"testing"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
-	indexmem "github.com/Fantom-foundation/Carmen/go/backend/index/memory"
 	"github.com/Fantom-foundation/Carmen/go/backend/store"
-	storemem "github.com/Fantom-foundation/Carmen/go/backend/store/memory"
 	"github.com/Fantom-foundation/Carmen/go/common"
-)
-
-const (
-	HashTreeFactor = 3
-	PageSize       = 32 * 32
 )
 
 var (
@@ -38,198 +29,189 @@ var (
 	nonce1 = common.Nonce{0x01}
 )
 
-func TestInMemoryComposition(t *testing.T) {
-	_, err := NewInMemoryComposition()
+type NamedStateConfig struct {
+	state State
+	name  string
+}
+
+func initGoStates(t *testing.T) []NamedStateConfig {
+	mem_state, err := NewGoInMemoryState()
 	if err != nil {
-		t.Fatalf("failed to create in-memory state; %s", err)
+		t.Fatalf("failed to init in-memory state: %v", err)
+	}
+	ldb_state, err := NewGoLevelDbState(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to init LevelDB state: %v", err)
+	}
+
+	t.Cleanup(func() {
+		mem_state.Close()
+		ldb_state.Close()
+	})
+	return []NamedStateConfig{
+		{mem_state, "memory"},
+		{ldb_state, "LevelDB"},
 	}
 }
 
 func TestMissingKeys(t *testing.T) {
-	state, err := NewInMemoryComposition()
-	if err != nil {
-		t.Fatalf("failed to create in-memory state; %s", err)
-	}
-
-	accountState, err := state.GetAccountState(address1)
-	if err != nil || accountState != common.Unknown {
-		t.Errorf("Account state must be Unknown. It is: %s, err: %s", accountState, err)
-	}
-	balance, err := state.GetBalance(address1)
-	if (err != nil || balance != common.Balance{}) {
-		t.Errorf("Balance must be empty. It is: %s, err: %s", balance, err)
-	}
-	nonce, err := state.GetNonce(address1)
-	if (err != nil || nonce != common.Nonce{}) {
-		t.Errorf("Nonce must be empty. It is: %s, err: %s", nonce, err)
-	}
-	value, err := state.GetStorage(address1, key1)
-	if (err != nil || value != common.Value{}) {
-		t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
-	}
-	code, err := state.GetCode(address1)
-	if err != nil || code != nil {
-		t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
+	for _, config := range initGoStates(t) {
+		t.Run(config.name, func(t *testing.T) {
+			state := config.state
+			accountState, err := state.GetAccountState(address1)
+			if err != nil || accountState != common.Unknown {
+				t.Errorf("Account state must be Unknown. It is: %s, err: %s", accountState, err)
+			}
+			balance, err := state.GetBalance(address1)
+			if (err != nil || balance != common.Balance{}) {
+				t.Errorf("Balance must be empty. It is: %s, err: %s", balance, err)
+			}
+			nonce, err := state.GetNonce(address1)
+			if (err != nil || nonce != common.Nonce{}) {
+				t.Errorf("Nonce must be empty. It is: %s, err: %s", nonce, err)
+			}
+			value, err := state.GetStorage(address1, key1)
+			if (err != nil || value != common.Value{}) {
+				t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
+			}
+			code, err := state.GetCode(address1)
+			if err != nil || code != nil {
+				t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
+			}
+		})
 	}
 }
 
 func TestBasicOperations(t *testing.T) {
-	state, err := NewInMemoryComposition()
-	if err != nil {
-		t.Fatalf("failed to create in-memory state; %s", err)
-	}
+	for _, config := range initGoStates(t) {
+		t.Run(config.name, func(t *testing.T) {
+			state := config.state
+			// fill-in values
+			if err := state.CreateAccount(address1); err != nil {
+				t.Errorf("Error: %s", err)
+			}
+			if err := state.SetNonce(address1, common.Nonce{123}); err != nil {
+				t.Errorf("Error: %s", err)
+			}
+			if err := state.SetBalance(address2, common.Balance{45}); err != nil {
+				t.Errorf("Error: %s", err)
+			}
+			if err := state.SetStorage(address3, key1, common.Value{67}); err != nil {
+				t.Errorf("Error: %s", err)
+			}
+			if err := state.SetCode(address1, []byte{0x12, 0x34}); err != nil {
+				t.Errorf("Error: %s", err)
+			}
 
-	// fill-in values
-	if err := state.CreateAccount(address1); err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	if err := state.SetNonce(address1, common.Nonce{123}); err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	if err := state.SetBalance(address2, common.Balance{45}); err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	if err := state.SetStorage(address3, key1, common.Value{67}); err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	if err := state.SetCode(address1, []byte{0x12, 0x34}); err != nil {
-		t.Errorf("Error: %s", err)
-	}
+			// fetch values
+			if val, err := state.GetAccountState(address1); err != nil || val != common.Exists {
+				t.Errorf("Created account does not exists: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetNonce(address1); (err != nil || val != common.Nonce{123}) {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetBalance(address2); (err != nil || val != common.Balance{45}) {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetStorage(address3, key1); (err != nil || val != common.Value{67}) {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetCode(address1); err != nil || !bytes.Equal(val, []byte{0x12, 0x34}) {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
 
-	// fetch values
-	if val, err := state.GetAccountState(address1); err != nil || val != common.Exists {
-		t.Errorf("Created account does not exists: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetNonce(address1); (err != nil || val != common.Nonce{123}) {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetBalance(address2); (err != nil || val != common.Balance{45}) {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetStorage(address3, key1); (err != nil || val != common.Value{67}) {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetCode(address1); err != nil || !bytes.Equal(val, []byte{0x12, 0x34}) {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
+			// delete account
+			if err := state.DeleteAccount(address1); err != nil {
+				t.Errorf("Error: %s", err)
+			}
+			if val, err := state.GetAccountState(address1); err != nil || val != common.Deleted {
+				t.Errorf("Deleted account is not deleted: Val: %s, Err: %s", val, err)
+			}
 
-	// delete account
-	if err := state.DeleteAccount(address1); err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	if val, err := state.GetAccountState(address1); err != nil || val != common.Deleted {
-		t.Errorf("Deleted account is not deleted: Val: %s, Err: %s", val, err)
-	}
-
-	// fetch wrong combinations
-	if val, err := state.GetStorage(address1, key1); (err != nil || val != common.Value{}) {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			// fetch wrong combinations
+			if val, err := state.GetStorage(address1, key1); (err != nil || val != common.Value{}) {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+		})
 	}
 }
 
 func TestMoreInserts(t *testing.T) {
-	state, err := NewInMemoryComposition()
-	if err != nil {
-		t.Fatalf("failed to create in-memory state; %s", err)
-	}
+	for _, config := range initGoStates(t) {
+		t.Run(config.name, func(t *testing.T) {
+			state := config.state
+			// insert more combinations, so we do not have only zero-indexes everywhere
+			_ = state.SetStorage(address1, key1, val1)
+			_ = state.SetStorage(address1, key2, val2)
+			_ = state.SetStorage(address1, key3, val3)
 
-	// insert more combinations, so we do not have only zero-indexes everywhere
-	_ = state.SetStorage(address1, key1, val1)
-	_ = state.SetStorage(address1, key2, val2)
-	_ = state.SetStorage(address1, key3, val3)
+			_ = state.SetStorage(address2, key1, val1)
+			_ = state.SetStorage(address2, key2, val2)
+			_ = state.SetStorage(address2, key3, val3)
 
-	_ = state.SetStorage(address2, key1, val1)
-	_ = state.SetStorage(address2, key2, val2)
-	_ = state.SetStorage(address2, key3, val3)
+			_ = state.SetStorage(address3, key1, val1)
+			_ = state.SetStorage(address3, key2, val2)
+			_ = state.SetStorage(address3, key3, val3)
 
-	_ = state.SetStorage(address3, key1, val1)
-	_ = state.SetStorage(address3, key2, val2)
-	_ = state.SetStorage(address3, key3, val3)
-
-	if val, err := state.GetStorage(address1, key3); err != nil || val != val3 {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetStorage(address2, key1); err != nil || val != val1 {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
-	}
-	if val, err := state.GetStorage(address3, key2); err != nil || val != val2 {
-		t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			if val, err := state.GetStorage(address1, key3); err != nil || val != val3 {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetStorage(address2, key1); err != nil || val != val1 {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+			if val, err := state.GetStorage(address3, key2); err != nil || val != val2 {
+				t.Errorf("Invalid value or error returned: Val: %s, Err: %s", val, err)
+			}
+		})
 	}
 }
 
 func TestHashing(t *testing.T) {
-	state, err := NewInMemoryComposition()
-	if err != nil {
-		t.Fatalf("failed to create in-memory state; %s", err)
-	}
+	for _, config := range initGoStates(t) {
+		t.Run(config.name, func(t *testing.T) {
+			state := config.state
+			initialHash, err := state.GetHash()
+			if err != nil {
+				t.Fatalf("unable to get state hash; %s", err)
+			}
 
-	initialHash, err := state.GetHash()
-	if err != nil {
-		t.Fatalf("unable to get state hash; %s", err)
-	}
+			_ = state.SetStorage(address1, key1, val1)
+			hash1, err := state.GetHash()
+			if err != nil {
+				t.Fatalf("unable to get state hash; %s", err)
+			}
+			if initialHash == hash1 {
+				t.Errorf("hash of changed state not changed; %s", err)
+			}
 
-	_ = state.SetStorage(address1, key1, val1)
-	hash1, err := state.GetHash()
-	if err != nil {
-		t.Fatalf("unable to get state hash; %s", err)
-	}
-	if initialHash == hash1 {
-		t.Errorf("hash of changed state not changed; %s", err)
-	}
+			_ = state.SetBalance(address1, balance1)
+			hash2, err := state.GetHash()
+			if err != nil {
+				t.Fatalf("unable to get state hash; %s", err)
+			}
+			if initialHash == hash2 || hash1 == hash2 {
+				t.Errorf("hash of changed state not changed; %s", err)
+			}
 
-	_ = state.SetBalance(address1, balance1)
-	hash2, err := state.GetHash()
-	if err != nil {
-		t.Fatalf("unable to get state hash; %s", err)
-	}
-	if initialHash == hash2 || hash1 == hash2 {
-		t.Errorf("hash of changed state not changed; %s", err)
-	}
+			_ = state.CreateAccount(address1)
+			hash3, err := state.GetHash()
+			if err != nil {
+				t.Fatalf("unable to get state hash; %s", err)
+			}
+			if initialHash == hash3 || hash1 == hash3 || hash2 == hash3 {
+				t.Errorf("hash of changed state not changed; %s", err)
+			}
 
-	_ = state.CreateAccount(address1)
-	hash3, err := state.GetHash()
-	if err != nil {
-		t.Fatalf("unable to get state hash; %s", err)
+			_ = state.SetCode(address1, []byte{0x12, 0x34, 0x56, 0x78})
+			hash4, err := state.GetHash()
+			if err != nil {
+				t.Fatalf("unable to get state hash; %s", err)
+			}
+			if initialHash == hash4 || hash3 == hash4 {
+				t.Errorf("hash of changed state not changed; %s", err)
+			}
+		})
 	}
-	if initialHash == hash3 || hash1 == hash3 || hash2 == hash3 {
-		t.Errorf("hash of changed state not changed; %s", err)
-	}
-
-	_ = state.SetCode(address1, []byte{0x12, 0x34, 0x56, 0x78})
-	hash4, err := state.GetHash()
-	if err != nil {
-		t.Fatalf("unable to get state hash; %s", err)
-	}
-	if initialHash == hash4 || hash3 == hash4 {
-		t.Errorf("hash of changed state not changed; %s", err)
-	}
-}
-
-func NewInMemoryComposition() (State, error) {
-	var addressIndex index.Index[common.Address, uint32] = indexmem.NewIndex[common.Address, uint32](common.AddressSerializer{})
-	var keyIndex index.Index[common.Key, uint32] = indexmem.NewIndex[common.Key, uint32](common.KeySerializer{})
-	var slotIndex index.Index[common.SlotIdx[uint32], uint32] = indexmem.NewIndex[common.SlotIdx[uint32], uint32](common.SlotIdxSerializer32{})
-	accountsStore, err := storemem.NewStore[uint32, common.AccountState](common.AccountStateSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
-	if err != nil {
-		return nil, err
-	}
-	noncesStore, err := storemem.NewStore[uint32, common.Nonce](common.NonceSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
-	if err != nil {
-		return nil, err
-	}
-	balancesStore, err := storemem.NewStore[uint32, common.Balance](common.BalanceSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
-	if err != nil {
-		return nil, err
-	}
-	valuesStore, err := storemem.NewStore[uint32, common.Value](common.ValueSerializer{}, PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
-	if err != nil {
-		return nil, err
-	}
-	codesDepot, err := memory.NewDepot[uint32](PageSize, htmemory.CreateHashTreeFactory(HashTreeFactor))
-	if err != nil {
-		return nil, err
-	}
-	return NewGoState(addressIndex, keyIndex, slotIndex, accountsStore, noncesStore, balancesStore, valuesStore, codesDepot), nil
 }
 
 var testingErr = fmt.Errorf("testing error")
@@ -253,7 +235,7 @@ func (m failingIndex[K, I]) Get(key K) (id I, err error) {
 }
 
 func TestFailingStore(t *testing.T) {
-	state, err := NewInMemoryComposition()
+	state, err := NewGoInMemoryState()
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}
@@ -283,7 +265,7 @@ func TestFailingStore(t *testing.T) {
 }
 
 func TestFailingIndex(t *testing.T) {
-	state, err := NewInMemoryComposition()
+	state, err := NewGoInMemoryState()
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}


### PR DESCRIPTION
This PR ...
 - moves the factory for the in-memory Go StateDB from a test utility to the library
 - adds a factory for a LevelDB-based Go StateDB
 - adds support for flushing to indexes, stores, and depots
 - adds test coverage for the LevelDB based StateDB