### PR TITLE
Fix stores benchmark initialization - hash before measuring

### DIFF
--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -284,5 +284,9 @@ func initStoreContent(b *testing.B, store store.Store[uint32, common.Value], dbS
 			b.Fatalf("failed to set store item; %s", err)
 		}
 	}
+	_, err := store.GetStateHash()
+	if err != nil {
+		b.Fatalf("failed to get store hash; %s", err)
+	}
 	b.StartTimer()
 }


### PR DESCRIPTION
This fixes incorrect results for sequential-update-hashing benchmarks - they reports incredibly big time, because it includes hashing of the initial (pre-inserted) database content.

```
BEFORE FIX:
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-8         	       1	5258606785 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-8            	     100	  12022697 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-8        	     230	   8417151 ns/op

AFTER FIX:
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-8         	    1864	    616263 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-8            	     123	  13983068 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-8        	      94	  12434536 ns/op
```