### PR TITLE
Extend Go Stores benchmark, unify with CPP

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -13,3 +13,12 @@ Before commiting any changes in the Go source files into the repository, please 
 ```
 gofmt -s -w .
 ```
+
+# Running benchmarks
+Benchmarks use Go "testing" package. To run for example the Stores benchmark, run:
+```
+go test ./backend/store -bench=/.*File.*_16
+```
+For more information about the regex selecting benchmarks to run,
+check [Go testing documentation](https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks).
+

--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -18,16 +18,24 @@ import (
 	"testing"
 )
 
+// Benchmark of isolated Stores
+// Use sub-benchmarks to test individual implementations with different parameters.
+// The name of benchmark is in form:
+// BenchmarkWrite/Store_File_initialSize_16777216_dist_Exponential
+// where "File" is used Store implementation, "16777216" is the initial amount of items
+// in the Store on the benchmark start and "Exponential" is a probability distribution
+// with which are items (indexes) to write chosen.
+// To run the benchmark for File-based impls and 2^24 initial items use regex like:
+//     go test ./backend/store -bench=/.*File.*_16777216
+
 const (
-	PageSize        = 128 * 32
+	PageSize        = 1 << 12 // = 4 KiB
 	PoolSize        = 100
-	BranchingFactor = 8
+	BranchingFactor = 32
 )
 
 // initial number of values inserted into the Store before the benchmark
 var initialSizes = []int{1 << 20, 1 << 24, 1 << 30}
-
-//var initialSizes = []int{1 << 20, 1 << 24}
 
 // number of values updated before each measured hash recalculation
 var updateSizes = []int{100}
@@ -38,8 +46,12 @@ func BenchmarkInsert(b *testing.B) {
 	for _, fac := range getStoresFactories() {
 		for _, initialSize := range initialSizes {
 			s := fac.getStore(b)
-			initStoreContent(b, s, initialSize)
+			initialized := false
 			b.Run(fmt.Sprintf("Store %s initialSize %d", fac.label, initialSize), func(b *testing.B) {
+				if !initialized {
+					initStoreContent(b, s, initialSize)
+					initialized = true
+				}
 				benchmarkInsert(b, s)
 			})
 			_ = s.Close()
@@ -60,9 +72,13 @@ func BenchmarkRead(b *testing.B) {
 	for _, fac := range getStoresFactories() {
 		for _, initialSize := range initialSizes {
 			s := fac.getStore(b)
-			initStoreContent(b, s, initialSize)
+			initialized := false
 			for _, dist := range common.GetDistributions(initialSize) {
 				b.Run(fmt.Sprintf("Store %s initialSize %d dist %s", fac.label, initialSize, dist.Label), func(b *testing.B) {
+					if !initialized {
+						initStoreContent(b, s, initialSize)
+						initialized = true
+					}
 					benchmarkRead(b, dist, s)
 				})
 			}
@@ -85,9 +101,13 @@ func BenchmarkWrite(b *testing.B) {
 	for _, fac := range getStoresFactories() {
 		for _, initialSize := range initialSizes {
 			s := fac.getStore(b)
-			initStoreContent(b, s, initialSize)
+			initialized := false
 			for _, dist := range common.GetDistributions(initialSize) {
 				b.Run(fmt.Sprintf("Store %s initialSize %d dist %s", fac.label, initialSize, dist.Label), func(b *testing.B) {
+					if !initialized {
+						initStoreContent(b, s, initialSize)
+						initialized = true
+					}
 					benchmarkWrite(b, dist, s)
 				})
 			}
@@ -109,10 +129,14 @@ func BenchmarkHash(b *testing.B) {
 	for _, fac := range getStoresFactories() {
 		for _, initialSize := range initialSizes {
 			s := fac.getStore(b)
-			initStoreContent(b, s, initialSize)
+			initialized := false
 			for _, updateSize := range updateSizes {
 				for _, dist := range common.GetDistributions(initialSize) {
 					b.Run(fmt.Sprintf("Store %s initialSize %d updateSize %d dist %s", fac.label, initialSize, updateSize, dist.Label), func(b *testing.B) {
+						if !initialized {
+							initStoreContent(b, s, initialSize)
+							initialized = true
+						}
 						benchmarkHash(b, dist, updateSize, s)
 					})
 				}
@@ -132,6 +156,44 @@ func benchmarkHash(b *testing.B, dist common.Distribution, updateSize int, store
 			}
 		}
 		b.StartTimer()
+
+		hash, err := store.GetStateHash()
+		if err != nil {
+			b.Fatalf("failed to hash store; %s", err)
+		}
+		sink = hash // prevent compiler to optimize it out
+	}
+}
+
+func BenchmarkWriteAndHash(b *testing.B) {
+	for _, fac := range getStoresFactories() {
+		for _, initialSize := range initialSizes {
+			s := fac.getStore(b)
+			initialized := false
+			for _, updateSize := range updateSizes {
+				for _, dist := range common.GetDistributions(initialSize) {
+					b.Run(fmt.Sprintf("Store %s initialSize %d updateSize %d dist %s", fac.label, initialSize, updateSize, dist.Label), func(b *testing.B) {
+						if !initialized {
+							initStoreContent(b, s, initialSize)
+							initialized = true
+						}
+						benchmarkWriteAndHash(b, dist, updateSize, s)
+					})
+				}
+			}
+			_ = s.Close()
+		}
+	}
+}
+
+func benchmarkWriteAndHash(b *testing.B, dist common.Distribution, updateSize int, store store.Store[uint32, common.Value]) {
+	for i := 0; i < b.N; i++ {
+		for ii := 0; ii < updateSize; ii++ {
+			err := store.Set(dist.GetNext(), toValue(rand.Uint32()))
+			if err != nil {
+				b.Fatalf("failed to set store item; %s", err)
+			}
+		}
 
 		hash, err := store.GetStateHash()
 		if err != nil {
@@ -182,7 +244,7 @@ func initMemStore(b *testing.B) (store store.Store[uint32, common.Value]) {
 }
 
 func initFileStore(b *testing.B) (str store.Store[uint32, common.Value]) {
-	str, err := file.NewStore[uint32, common.Value](b.TempDir(), common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(b.TempDir()+"/hashtree", BranchingFactor))
+	str, err := file.NewStore[uint32, common.Value](b.TempDir(), common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(b.TempDir(), BranchingFactor))
 	if err != nil {
 		b.Fatalf("failed to init file store; %s", err)
 	}
@@ -190,7 +252,7 @@ func initFileStore(b *testing.B) (str store.Store[uint32, common.Value]) {
 }
 
 func initPagedFileStore(b *testing.B) (str store.Store[uint32, common.Value]) {
-	str, err := pagedfile.NewStore[uint32, common.Value](b.TempDir(), common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(b.TempDir()+"/hashes", BranchingFactor), PoolSize, eviction.NewLRUPolicy(PoolSize))
+	str, err := pagedfile.NewStore[uint32, common.Value](b.TempDir(), common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(b.TempDir(), BranchingFactor), PoolSize, eviction.NewLRUPolicy(PoolSize))
 	if err != nil {
 		b.Fatalf("failed to init pagedfile store; %s", err)
 	}


### PR DESCRIPTION
* Add WriteAndHash benchmark (present in CPP, missing in Go yet)
* Initialize only benchmarks, which are going to run (initialize in the `b.Run` - but still excluded from the measured time by `b.StopTimer()`) - prevent creating Stores with 2^30 items when the benchmarks using them does not run.
* Add doc into README - how to start specific subset of benchmarks