### PR TITLE
Optimize seeking - ReadAt/WriteAt instead of Seek+Read/Write

### DIFF
--- a/go/backend/store/pagedfile/page.go
+++ b/go/backend/store/pagedfile/page.go
@@ -16,12 +16,7 @@ type Page struct {
 }
 
 func (p *Page) Load(file *os.File, pageId int) error {
-	_, err := file.Seek(int64(pageId)*int64(len(p.data)), io.SeekStart)
-	if err != nil {
-		return err
-	}
-
-	n, err := file.Read(p.data)
+	n, err := file.ReadAt(p.data, int64(pageId)*int64(len(p.data)))
 	if err != nil && !errors.Is(err, io.EOF) { // EOF = the page does not exist in the data file yet
 		return err
 	}
@@ -51,12 +46,7 @@ func (p *Page) Get(position int64, size int64) []byte {
 }
 
 func (p *Page) Store(file *os.File, pageId int) error {
-	_, err := file.Seek(int64(pageId)*int64(len(p.data)), io.SeekStart)
-	if err != nil {
-		return err
-	}
-
-	_, err = file.Write(p.data)
+	_, err := file.WriteAt(p.data, int64(pageId)*int64(len(p.data)))
 	if err != nil {
 		return fmt.Errorf("failed to write the page into file; %s", err)
 	}


### PR DESCRIPTION
BEFORE:
```
BenchmarkInsert/Store_File_initialSize_16777216-32         	 2126420	       552.4 ns/op
BenchmarkInsert/Store_PagedFile_initialSize_16777216-32    	14450515	        72.96 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Sequential-32         	 2980207	       389.8 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Uniform-32            	 2110741	       543.2 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Exponential-32        	 2306751	       535.0 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Sequential-32    	29252247	        36.77 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Uniform-32       	 1182500	      1015 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Exponential-32   	  983680	      1027 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Sequential-32        	 2116735	       574.5 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Uniform-32           	 1461133	       803.8 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Exponential-32       	 1599750	       718.9 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Sequential-32   	14737245	        78.95 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Uniform-32      	  496418	      2187 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Exponential-32  	  522918	      1986 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Sequential-32         	   25815	     47346 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Uniform-32            	     674	   1996370 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Exponential-32        	     616	   1830046 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32    	    3211	    435254 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32       	     384	   3053758 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32   	     445	   2724750 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Sequential-32 	   10909	    112612 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Uniform-32    	     582	   2126933 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Exponential-32         	     625	   1889384 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32     	    3754	    418593 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32        	     384	   3060992 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32    	     439	   2813752 ns/op
```
AFTER:
```
BenchmarkInsert/Store_File_initialSize_16777216-32         	 2685712	       433.4 ns/op
BenchmarkInsert/Store_PagedFile_initialSize_16777216-32    	16565042	        69.28 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Sequential-32         	 4206169	       263.1 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Uniform-32            	 2794951	       431.1 ns/op
BenchmarkRead/Store_File_initialSize_16777216_dist_Exponential-32        	 3146910	       392.3 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Sequential-32    	29947532	        36.32 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Uniform-32       	 1308140	       866.1 ns/op
BenchmarkRead/Store_PagedFile_initialSize_16777216_dist_Exponential-32   	 1363056	       873.2 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Sequential-32        	 2712122	       444.9 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Uniform-32           	 1708236	       652.6 ns/op
BenchmarkWrite/Store_File_initialSize_16777216_dist_Exponential-32       	 2041506	       589.8 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Sequential-32   	18598340	        70.31 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Uniform-32      	  639606	      1869 ns/op
BenchmarkWrite/Store_PagedFile_initialSize_16777216_dist_Exponential-32  	  703730	      1677 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Sequential-32         	   25456	     49110 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Uniform-32            	     594	   1954541 ns/op
BenchmarkHash/Store_File_initialSize_16777216_updateSize_100_dist_Exponential-32        	     747	   1704641 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32    	    3386	    431550 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32       	     398	   2992117 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32   	     459	   2615732 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Sequential-32 	   12532	     94741 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Uniform-32    	     604	   1919195 ns/op
BenchmarkWriteAndHash/Store_File_initialSize_16777216_updateSize_100_dist_Exponential-32         	     619	   1799643 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32     	    3720	    419338 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32        	     396	   3020217 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32    	     447	   2628160 ns/op
```