### PR TITLE
add tests for state persistance

### DIFF
--- a/go/common/benchmarkhasher_test.go
+++ b/go/common/benchmarkhasher_test.go
@@ -100,6 +100,7 @@ func BenchmarkKeccak256(b *testing.B) {
 
 // BenchmarkMapHash hashes a number of bytes testing performance of a map (non-cryptographical) hash
 func BenchmarkMapHash(b *testing.B) {
+	hashSeed := maphash.MakeSeed()
 	for i := 1; i <= numBytes; i = i << step {
 		data := make([]byte, i)
 		b.Run(fmt.Sprintf("MapHash EveryLoop dataSize: %d", i), func(b *testing.B) {
@@ -111,5 +112,107 @@ func BenchmarkMapHash(b *testing.B) {
 				intSink = hash
 			}
 		})
+	}
+}
+
+// BenchmarkMapHashFromBytes hashes a map (non-cryptographical) hash using the build-in library
+func BenchmarkMapHashAllBytes(b *testing.B) {
+	key := KeySerializer{}
+	data := GetKeccak256Hash(key.ToBytes(Key{})).ToBytes()
+	hashSeed := maphash.MakeSeed()
+
+	for i := 1; i <= b.N; i++ {
+		var h maphash.Hash
+		h.SetSeed(hashSeed)
+		_, _ = h.Write(data)
+		hash := h.Sum64()
+		intSink = hash
+	}
+}
+
+func BenchmarkMapHashComputeEach32Byte(b *testing.B) {
+	key := KeySerializer{}
+	data := GetKeccak256Hash(key.ToBytes(Key{}))
+
+	for j := 1; j <= b.N; j++ {
+
+		hash := uint64(17)
+		hash = hash*prime + uint64(data[0])
+		hash = hash*prime + uint64(data[1])
+		hash = hash*prime + uint64(data[2])
+		hash = hash*prime + uint64(data[3])
+		hash = hash*prime + uint64(data[4])
+		hash = hash*prime + uint64(data[5])
+		hash = hash*prime + uint64(data[6])
+		hash = hash*prime + uint64(data[7])
+		hash = hash*prime + uint64(data[8])
+		hash = hash*prime + uint64(data[9])
+		hash = hash*prime + uint64(data[10])
+		hash = hash*prime + uint64(data[11])
+		hash = hash*prime + uint64(data[12])
+		hash = hash*prime + uint64(data[13])
+		hash = hash*prime + uint64(data[14])
+		hash = hash*prime + uint64(data[15])
+		hash = hash*prime + uint64(data[16])
+		hash = hash*prime + uint64(data[17])
+		hash = hash*prime + uint64(data[18])
+		hash = hash*prime + uint64(data[19])
+		hash = hash*prime + uint64(data[20])
+		hash = hash*prime + uint64(data[21])
+		hash = hash*prime + uint64(data[22])
+		hash = hash*prime + uint64(data[23])
+		hash = hash*prime + uint64(data[24])
+		hash = hash*prime + uint64(data[25])
+		hash = hash*prime + uint64(data[26])
+		hash = hash*prime + uint64(data[27])
+		hash = hash*prime + uint64(data[28])
+		hash = hash*prime + uint64(data[29])
+		hash = hash*prime + uint64(data[30])
+		hash = hash*prime + uint64(data[31])
+
+		intSink = hash
+	}
+}
+
+func BenchmarkMapHashCompute32BytesInLoop(b *testing.B) {
+	key := KeySerializer{}
+	data := GetKeccak256Hash(key.ToBytes(Key{}))
+
+	for j := 1; j <= b.N; j++ {
+
+		hash := uint64(17)
+		for i := 0; i < 32; i++ {
+			hash = hash*prime + uint64(data[i])
+		}
+
+		intSink = hash
+	}
+}
+
+func BenchmarkMapHashComputeEach32ByteShifts(b *testing.B) {
+	key := KeySerializer{}
+	data := GetKeccak256Hash(key.ToBytes(Key{})).ToBytes()
+
+	for j := 1; j <= b.N; j++ {
+
+		a := uint64(data[0]) | uint64(data[1])<<8 | uint64(data[2])<<16 | uint64(data[3])<<24 |
+			uint64(data[4])<<32 | uint64(data[5])<<40 | uint64(data[6])<<48 | uint64(data[7])<<56
+
+		b := uint64(data[8]) | uint64(data[9])<<8 | uint64(data[10])<<16 | uint64(data[11])<<24 |
+			uint64(data[12])<<32 | uint64(data[13])<<40 | uint64(data[14])<<48 | uint64(data[15])<<56
+
+		c := uint64(data[16]) | uint64(data[17])<<8 | uint64(data[18])<<16 | uint64(data[19])<<24 |
+			uint64(data[20])<<32 | uint64(data[21])<<40 | uint64(data[22])<<48 | uint64(data[23])<<56
+
+		d := uint64(data[24]) | uint64(data[25])<<8 | uint64(data[26])<<16 | uint64(data[27])<<24 |
+			uint64(data[28])<<32 | uint64(data[29])<<40 | uint64(data[30])<<48 | uint64(data[31])<<56
+
+		hash := uint64(17)
+		hash = hash*prime + a
+		hash = hash*prime + b
+		hash = hash*prime + c
+		hash = hash*prime + d
+
+		intSink = hash
 	}
 }

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"hash/maphash"
 	"math/big"
 
 	"golang.org/x/crypto/sha3"
@@ -205,26 +204,78 @@ func GetHash(h hash.Hash, data []byte) (res Hash) {
 	return
 }
 
-var hashSeed = maphash.MakeSeed() // TODO this is a stable seed only within one runtime
+const prime = 31
 
 type AddressHasher struct{}
 
 // Hash implements non-cryptographical hash to be used in maps
-func (s AddressHasher) Hash(a *Address) uint64 {
-	var h maphash.Hash
-	h.SetSeed(hashSeed)
-	_, _ = h.Write(a[:])
-	return h.Sum64()
+func (s AddressHasher) Hash(data *Address) uint64 {
+	// enumerate all indexes for the best performance, even a for-loop adds 25% overhead
+	h := uint64(17)
+	h = h*prime + uint64(data[0])
+	h = h*prime + uint64(data[1])
+	h = h*prime + uint64(data[2])
+	h = h*prime + uint64(data[3])
+	h = h*prime + uint64(data[4])
+	h = h*prime + uint64(data[5])
+	h = h*prime + uint64(data[6])
+	h = h*prime + uint64(data[7])
+	h = h*prime + uint64(data[8])
+	h = h*prime + uint64(data[9])
+	h = h*prime + uint64(data[10])
+	h = h*prime + uint64(data[11])
+	h = h*prime + uint64(data[12])
+	h = h*prime + uint64(data[13])
+	h = h*prime + uint64(data[14])
+	h = h*prime + uint64(data[15])
+	h = h*prime + uint64(data[16])
+	h = h*prime + uint64(data[17])
+	h = h*prime + uint64(data[18])
+	h = h*prime + uint64(data[19])
+
+	return h
 }
 
 type KeyHasher struct{}
 
 // Hash implements non-cryptographical hash to be used in maps
-func (s KeyHasher) Hash(a *Key) uint64 {
-	var h maphash.Hash
-	h.SetSeed(hashSeed)
-	_, _ = h.Write(a[:])
-	return h.Sum64()
+func (s KeyHasher) Hash(data *Key) uint64 {
+	// enumerate all indexes for the best performance, even a for-loop adds 25% overhead
+	h := uint64(17)
+	h = h*prime + uint64(data[0])
+	h = h*prime + uint64(data[1])
+	h = h*prime + uint64(data[2])
+	h = h*prime + uint64(data[3])
+	h = h*prime + uint64(data[4])
+	h = h*prime + uint64(data[5])
+	h = h*prime + uint64(data[6])
+	h = h*prime + uint64(data[7])
+	h = h*prime + uint64(data[8])
+	h = h*prime + uint64(data[9])
+	h = h*prime + uint64(data[10])
+	h = h*prime + uint64(data[11])
+	h = h*prime + uint64(data[12])
+	h = h*prime + uint64(data[13])
+	h = h*prime + uint64(data[14])
+	h = h*prime + uint64(data[15])
+	h = h*prime + uint64(data[16])
+	h = h*prime + uint64(data[17])
+	h = h*prime + uint64(data[18])
+	h = h*prime + uint64(data[19])
+	h = h*prime + uint64(data[20])
+	h = h*prime + uint64(data[21])
+	h = h*prime + uint64(data[22])
+	h = h*prime + uint64(data[23])
+	h = h*prime + uint64(data[24])
+	h = h*prime + uint64(data[25])
+	h = h*prime + uint64(data[26])
+	h = h*prime + uint64(data[27])
+	h = h*prime + uint64(data[28])
+	h = h*prime + uint64(data[29])
+	h = h*prime + uint64(data[30])
+	h = h*prime + uint64(data[31])
+
+	return h
 }
 
 type SlotIdxHasher struct{}

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -82,7 +82,7 @@ func NewGoFileState(path string) (State, error) {
 	}
 
 	addressIndexPath := indexPath + string(filepath.Separator) + "addresses"
-	if err = os.Mkdir(addressIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(addressIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	addressIndex, err := file.NewIndex[common.Address, uint32](addressIndexPath, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressHasher{}, common.AddressComparator{})
@@ -90,7 +90,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	slotsIndexPath := indexPath + string(filepath.Separator) + "slots"
-	if err = os.Mkdir(slotsIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(slotsIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	slotIndex, err := file.NewIndex[common.SlotIdx[uint32], uint32](slotsIndexPath, common.SlotIdxSerializer32{}, common.Identifier32Serializer{}, common.SlotIdxHasher{}, common.Identifier32Comparator{})
@@ -98,7 +98,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	keysIndexPath := indexPath + string(filepath.Separator) + "keys"
-	if err = os.Mkdir(keysIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(keysIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	keyIndex, err := file.NewIndex[common.Key, uint32](keysIndexPath, common.KeySerializer{}, common.Identifier32Serializer{}, common.KeyHasher{}, common.KeyComparator{})
@@ -107,7 +107,7 @@ func NewGoFileState(path string) (State, error) {
 	}
 
 	accountStorePath := storePath + string(filepath.Separator) + "accounts"
-	if err = os.Mkdir(accountStorePath, 0700); err != nil {
+	if err = os.MkdirAll(accountStorePath, 0700); err != nil {
 		return nil, err
 	}
 	accountsStore, err := pagedfile.NewStore[uint32, common.AccountState](accountStorePath, common.AccountStateSerializer{}, PageSize, htfile.CreateHashTreeFactory(accountStorePath, HashTreeFactor), PoolSize)
@@ -115,7 +115,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	noncesStorePath := storePath + string(filepath.Separator) + "nonces"
-	if err = os.Mkdir(noncesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(noncesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	noncesStore, err := pagedfile.NewStore[uint32, common.Nonce](noncesStorePath, common.NonceSerializer{}, PageSize, htfile.CreateHashTreeFactory(noncesStorePath, HashTreeFactor), PoolSize)
@@ -123,7 +123,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	balancesStorePath := storePath + string(filepath.Separator) + "balances"
-	if err = os.Mkdir(balancesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(balancesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	balancesStore, err := pagedfile.NewStore[uint32, common.Balance](balancesStorePath, common.BalanceSerializer{}, PageSize, htfile.CreateHashTreeFactory(balancesStorePath, HashTreeFactor), PoolSize)
@@ -131,7 +131,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	valuesStorePath := storePath + string(filepath.Separator) + "values"
-	if err = os.Mkdir(valuesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(valuesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	valuesStore, err := pagedfile.NewStore[uint32, common.Value](valuesStorePath, common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(valuesStorePath, HashTreeFactor), PoolSize)
@@ -140,7 +140,7 @@ func NewGoFileState(path string) (State, error) {
 	}
 
 	codesPath := storePath + string(filepath.Separator) + "codes"
-	if err = os.Mkdir(codesPath, 0700); err != nil {
+	if err = os.MkdirAll(codesPath, 0700); err != nil {
 		return nil, err
 	}
 	codesDepot, err := fileDepot.NewDepot[uint32](codesPath, common.Identifier32Serializer{}, htfile.CreateHashTreeFactory(codesPath, HashTreeFactor), CodeHashGroupSize)
@@ -148,7 +148,7 @@ func NewGoFileState(path string) (State, error) {
 		return nil, err
 	}
 	codeHashesStorePath := storePath + string(filepath.Separator) + "codeHashes"
-	if err = os.Mkdir(codeHashesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(codeHashesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	codeHashesStore, err := pagedfile.NewStore[uint32, common.Hash](codeHashesStorePath, common.HashSerializer{}, PageSize, hashtree.GetNoHashFactory(), PoolSize)
@@ -179,7 +179,7 @@ func NewGoCachedFileState(path string) (State, error) {
 	}
 
 	addressIndexPath := indexPath + string(filepath.Separator) + "addresses"
-	if err = os.Mkdir(addressIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(addressIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	addressIndex, err := file.NewIndex[common.Address, uint32](addressIndexPath, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressHasher{}, common.AddressComparator{})
@@ -187,7 +187,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	slotsIndexPath := indexPath + string(filepath.Separator) + "slots"
-	if err = os.Mkdir(slotsIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(slotsIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	slotIndex, err := file.NewIndex[common.SlotIdx[uint32], uint32](slotsIndexPath, common.SlotIdxSerializer32{}, common.Identifier32Serializer{}, common.SlotIdxHasher{}, common.Identifier32Comparator{})
@@ -195,7 +195,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	keysIndexPath := indexPath + string(filepath.Separator) + "keys"
-	if err = os.Mkdir(keysIndexPath, 0700); err != nil {
+	if err = os.MkdirAll(keysIndexPath, 0700); err != nil {
 		return nil, err
 	}
 	keyIndex, err := file.NewIndex[common.Key, uint32](keysIndexPath, common.KeySerializer{}, common.Identifier32Serializer{}, common.KeyHasher{}, common.KeyComparator{})
@@ -204,7 +204,7 @@ func NewGoCachedFileState(path string) (State, error) {
 	}
 
 	accountStorePath := storePath + string(filepath.Separator) + "accounts"
-	if err = os.Mkdir(accountStorePath, 0700); err != nil {
+	if err = os.MkdirAll(accountStorePath, 0700); err != nil {
 		return nil, err
 	}
 	accountsStore, err := pagedfile.NewStore[uint32, common.AccountState](accountStorePath, common.AccountStateSerializer{}, PageSize, htfile.CreateHashTreeFactory(accountStorePath, HashTreeFactor), PoolSize)
@@ -212,7 +212,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	noncesStorePath := storePath + string(filepath.Separator) + "nonces"
-	if err = os.Mkdir(noncesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(noncesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	noncesStore, err := pagedfile.NewStore[uint32, common.Nonce](noncesStorePath, common.NonceSerializer{}, PageSize, htfile.CreateHashTreeFactory(noncesStorePath, HashTreeFactor), PoolSize)
@@ -220,7 +220,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	balancesStorePath := storePath + string(filepath.Separator) + "balances"
-	if err = os.Mkdir(balancesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(balancesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	balancesStore, err := pagedfile.NewStore[uint32, common.Balance](balancesStorePath, common.BalanceSerializer{}, PageSize, htfile.CreateHashTreeFactory(balancesStorePath, HashTreeFactor), PoolSize)
@@ -228,7 +228,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	valuesStorePath := storePath + string(filepath.Separator) + "values"
-	if err = os.Mkdir(valuesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(valuesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	valuesStore, err := pagedfile.NewStore[uint32, common.Value](valuesStorePath, common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(valuesStorePath, HashTreeFactor), PoolSize)
@@ -237,7 +237,7 @@ func NewGoCachedFileState(path string) (State, error) {
 	}
 
 	codesPath := storePath + string(filepath.Separator) + "codes"
-	if err = os.Mkdir(codesPath, 0700); err != nil {
+	if err = os.MkdirAll(codesPath, 0700); err != nil {
 		return nil, err
 	}
 	codesDepot, err := fileDepot.NewDepot[uint32](codesPath, common.Identifier32Serializer{}, htfile.CreateHashTreeFactory(codesPath, HashTreeFactor), CodeHashGroupSize)
@@ -245,7 +245,7 @@ func NewGoCachedFileState(path string) (State, error) {
 		return nil, err
 	}
 	codeHashesStorePath := storePath + string(filepath.Separator) + "codeHashes"
-	if err = os.Mkdir(codeHashesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(codeHashesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	codeHashesStore, err := pagedfile.NewStore[uint32, common.Hash](codeHashesStorePath, common.HashSerializer{}, PageSize, hashtree.GetNoHashFactory(), PoolSize)
@@ -293,7 +293,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	accountStorePath := storePath + string(filepath.Separator) + "accounts"
-	if err = os.Mkdir(accountStorePath, 0700); err != nil {
+	if err = os.MkdirAll(accountStorePath, 0700); err != nil {
 		return nil, err
 	}
 	accountsStore, err := pagedfile.NewStore[uint32, common.AccountState](accountStorePath, common.AccountStateSerializer{}, PageSize, htfile.CreateHashTreeFactory(accountStorePath, HashTreeFactor), PoolSize)
@@ -301,7 +301,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	noncesStorePath := storePath + string(filepath.Separator) + "nonces"
-	if err = os.Mkdir(noncesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(noncesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	noncesStore, err := pagedfile.NewStore[uint32, common.Nonce](noncesStorePath, common.NonceSerializer{}, PageSize, htfile.CreateHashTreeFactory(noncesStorePath, HashTreeFactor), PoolSize)
@@ -309,7 +309,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	balancesStorePath := storePath + string(filepath.Separator) + "balances"
-	if err = os.Mkdir(balancesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(balancesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	balancesStore, err := pagedfile.NewStore[uint32, common.Balance](balancesStorePath, common.BalanceSerializer{}, PageSize, htfile.CreateHashTreeFactory(balancesStorePath, HashTreeFactor), PoolSize)
@@ -317,7 +317,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	valuesStorePath := storePath + string(filepath.Separator) + "values"
-	if err = os.Mkdir(valuesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(valuesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	valuesStore, err := pagedfile.NewStore[uint32, common.Value](valuesStorePath, common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(valuesStorePath, HashTreeFactor), PoolSize)
@@ -326,7 +326,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	codesPath := storePath + string(filepath.Separator) + "codes"
-	if err = os.Mkdir(codesPath, 0700); err != nil {
+	if err = os.MkdirAll(codesPath, 0700); err != nil {
 		return nil, err
 	}
 	codesDepot, err := fileDepot.NewDepot[uint32](codesPath, common.Identifier32Serializer{}, htfile.CreateHashTreeFactory(codesPath, HashTreeFactor), CodeHashGroupSize)
@@ -334,7 +334,7 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	codeHashesStorePath := storePath + string(filepath.Separator) + "codeHashes"
-	if err = os.Mkdir(codeHashesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(codeHashesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	codeHashesStore, err := pagedfile.NewStore[uint32, common.Hash](codeHashesStorePath, common.HashSerializer{}, PageSize, hashtree.GetNoHashFactory(), PoolSize)
@@ -372,7 +372,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	accountStorePath := storePath + string(filepath.Separator) + "accounts"
-	if err = os.Mkdir(accountStorePath, 0700); err != nil {
+	if err = os.MkdirAll(accountStorePath, 0700); err != nil {
 		return nil, err
 	}
 	accountsStore, err := pagedfile.NewStore[uint32, common.AccountState](accountStorePath, common.AccountStateSerializer{}, PageSize, htfile.CreateHashTreeFactory(accountStorePath, HashTreeFactor), PoolSize)
@@ -380,7 +380,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	noncesStorePath := storePath + string(filepath.Separator) + "nonces"
-	if err = os.Mkdir(noncesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(noncesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	noncesStore, err := pagedfile.NewStore[uint32, common.Nonce](noncesStorePath, common.NonceSerializer{}, PageSize, htfile.CreateHashTreeFactory(noncesStorePath, HashTreeFactor), PoolSize)
@@ -388,7 +388,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	balancesStorePath := storePath + string(filepath.Separator) + "balances"
-	if err = os.Mkdir(balancesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(balancesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	balancesStore, err := pagedfile.NewStore[uint32, common.Balance](balancesStorePath, common.BalanceSerializer{}, PageSize, htfile.CreateHashTreeFactory(balancesStorePath, HashTreeFactor), PoolSize)
@@ -397,7 +397,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	valuesStorePath := storePath + string(filepath.Separator) + "values"
-	if err = os.Mkdir(valuesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(valuesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	valuesStore, err := pagedfile.NewStore[uint32, common.Value](valuesStorePath, common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(valuesStorePath, HashTreeFactor), PoolSize)
@@ -406,7 +406,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	codesPath := storePath + string(filepath.Separator) + "codes"
-	if err = os.Mkdir(codesPath, 0700); err != nil {
+	if err = os.MkdirAll(codesPath, 0700); err != nil {
 		return nil, err
 	}
 	codesDepot, err := fileDepot.NewDepot[uint32](codesPath, common.Identifier32Serializer{}, htfile.CreateHashTreeFactory(codesPath, HashTreeFactor), CodeHashGroupSize)
@@ -414,7 +414,7 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	codeHashesStorePath := storePath + string(filepath.Separator) + "codeHashes"
-	if err = os.Mkdir(codeHashesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(codeHashesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	codeHashesStore, err := pagedfile.NewStore[uint32, common.Hash](codeHashesStorePath, common.HashSerializer{}, PageSize, hashtree.GetNoHashFactory(), PoolSize)
@@ -468,7 +468,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	accountStorePath := storePath + string(filepath.Separator) + "accounts"
-	if err = os.Mkdir(accountStorePath, 0700); err != nil {
+	if err = os.MkdirAll(accountStorePath, 0700); err != nil {
 		return nil, err
 	}
 	accountsStore, err := pagedfile.NewStore[uint32, common.AccountState](accountStorePath, common.AccountStateSerializer{}, PageSize, htfile.CreateHashTreeFactory(accountStorePath, HashTreeFactor), PoolSize)
@@ -476,7 +476,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	noncesStorePath := storePath + string(filepath.Separator) + "nonces"
-	if err = os.Mkdir(noncesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(noncesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	noncesStore, err := pagedfile.NewStore[uint32, common.Nonce](noncesStorePath, common.NonceSerializer{}, PageSize, htfile.CreateHashTreeFactory(noncesStorePath, HashTreeFactor), PoolSize)
@@ -484,7 +484,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	balancesStorePath := storePath + string(filepath.Separator) + "balances"
-	if err = os.Mkdir(balancesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(balancesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	balancesStore, err := pagedfile.NewStore[uint32, common.Balance](balancesStorePath, common.BalanceSerializer{}, PageSize, htfile.CreateHashTreeFactory(balancesStorePath, HashTreeFactor), PoolSize)
@@ -493,7 +493,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	valuesStorePath := storePath + string(filepath.Separator) + "values"
-	if err = os.Mkdir(valuesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(valuesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	valuesStore, err := pagedfile.NewStore[uint32, common.Value](valuesStorePath, common.ValueSerializer{}, PageSize, htfile.CreateHashTreeFactory(valuesStorePath, HashTreeFactor), PoolSize)
@@ -502,7 +502,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 	}
 
 	codesPath := storePath + string(filepath.Separator) + "codes"
-	if err = os.Mkdir(codesPath, 0700); err != nil {
+	if err = os.MkdirAll(codesPath, 0700); err != nil {
 		return nil, err
 	}
 	codesDepot, err := fileDepot.NewDepot[uint32](codesPath, common.Identifier32Serializer{}, htfile.CreateHashTreeFactory(codesPath, HashTreeFactor), CodeHashGroupSize)
@@ -510,7 +510,7 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 		return nil, err
 	}
 	codeHashesStorePath := storePath + string(filepath.Separator) + "codeHashes"
-	if err = os.Mkdir(codeHashesStorePath, 0700); err != nil {
+	if err = os.MkdirAll(codeHashesStorePath, 0700); err != nil {
 		return nil, err
 	}
 	codeHashesStore, err := pagedfile.NewStore[uint32, common.Hash](codeHashesStorePath, common.HashSerializer{}, PageSize, hashtree.GetNoHashFactory(), PoolSize)
@@ -738,12 +738,12 @@ func NewGoTransactCachedLeveLIndexAndStoreState(path string) (State, error) {
 // createSubDirs creates two subdirectories of the given for the Store and the Index
 func createSubDirs(rootPath string) (indexPath, storePath string, err error) {
 	indexPath = rootPath + string(filepath.Separator) + "index"
-	if err = os.Mkdir(indexPath, 0700); err != nil {
+	if err = os.MkdirAll(indexPath, 0700); err != nil {
 		return
 	}
 
 	storePath = rootPath + string(filepath.Separator) + "store"
-	err = os.Mkdir(storePath, 0700)
+	err = os.MkdirAll(storePath, 0700)
 
 	return
 }


### PR DESCRIPTION
This PR creates 
* a test that verifies the State is persisted. 
* and  it adds stable hash for maps. 
 
The new hash computation is slower than the original one - about two times.  

`BenchmarkMapHashAllBytes-8                                      	138444558	         8.748 ns/op`
vs
`BenchmarkMapHashComputeEach32Byte-8                             	75398594	        16.07 ns/op`

Surprisingly the benchmark shows better performance for the new hash. Can it be that most of the  bytes of addresses/keys are zero in our benchmark and it is somehow optimised by CPU when doing multiplication/addition?

Before
```
BenchmarkInsert/Index_MemoryLinearHash_initialSize_1048576-32         	 1878120	       676.5 ns/op
BenchmarkInsert/Index_File_initialSize_1048576-32                     	 1764854	       740.1 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Sequential-32         	 3237631	       333.0 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Uniform-32            	 2785014	       450.5 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Exponential-32        	 3770527	       313.5 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Sequential-32                     	 3815151	       284.3 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Uniform-32                        	 3031462	       370.9 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Exponential-32                    	 3762001	       286.5 ns/op
```


After
```
BenchmarkInsert/Index_MemoryLinearHash_initialSize_1048576-32         	 2959026	       375.9 ns/op
BenchmarkInsert/Index_File_initialSize_1048576-32                     	 2551987	       592.7 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Sequential-32         	 7816128	       137.9 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Uniform-32            	 3528930	       323.6 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Exponential-32        	 4866277	       221.3 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Sequential-32                     	 6331116	       167.9 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Uniform-32                        	 3108802	       357.2 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Exponential-32                    	 4160307	       249.5 ns/op
```
