### PR TITLE
Optimize paged file store - undirty pages on hash

### DIFF
--- a/go/backend/store/pagedfile/page.go
+++ b/go/backend/store/pagedfile/page.go
@@ -50,5 +50,6 @@ func (p *Page) Store(file *os.File, pageId int) error {
 	if err != nil {
 		return fmt.Errorf("failed to write the page into file; %s", err)
 	}
+	p.dirty = false
 	return nil
 }


### PR DESCRIPTION
Before this patch, GetStateHash re-calculates hash for dirty pages, but keeps them dirty - because of it, they needs to be re-calculated again on next GetStateHash.
This patch adds writing the dirty pages to disk on hash calculation - leaving them in the page pool as not-dirty pages.
This makes PagedFile store hashing similarly fast as File store hashing, in some cases even faster.

![image](https://user-images.githubusercontent.com/3178122/199962526-0c2d06e7-027b-4731-a82c-6d3afcb965f4.png)

BEFORE:
```
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32         	    3262	    437028 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32            	     379	   3063013 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32        	     459	   2690024 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32 	    3463	    423629 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32    	     375	   3167044 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32         	     406	   2769504 ns/op
```

AFTER:
```
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32         	   24096	     51147 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32            	     751	   1538831 ns/op
BenchmarkHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32        	     854	   1437404 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Sequential-32 	   20218	     58396 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Uniform-32    	     675	   1676186 ns/op
BenchmarkWriteAndHash/Store_PagedFile_initialSize_16777216_updateSize_100_dist_Exponential-32         	     768	   1535613 ns/op
```