### PR TITLE
Fix benchmarks sink - remove conversion to interface{}

### DIFF
--- a/go/backend/index/benchmark_test.go
+++ b/go/backend/index/benchmark_test.go
@@ -93,7 +93,7 @@ func (iw *indexWrapper[K, I]) benchmarkInsert(b *testing.B, keyShift uint32) {
 		if err != nil {
 			b.Fatalf("failed to add item into Index; %s", err)
 		}
-		sink = idx // prevent compiler to optimize it out
+		sinkInt = uint32(idx) // prevent compiler to optimize it out
 	}
 }
 
@@ -104,7 +104,7 @@ func (iw *indexWrapper[K, I]) benchmarkRead(b *testing.B, dist common.Distributi
 		if err != nil {
 			b.Fatalf("failed to add item into Index; %s", err)
 		}
-		sink = idx // prevent compiler to optimize it out
+		sinkInt = uint32(idx) // prevent compiler to optimize it out
 	}
 }
 
@@ -123,11 +123,11 @@ func (iw *indexWrapper[K, I]) benchmarkHash(b *testing.B, updateSize, keyShift u
 		b.StartTimer()
 
 		// this we measure
-		idx, err := iw.idx.GetStateHash()
+		hash, err := iw.idx.GetStateHash()
 		if err != nil {
 			b.Fatalf("failed to hash; %s", err)
 		}
-		sink = idx
+		sinkHash = hash
 	}
 }
 
@@ -265,7 +265,8 @@ func createCachedLevelDbIndex[K comparable, I common.Identifier](b *testing.B, c
 	return indexWrapper[K, I]{keySerializer, indexSerializer, cached}
 }
 
-var sink interface{}
+var sinkInt uint32
+var sinkHash common.Hash
 
 // toKey converts the key from an input uint32 to the generic Key
 func (iw *indexWrapper[K, I]) toKey(key uint32) K {

--- a/go/backend/index/benchmarkhash_test.go
+++ b/go/backend/index/benchmarkhash_test.go
@@ -10,7 +10,7 @@ import (
 
 var updateKeysSizes = []int{100}
 
-var hashSink interface{}
+var hashSink common.Hash
 
 // hashWrapper wraps an instance of the hash index to have serializers and the hash index available at hand
 type hashWrapper[K comparable] struct {

--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -40,7 +40,8 @@ var initialSizes = []int{1 << 20, 1 << 24, 1 << 30}
 // number of values updated before each measured hash recalculation
 var updateSizes = []int{100}
 
-var sink interface{}
+var sinkValue common.Value
+var sinkHash common.Hash
 
 func BenchmarkInsert(b *testing.B) {
 	for _, fac := range getStoresFactories() {
@@ -93,7 +94,7 @@ func benchmarkRead(b *testing.B, dist common.Distribution, store store.Store[uin
 		if err != nil {
 			b.Fatalf("failed to read item from store; %s", err)
 		}
-		sink = value // prevent compiler to optimize it out
+		sinkValue = value // prevent compiler to optimize it out
 	}
 }
 
@@ -161,7 +162,7 @@ func benchmarkHash(b *testing.B, dist common.Distribution, updateSize int, store
 		if err != nil {
 			b.Fatalf("failed to hash store; %s", err)
 		}
-		sink = hash // prevent compiler to optimize it out
+		sinkHash = hash // prevent compiler to optimize it out
 	}
 }
 
@@ -199,7 +200,7 @@ func benchmarkWriteAndHash(b *testing.B, dist common.Distribution, updateSize in
 		if err != nil {
 			b.Fatalf("failed to hash store; %s", err)
 		}
-		sink = hash // prevent compiler to optimize it out
+		sinkHash = hash // prevent compiler to optimize it out
 	}
 }
 


### PR DESCRIPTION
For microbenchmarks (like reading from in-memory store page) there is significant influence of setting the value into the interface{} sink - this can be eliminated by having sinks for individual types.

![image](https://user-images.githubusercontent.com/3178122/199289040-7cdbfd9a-a98c-4a0d-808a-921a9e628f02.png)
