### PR TITLE
Add cache hit ratio reporting

### DIFF
--- a/go/common/cache_test.go
+++ b/go/common/cache_test.go
@@ -1,6 +1,8 @@
 package common
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestEmpty(t *testing.T) {
 	c := initCache(3)
@@ -100,6 +102,26 @@ func TestSettingExisting(t *testing.T) {
 	value, exists := c.Get(1)
 	if !exists || value != 67 {
 		t.Errorf("Item value invalid")
+	}
+}
+
+func TestHitRatio(t *testing.T) {
+	if !MissHitMeasuring {
+		t.Skip("MissHitMeasuring is disabled - skipping the test")
+	}
+
+	c := initCache(3)
+	c.Set(1, 11)
+	c.Set(2, 22)
+
+	c.Get(1) // hit
+	c.Get(8) // miss
+	c.Get(2) // hit
+	c.Get(9) // miss
+
+	report := c.getHitRatioReport()
+	if report != "(misses: 2, hits: 2, hitRatio: 0.500000)" {
+		t.Errorf("unexpected memory footprint report: %s", report)
 	}
 }
 

--- a/go/common/mem_footprint.go
+++ b/go/common/mem_footprint.go
@@ -10,6 +10,7 @@ import (
 type MemoryFootprint struct {
 	value    uintptr
 	children map[string]*MemoryFootprint
+	note     string
 }
 
 // NewMemoryFootprint creates a new MemoryFootprint instance for a database structure
@@ -18,6 +19,11 @@ func NewMemoryFootprint(value uintptr) *MemoryFootprint {
 		value:    value,
 		children: make(map[string]*MemoryFootprint),
 	}
+}
+
+// SetNote allows to attach a string comment to the memory report
+func (mf *MemoryFootprint) SetNote(note string) {
+	mf.note = note
 }
 
 // AddChild allows to attach a MemoryFootprint of the database structure subcomponent
@@ -89,6 +95,10 @@ func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) (er
 	}
 	sb.WriteRune(' ')
 	sb.WriteString(path)
+	if len(mf.note) != 0 {
+		sb.WriteRune(' ')
+		sb.WriteString(mf.note)
+	}
 	sb.WriteRune('\n')
 
 	return


### PR DESCRIPTION
Adds note to the MemoryFootprint, like:
```
(misses: 47738, hits: 2742308, hitRatio: 0.982890)
```
Output from run-vm on 4564026-4600000:
```
   48.0  B ./state/accountsStore/backingStore/hashTree
  406.2 KB ./state/accountsStore/backingStore/pagesPool (misses: 10, hits: 40572, hitRatio: 0.999754)
  406.4 KB ./state/accountsStore/backingStore
   24.0 MB ./state/accountsStore/cache (misses: 0, hits: 230007, hitRatio: 1.000000)
   24.4 MB ./state/accountsStore
   40.0 MB ./state/addressIndex/cache (misses: 47738, hits: 2742308, hitRatio: 0.982890)
   72.0  B ./state/addressIndex/sourceIndex/hashIndex
    8.0 MB ./state/addressIndex/sourceIndex/levelDb/blockCache
    4.0 MB ./state/addressIndex/sourceIndex/levelDb/writeBuffer
   12.0 MB ./state/addressIndex/sourceIndex/levelDb
   12.0 MB ./state/addressIndex/sourceIndex
   52.0 MB ./state/addressIndex
   48.0  B ./state/balancesStore/backingStore/hashTree
  406.2 KB ./state/balancesStore/backingStore/pagesPool (misses: 7902, hits: 156872, hitRatio: 0.952043)
  406.4 KB ./state/balancesStore/backingStore
   40.0 MB ./state/balancesStore/cache (misses: 8, hits: 152455, hitRatio: 0.999948)
   40.4 MB ./state/balancesStore
    0.0  B ./state/codeHashesStore/backingStore/hashTree
  406.2 KB ./state/codeHashesStore/backingStore/pagesPool (misses: 316, hits: 38711, hitRatio: 0.991903)
  406.3 KB ./state/codeHashesStore/backingStore
   56.0 MB ./state/codeHashesStore/cache (misses: 823, hits: 299826, hitRatio: 0.997263)
   56.4 MB ./state/codeHashesStore
   55.6 MB ./state/codesDepot/cache (misses: 383, hits: 245919, hitRatio: 0.998445)
   48.0  B ./state/codesDepot/sourceDepot/hashTree
  104.0  B ./state/codesDepot/sourceDepot
   55.6 MB ./state/codesDepot
   56.0 MB ./state/keyIndex/cache (misses: 670211, hits: 617234, hitRatio: 0.479426)
   72.0  B ./state/keyIndex/sourceIndex/hashIndex
    8.0 MB ./state/keyIndex/sourceIndex/levelDb/blockCache
    4.0 MB ./state/keyIndex/sourceIndex/levelDb/writeBuffer
   12.0 MB ./state/keyIndex/sourceIndex/levelDb
   12.0 MB ./state/keyIndex/sourceIndex
   68.0 MB ./state/keyIndex
   48.0  B ./state/noncesStore/backingStore/hashTree
  406.2 KB ./state/noncesStore/backingStore/pagesPool (misses: 79, hits: 124225, hitRatio: 0.999364)
  406.4 KB ./state/noncesStore/backingStore
   32.0 MB ./state/noncesStore/cache (misses: 823, hits: 76366, hitRatio: 0.989338)
   32.4 MB ./state/noncesStore
   32.0 MB ./state/slotIndex/cache (misses: 545126, hits: 493549, hitRatio: 0.475172)
   72.0  B ./state/slotIndex/sourceIndex/hashIndex
    8.0 MB ./state/slotIndex/sourceIndex/levelDb/blockCache
    4.0 MB ./state/slotIndex/sourceIndex/levelDb/writeBuffer
   12.0 MB ./state/slotIndex/sourceIndex/levelDb
   12.0 MB ./state/slotIndex/sourceIndex
   44.0 MB ./state/slotIndex
   48.0  B ./state/valuesStore/backingStore/hashTree
  406.2 KB ./state/valuesStore/backingStore/pagesPool (misses: 227126, hits: 826158, hitRatio: 0.784364)
  406.4 KB ./state/valuesStore/backingStore
   56.0 MB ./state/valuesStore/cache (misses: 0, hits: 39789, hitRatio: 1.000000)
   56.4 MB ./state/valuesStore
  405.6 MB ./state
   99.2 MB ./storedDataCache (misses: 304849, hits: 4729651, hitRatio: 0.939448)
    0.0  B ./writtenSlots
  504.8 MB .
```