### PR TITLE
Align hashes between Go and C++ implementations

### DIFF
--- a/cpp/backend/store/file/hash_tree.cc
+++ b/cpp/backend/store/file/hash_tree.cc
@@ -46,6 +46,7 @@ Hash HashTree::GetHash() {
 
   // Update hashes of dirty pages.
   absl::flat_hash_set<int> dirty_parent;
+  std::swap(dirty_level_one_positions_, dirty_parent);
   for (PageId i : dirty_pages_) {
     auto data = page_source_->GetPageData(i);
     GetMutableHash(0, i) = carmen::GetHash(hasher_, data);
@@ -57,11 +58,6 @@ Hash HashTree::GetHash() {
   if (num_pages_ == 1) {
     return GetMutableHash(0, 0);
   }
-
-  // Complete list of level-1 nodes that are dirty.
-  dirty_parent.insert(dirty_level_one_positions_.begin(),
-                      dirty_level_one_positions_.end());
-  dirty_level_one_positions_.clear();
 
   // Perform hash aggregation.
   for (std::size_t level = 1;; level++) {

--- a/cpp/state/c_state.cc
+++ b/cpp/state/c_state.cc
@@ -13,14 +13,14 @@
 namespace carmen {
 namespace {
 
-constexpr const std::size_t kPageSize = 1 << 14;  // 16 KiB
+constexpr const std::size_t kPageSize = 1 << 12;  // 4 KiB
 constexpr const std::size_t kHashBranchFactor = 32;
 
 template <typename K, typename V>
 using InMemoryIndex = backend::index::InMemoryIndex<K, V>;
 
 template <typename K, typename V>
-using InMemoryStore = backend::store::InMemoryStore<K, V>;
+using InMemoryStore = backend::store::InMemoryStore<K, V, kPageSize>;
 
 template <typename K, typename V>
 using FileBasedStore =

--- a/cpp/state/state.h
+++ b/cpp/state/state.h
@@ -207,10 +207,10 @@ void State<IndexType, StoreType>::SetStorageValue(const Address& address,
 template <template <typename K, typename V> class IndexType,
           template <typename K, typename V> class StoreType>
 Hash State<IndexType, StoreType>::GetHash() const {
-  return GetSha256Hash(address_index_.GetHash(), key_index_.GetHash(),
-                       slot_index_.GetHash(), balances_.GetHash(),
-                       nonces_.GetHash(), value_store_.GetHash(),
-                       account_states_.GetHash());
+  return GetSha256Hash(
+      address_index_.GetHash(), key_index_.GetHash(), slot_index_.GetHash(),
+      balances_.GetHash(), nonces_.GetHash(), value_store_.GetHash(),
+      account_states_.GetHash(), /*placeholder for code depot*/ Hash{});
 }
 
 template <template <typename K, typename V> class IndexType,

--- a/go/common/serializers.go
+++ b/go/common/serializers.go
@@ -87,7 +87,7 @@ func (a BalanceSerializer) FromBytes(bytes []byte) Balance {
 	return value
 }
 func (a BalanceSerializer) Size() int {
-	return 32
+	return 16
 }
 
 // NonceSerializer is a Serializer of the Nonce type
@@ -102,7 +102,7 @@ func (a NonceSerializer) FromBytes(bytes []byte) Nonce {
 	return value
 }
 func (a NonceSerializer) Size() int {
-	return 32
+	return 8
 }
 
 // SlotIdxSerializer32 is a Serializer of the SlotIdx[uint32] type
@@ -111,14 +111,15 @@ type SlotIdxSerializer32 struct {
 }
 
 func (a SlotIdxSerializer32) ToBytes(value SlotIdx[uint32]) []byte {
-	b1 := a.identifierSerializer32.ToBytes(value.AddressIdx)
-	b2 := a.identifierSerializer32.ToBytes(value.KeyIdx)
-	return append(b1, b2...)
+	res := make([]byte, 0, 8)
+	res = binary.LittleEndian.AppendUint32(res, value.AddressIdx)
+	res = binary.LittleEndian.AppendUint32(res, value.KeyIdx)
+	return res
 }
 func (a SlotIdxSerializer32) FromBytes(bytes []byte) SlotIdx[uint32] {
 	value := SlotIdx[uint32]{
-		AddressIdx: a.identifierSerializer32.FromBytes(bytes[0:4]),
-		KeyIdx:     a.identifierSerializer32.FromBytes(bytes[4:8]),
+		AddressIdx: binary.LittleEndian.Uint32(bytes[0:4]),
+		KeyIdx:     binary.LittleEndian.Uint32(bytes[4:8]),
 	}
 	return value
 }

--- a/go/state/cpp_state_test.go
+++ b/go/state/cpp_state_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccountsAreInitiallyUnknown(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -20,7 +20,7 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 }
 
 func TestAccountsCanBeCreated(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -34,7 +34,7 @@ func TestAccountsCanBeCreated(t *testing.T) {
 }
 
 func TestAccountsCanBeDeleted(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestAccountsCanBeDeleted(t *testing.T) {
 }
 
 func TestReadUninitializedBalance(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestReadUninitializedBalance(t *testing.T) {
 }
 
 func TestWriteAndReadBalance(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestWriteAndReadBalance(t *testing.T) {
 }
 
 func TestReadUninitializedNonce(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestReadUninitializedNonce(t *testing.T) {
 }
 
 func TestWriteAndReadNonce(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -121,7 +121,7 @@ func TestWriteAndReadNonce(t *testing.T) {
 }
 
 func TestReadUninitializedSlot(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestReadUninitializedSlot(t *testing.T) {
 }
 
 func TestWriteAndReadSlot(t *testing.T) {
-	for _, named_state := range initStates(t) {
+	for _, named_state := range initCppStates(t) {
 		name := named_state.name
 		state := named_state.state
 		t.Run(name, func(t *testing.T) {
@@ -156,12 +156,7 @@ func TestWriteAndReadSlot(t *testing.T) {
 	}
 }
 
-type namedState struct {
-	name  string
-	state State
-}
-
-func initStates(t *testing.T) []namedState {
+func initCppStates(t *testing.T) []NamedStateConfig {
 	in_memory, err := NewCppInMemoryState()
 	if err != nil {
 		t.Fatalf("Failed to create in-memory store: %v", err)
@@ -172,7 +167,7 @@ func initStates(t *testing.T) []namedState {
 		t.Fatalf("Failed to create in-memory store: %v", err)
 	}
 	t.Cleanup(func() { file_based.Release() })
-	return []namedState{
+	return []NamedStateConfig{
 		{"InMemory", in_memory},
 		{"FileBased", file_based},
 	}

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	HashTreeFactor = 3
-	PageSize       = 32 * 32
+	HashTreeFactor = 32
+	PageSize       = 1 << 12
 )
 
 // GoState manages dependencies to other interfaces to build this service

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -25,14 +25,13 @@ var (
 	val3 = common.Value{0x03}
 
 	balance1 = common.Balance{0x01}
+	balance2 = common.Balance{0x02}
+	balance3 = common.Balance{0x03}
 
 	nonce1 = common.Nonce{0x01}
+	nonce2 = common.Nonce{0x02}
+	nonce3 = common.Nonce{0x03}
 )
-
-type NamedStateConfig struct {
-	state State
-	name  string
-}
 
 func initGoStates(t *testing.T) []NamedStateConfig {
 	mem_state, err := NewGoInMemoryState()
@@ -49,8 +48,8 @@ func initGoStates(t *testing.T) []NamedStateConfig {
 		ldb_state.Close()
 	})
 	return []NamedStateConfig{
-		{mem_state, "memory"},
-		{ldb_state, "LevelDB"},
+		{"memory", mem_state},
+		{"LevelDB", ldb_state},
 	}
 }
 

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -1,0 +1,141 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+type NamedStateConfig struct {
+	name  string
+	state State
+}
+
+func referenceState() (State, error) {
+	return NewGoInMemoryState()
+}
+
+func initStates(t *testing.T) []NamedStateConfig {
+	res := []NamedStateConfig{}
+	for _, s := range initCppStates(t) {
+		res = append(res, NamedStateConfig{name: "cpp-" + s.name, state: s.state})
+	}
+	for _, s := range initGoStates(t) {
+		res = append(res, NamedStateConfig{name: "go-" + s.name, state: s.state})
+	}
+	return res
+}
+
+func testHashAfterModification(t *testing.T, mod func(s State)) {
+	ref, err := referenceState()
+	if err != nil {
+		t.Fatalf("failed to create reference state: %v", err)
+	}
+	mod(ref)
+	want, err := ref.GetHash()
+	if err != nil {
+		t.Fatalf("failed to get hash of reference state: %v", err)
+	}
+	for _, config := range initStates(t) {
+		t.Run(config.name, func(t *testing.T) {
+			mod(config.state)
+			got, err := config.state.GetHash()
+			if err != nil {
+				t.Fatalf("failed to compute hash: %v", err)
+			}
+			if want != got {
+				t.Errorf("Invalid hash, wanted %v, got %v", want, got)
+			}
+		})
+	}
+}
+
+func TestEmptyHash(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		// nothing
+	})
+}
+
+func TestAddressHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.CreateAccount(address1)
+	})
+}
+
+func TestMultipleAddressHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.CreateAccount(address1)
+		s.CreateAccount(address2)
+		s.CreateAccount(address3)
+	})
+}
+
+func TestDeletedAddressHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.CreateAccount(address1)
+		s.CreateAccount(address2)
+		s.CreateAccount(address3)
+		s.DeleteAccount(address1)
+		s.DeleteAccount(address2)
+	})
+}
+
+func TestStorageHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetStorage(address1, key2, val3)
+	})
+}
+
+func TestMultipleStorageHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetStorage(address1, key2, val3)
+		s.SetStorage(address2, key3, val1)
+		s.SetStorage(address3, key1, val2)
+	})
+}
+
+func TestBalanceUpdateHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetBalance(address1, balance1)
+	})
+}
+
+func TestMultipleBalanceUpdateHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetBalance(address1, balance1)
+		s.SetBalance(address2, balance2)
+		s.SetBalance(address3, balance3)
+	})
+}
+
+func TestNonceUpdateHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetNonce(address1, nonce1)
+	})
+}
+
+func TestMultipleNonceUpdateHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		s.SetNonce(address1, nonce1)
+		s.SetNonce(address2, nonce2)
+		s.SetNonce(address3, nonce3)
+	})
+}
+
+func TestLargeStateHashes(t *testing.T) {
+	testHashAfterModification(t, func(s State) {
+		for i := 0; i < 100; i++ {
+			address := common.Address{byte(i)}
+			s.CreateAccount(address)
+			for j := 0; j < 100; j++ {
+				key := common.Key{byte(j)}
+				s.SetStorage(address, key, common.Value{byte(i), 0, 0, byte(j)})
+			}
+			if i%21 == 0 {
+				s.DeleteAccount(address)
+			}
+			s.SetBalance(address, common.Balance{byte(i)})
+			s.SetNonce(address, common.Nonce{byte(i + 1)})
+		}
+	})
+}


### PR DESCRIPTION
This fixes #133; 

major issues observed:
 - different page size configurations
 - different serialization length of nonces and balances
 - different byte order of hashed objects