### PR TITLE
Refactor FileStore to make Eager/Lazy distinction more apparent

### DIFF
--- a/cpp/backend/store/file/store_test.cc
+++ b/cpp/backend/store/file/store_test.cc
@@ -8,8 +8,13 @@
 namespace carmen::backend::store {
 namespace {
 
-TEST(FileStoreTest, StoreCanBeSavedAndRestored) {
-  using Store = FileStore<int, int, SingleFile>;
+template <typename T>
+class FileStoreTest : public testing::Test {};
+
+TYPED_TEST_SUITE_P(FileStoreTest);
+
+TYPED_TEST_P(FileStoreTest, StoreCanBeSavedAndRestored) {
+  using Store = TypeParam;
   const auto kNumElements = static_cast<int>(Store::kPageSize * 10);
   TempDir dir;
   Hash hash;
@@ -28,6 +33,15 @@ TEST(FileStoreTest, StoreCanBeSavedAndRestored) {
     }
   }
 }
+
+REGISTER_TYPED_TEST_SUITE_P(FileStoreTest, StoreCanBeSavedAndRestored);
+
+using FileStoreVariants =
+    ::testing::Types<EagerFileStore<int, int, SingleFile>,
+                     LazyFileStore<int, int, SingleFile> >;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(FileStoreTests, FileStoreTest,
+                               FileStoreVariants);
 
 }  // namespace
 }  // namespace carmen::backend::store

--- a/cpp/backend/store/store_benchmark.cc
+++ b/cpp/backend/store/store_benchmark.cc
@@ -13,16 +13,12 @@ constexpr const std::size_t kBranchFactor = 32;
 // To run benchmarks, use the following command:
 //    bazel run -c opt //backend/store:store_benchmark
 
-template <typename K, Trivial V, template <typename> class F,
-          std::size_t page_size>
-using LazyFileStore = FileStore<K, V, F, page_size, false>;
-
 // Defines the list of configurations to be benchmarked.
 BENCHMARK_TYPE_LIST(StoreConfigList, (ReferenceStore<kPageSize>),
                     (InMemoryStore<int, Value, kPageSize>),
                     (LevelDBStore<int, Value, kPageSize>),
-                    (FileStore<int, Value, InMemoryFile, kPageSize>),
-                    (FileStore<int, Value, SingleFile, kPageSize>),
+                    (EagerFileStore<int, Value, InMemoryFile, kPageSize>),
+                    (EagerFileStore<int, Value, SingleFile, kPageSize>),
                     (LazyFileStore<int, Value, SingleFile, kPageSize>));
 
 // Defines the list of problem sizes.

--- a/cpp/backend/store/store_test.cc
+++ b/cpp/backend/store/store_test.cc
@@ -260,33 +260,33 @@ using StoreTypes = ::testing::Types<
     // Page size 32, branching size 32.
     StoreHandler<ReferenceStore<32>, 32>,
     StoreHandler<InMemoryStore<int, Value, 32>, 32>,
-    StoreHandler<FileStore<int, Value, InMemoryFile, 32>, 32>,
-    StoreHandler<FileStore<int, Value, SingleFile, 32>, 32>,
-    StoreHandler<FileStore<int, Value, SingleFile, 32, false>, 32>,
+    StoreHandler<EagerFileStore<int, Value, InMemoryFile, 32>, 32>,
+    StoreHandler<EagerFileStore<int, Value, SingleFile, 32>, 32>,
+    StoreHandler<LazyFileStore<int, Value, SingleFile, 32>, 32>,
     StoreHandler<LevelDBStore<int, Value, 32>, 32>,
 
     // Page size 64, branching size 3.
     StoreHandler<ReferenceStore<64>, 3>,
     StoreHandler<InMemoryStore<int, Value, 64>, 3>,
-    StoreHandler<FileStore<int, Value, InMemoryFile, 64>, 3>,
-    StoreHandler<FileStore<int, Value, SingleFile, 64>, 3>,
-    StoreHandler<FileStore<int, Value, SingleFile, 64, false>, 3>,
+    StoreHandler<EagerFileStore<int, Value, InMemoryFile, 64>, 3>,
+    StoreHandler<EagerFileStore<int, Value, SingleFile, 64>, 3>,
+    StoreHandler<LazyFileStore<int, Value, SingleFile, 64>, 3>,
     StoreHandler<LevelDBStore<int, Value, 64>, 3>,
 
     // Page size 64, branching size 8.
     StoreHandler<ReferenceStore<64>, 8>,
     StoreHandler<InMemoryStore<int, Value, 64>, 8>,
-    StoreHandler<FileStore<int, Value, InMemoryFile, 64>, 8>,
-    StoreHandler<FileStore<int, Value, SingleFile, 64>, 8>,
-    StoreHandler<FileStore<int, Value, SingleFile, 64, false>, 8>,
+    StoreHandler<EagerFileStore<int, Value, InMemoryFile, 64>, 8>,
+    StoreHandler<EagerFileStore<int, Value, SingleFile, 64>, 8>,
+    StoreHandler<LazyFileStore<int, Value, SingleFile, 64>, 8>,
     StoreHandler<LevelDBStore<int, Value, 64>, 8>,
 
     // Page size 128, branching size 4.
     StoreHandler<ReferenceStore<128>, 4>,
     StoreHandler<InMemoryStore<int, Value, 128>, 4>,
-    StoreHandler<FileStore<int, Value, InMemoryFile, 128>, 4>,
-    StoreHandler<FileStore<int, Value, SingleFile, 128>, 4>,
-    StoreHandler<FileStore<int, Value, SingleFile, 128, false>, 4>,
+    StoreHandler<EagerFileStore<int, Value, InMemoryFile, 128>, 4>,
+    StoreHandler<EagerFileStore<int, Value, SingleFile, 128>, 4>,
+    StoreHandler<LazyFileStore<int, Value, SingleFile, 128>, 4>,
     StoreHandler<LevelDBStore<int, Value, 128>, 4>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(All, StoreTest, StoreTypes);

--- a/cpp/state/c_state.cc
+++ b/cpp/state/c_state.cc
@@ -37,7 +37,7 @@ using FileBasedIndex =
 
 template <typename K, typename V>
 using FileBasedStore =
-    backend::store::FileStore<K, V, backend::SingleFile, kPageSize>;
+    backend::store::EagerFileStore<K, V, backend::SingleFile, kPageSize>;
 
 // An abstract interface definition of WorldState instances.
 class WorldState {


### PR DESCRIPTION
With this change the distinction between eager and lazy hashed file stores is made more prominent, marking those two configurations as two distinct implementation options in tests and benchmarks.