### PR TITLE
Add Go-side code cache into CppState

### DIFF
--- a/go/backend/depot/cache/cachedepot.go
+++ b/go/backend/depot/cache/cachedepot.go
@@ -73,7 +73,7 @@ func (m *Depot[I]) Close() error {
 func (m *Depot[I]) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*m))
 	mf.AddChild("cache", m.cache.GetDynamicMemoryFootprint(func(value []byte) uintptr {
-		return uintptr(len(value))
+		return uintptr(cap(value)) // memory consumed by the code slice
 	}))
 	mf.AddChild("sourceDepot", m.depot.GetMemoryFootprint())
 	return mf


### PR DESCRIPTION
Add code cache into the CppState.

**Cache size tuning - Aida replay measurements (blocks 4564026-4600000):** (time in CppState.GetCode)
* no cache: 0.67s
* cache 500_000: 0.07s
* cache 100_000: 0.03s
* cache 10_000: 0.03s
* somewhere here should be the optimal size - chosen 8_000 for now
* cache 5_000: 0.04s
* cache 1_000: 0.04s
