### PR TITLE
Undo unintentional go state api change

### DIFF
--- a/go/simulation/state_simulation.go
+++ b/go/simulation/state_simulation.go
@@ -14,7 +14,7 @@ import (
 const KeysCacheSize = 256
 
 func main() {
-	memState, err := state.NewMemory("")
+	memState, err := state.NewMemory()
 	if err != nil {
 		panic(err)
 	}

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -35,7 +35,7 @@ var (
 
 func initGoStates() []namedStateConfig {
 	return []namedStateConfig{
-		{"Memory", NewMemory},
+		{"Memory", newTestingMemory},
 		{"LevelDB Index, File Store", NewLeveLIndexFileStore},
 		{"Cached LevelDB Index, File Store", NewCachedLeveLIndexFileStore},
 		{"Cached Transact LevelDB, Index File Store", NewCachedTransactLeveLIndexFileStore},
@@ -43,6 +43,10 @@ func initGoStates() []namedStateConfig {
 		{"Cached LevelDB Index and Store", NewCachedLeveLIndexAndStore},
 		{"Cached Transact LevelDB Index and Store", NewTransactCachedLeveLIndexAndStore}, // cannot combine transact and non-transact access
 	}
+}
+
+func newTestingMemory(_ string) (State, error) {
+	return NewMemory()
 }
 
 func TestMissingKeys(t *testing.T) {
@@ -255,7 +259,7 @@ func (m failingIndex[K, I]) Get(key K) (id I, err error) {
 }
 
 func TestFailingStore(t *testing.T) {
-	state, err := NewMemory("")
+	state, err := NewMemory()
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}
@@ -285,7 +289,7 @@ func TestFailingStore(t *testing.T) {
 }
 
 func TestFailingIndex(t *testing.T) {
-	state, err := NewMemory("")
+	state, err := NewMemory()
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -29,7 +29,7 @@ const TransactBufferMB = 128 * opt.MiB
 
 // NewMemory creates in memory implementation
 // (path parameter for compatibility with other state factories, can be left empty)
-func NewMemory(path string) (State, error) {
+func NewMemory() (State, error) {
 	addressIndex := indexmem.NewIndex[common.Address, uint32](common.AddressSerializer{})
 	slotIndex := indexmem.NewIndex[common.SlotIdx[uint32], uint32](common.SlotIdxSerializer32{})
 	keyIndex := indexmem.NewIndex[common.Key, uint32](common.KeySerializer{})

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -1390,7 +1390,7 @@ func TestCarmenStateAccessedAddressedAreResetAtTransactionAbort(t *testing.T) {
 }
 
 func testStateDbHashAfterModification(t *testing.T, mod func(s StateDB)) {
-	ref_state, err := NewMemory("")
+	ref_state, err := NewMemory()
 	if err != nil {
 		t.Fatalf("failed to create reference state: %v", err)
 	}

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -23,7 +23,7 @@ func initStates() []namedStateConfig {
 }
 
 func testHashAfterModification(t *testing.T, mod func(s State)) {
-	ref, err := NewMemory("")
+	ref, err := NewMemory()
 	if err != nil {
 		t.Fatalf("failed to create reference state: %v", err)
 	}


### PR DESCRIPTION
In my tests unifying PR I have unintentionally changed public API of the Carmen state used in Aida - function `state.NewMemory()` (added path param necessary only for usage in our tests).
This PR changes it back.