### PR TITLE
create cache for key-value pair Stores

### DIFF
--- a/go/backend/store/cache/cachedstore.go
+++ b/go/backend/store/cache/cachedstore.go
@@ -1,0 +1,50 @@
+package cache
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/store"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// Store wraps a cache and a store. It caches the stored keys
+type Store[I common.Identifier, V any] struct {
+	store store.Store[I, V]
+	cache *common.Cache[I, V]
+}
+
+// NewStore creates a new store wrapping the input one, and creates a new cache with the given capacity
+// this store maintains a cache of keys
+func NewStore[I common.Identifier, V any](store store.Store[I, V], cacheCapacity int) *Store[I, V] {
+	return &Store[I, V]{store, common.NewCache[I, V](cacheCapacity)}
+}
+
+func (m *Store[I, V]) Set(id I, value V) error {
+	// write through cache
+	m.cache.Set(id, value)
+	return m.store.Set(id, value)
+}
+
+func (m *Store[I, V]) Get(id I) (v V, err error) {
+	v, exists := m.cache.Get(id)
+	if !exists {
+		if v, err = m.store.Get(id); err == nil {
+			m.cache.Set(id, v)
+		}
+	}
+
+	return
+}
+
+// GetStateHash computes and returns a cryptographical hash of the stored data
+func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
+	return m.store.GetStateHash()
+}
+
+func (m *Store[I, V]) Flush() error {
+	// commit state hash root
+	_, err := m.GetStateHash()
+	return err
+}
+
+func (m *Store[I, V]) Close() error {
+	return m.Flush()
+}

--- a/go/backend/store/cache/cachedstore_test.go
+++ b/go/backend/store/cache/cachedstore_test.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree/htmemory"
+	"github.com/Fantom-foundation/Carmen/go/backend/store/memory"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"testing"
+)
+
+const (
+	BranchingFactor = 3
+	PageSize        = 2 * 32
+	CacheCapacity   = 3
+)
+
+var (
+	A = common.Value{0xAA}
+	B = common.Value{0xBB}
+	C = common.Value{0xCC}
+	D = common.Value{0xDD}
+)
+
+func TestStoreCacheFilled(t *testing.T) {
+	mem, _ := memory.NewStore[uint32, common.Value](common.ValueSerializer{}, PageSize, htmemory.CreateHashTreeFactory(BranchingFactor))
+	store := NewStore[uint32, common.Value](mem, CacheCapacity)
+
+	if _, err := store.Get(0); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+
+	// default value is cached
+	if _, exists := store.cache.Get(0); !exists {
+		t.Errorf("Cache must be filled")
+	}
+
+	// fill in next store elements
+	if err := store.Set(1, B); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+	if err := store.Set(2, C); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+
+	// and check the cache
+	if _, exists := store.cache.Get(0); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(1); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(2); !exists {
+		t.Errorf("Cache must be filled")
+	}
+}
+
+func TestStoreCacheEviction(t *testing.T) {
+	mem, _ := memory.NewStore[uint32, common.Value](common.ValueSerializer{}, PageSize, htmemory.CreateHashTreeFactory(BranchingFactor))
+	store := NewStore[uint32, common.Value](mem, CacheCapacity)
+
+	// fill in store
+	if err := store.Set(0, A); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+	if err := store.Set(1, B); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+	if err := store.Set(2, C); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+	// case eviction of "A" (first one)
+	if err := store.Set(3, D); err != nil {
+		t.Errorf("Error: %x", err)
+	}
+
+	// and check the cache - first one is evicted
+	if _, exists := store.cache.Get(0); exists {
+		t.Errorf("Cache item must be evicted")
+	}
+	if _, exists := store.cache.Get(1); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(2); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(3); !exists {
+		t.Errorf("Cache must be filled")
+	}
+
+	// but the item is in the store - it will go back to the cache
+	if _, err := store.Get(0); err != nil {
+		t.Errorf("Value cannot be fetched: %x", err)
+	}
+
+	// first value went back to the cache
+	if _, exists := store.cache.Get(0); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(1); exists {
+		t.Errorf("Cache item must be evicted")
+	}
+	if _, exists := store.cache.Get(2); !exists {
+		t.Errorf("Cache must be filled")
+	}
+	if _, exists := store.cache.Get(3); !exists {
+		t.Errorf("Cache must be filled")
+	}
+}


### PR DESCRIPTION
This PR adds cache support to the Store the same way we already have for the index. 
It makes sense to use it at the moment only for the LevelDB I guess, because the File based store uses the PagePool as a means of caching. 
However, it is implemented generally, so theoretically it can be mixed with the File store and other potential stores. 