### PR TITLE
Add missing template keyword for dependent type in IndexHandler

### DIFF
--- a/cpp/backend/index/index_handler.h
+++ b/cpp/backend/index/index_handler.h
@@ -63,8 +63,8 @@ template <Trivial K, std::integral I>
 class IndexHandler<SingleLevelDBIndexTestAdapter<K, I>> {
  public:
   IndexHandler()
-      : index_(
-            (*SingleLevelDBIndex::Open(dir_.GetPath())).KeySpace<K, I>('t')) {}
+      : index_((*SingleLevelDBIndex::Open(dir_.GetPath()))
+                   .template KeySpace<K, I>('t')) {}
   SingleLevelDBIndexTestAdapter<K, I>& GetIndex() { return index_; }
 
  private:


### PR DESCRIPTION
This causes builds to fail for some compiler versions (reported by Matej).