### PR TITLE
Set Go PoolSize to 100000 (consistent with cpp)

### DIFF
--- a/go/backend/store/benchmark_test.go
+++ b/go/backend/store/benchmark_test.go
@@ -23,7 +23,7 @@ import (
 const (
 	BmBranchingFactor = 32
 	BmPageSize        = 1 << 12 // = 4 KiB
-	BmPoolSize        = 100
+	BmPoolSize        = 100000
 )
 
 // initial number of values inserted into the Store before the benchmark

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -31,7 +31,7 @@ const CacheCapacity = 1 << 20 // 2 ^ 20 keys -> 32MB for 32-bytes keys
 const TransactBufferMB = 128 * opt.MiB
 
 // PoolSize is the maximum amount of data pages loaded in memory for the paged file store
-const PoolSize = 100
+const PoolSize = 100000
 
 // NewMemory creates in memory implementation
 // (path parameter for compatibility with other state factories, can be left empty)


### PR DESCRIPTION
go-file has currently much higher IO than cpp-file - seems the major issue is this forgotten PoolSize parameter - setting it now to value currently used in cpp.