### PR TITLE
Fix removing non-existing account in GoState

### DIFF
--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -51,13 +51,13 @@ func (s *GoState) GetAccountState(address common.Address) (state common.AccountS
 	return s.accountsStore.Get(idx)
 }
 
-func (s *GoState) DeleteAccount(address common.Address) (err error) {
+func (s *GoState) DeleteAccount(address common.Address) error {
 	idx, err := s.addressIndex.Get(address)
-	if err == index.ErrNotFound {
-		err = nil
-	}
 	if err != nil {
-		return
+		if err == index.ErrNotFound {
+			return nil
+		}
+		return err
 	}
 	return s.accountsStore.Set(idx, common.Deleted)
 }


### PR DESCRIPTION
* Fix behavior of GoState when removing an account, which have not existed
* Added test-coverage, behavior of GoState is now consistent with CppState
* Fixed testEachConfiguration method to fail in the sub-test, where a fail occurred

Possibly related to https://github.com/Fantom-foundation/Aida/issues/156