### PR TITLE
Reduce the initialization latency of page pools

### DIFF
--- a/cpp/backend/common/page.h
+++ b/cpp/backend/common/page.h
@@ -17,14 +17,14 @@ template <typename P>
 concept Page =
     // Pages must be aligned to a multiple of a file system page.
     alignof(P) >= kFileSystemPageSize &&
-    alignof(P) % kFileSystemPageSize == 0 && requires(const P a, P b) {
+    alignof(P) % kFileSystemPageSize == 0 &&
+    // To be used in page pools, pages must also be trivially default
+    // constructible and destructible.
+    std::is_trivially_default_constructible_v<
+        P>&& std::is_trivially_destructible_v<P>&& requires(const P a, P b) {
   // Pages must support immutable and mutable raw data access.
   { a.AsRawData() } -> std::same_as<std::span<const std::byte, sizeof(P)>>;
   { b.AsRawData() } -> std::same_as<std::span<std::byte, sizeof(P)>>;
-  // To be used in page pools, pages must also be default constructable and
-  // destructible.
-  std::is_default_constructible_v<P>;
-  std::is_destructible_v<P>;
 };
 
 // Computes the required page size based on a use case specific needed page

--- a/cpp/backend/index/file/hash_page.h
+++ b/cpp/backend/index/file/hash_page.h
@@ -55,9 +55,6 @@ class alignas(kFileSystemPageSize) HashPage {
       "A HashPage must be at least sizeof(Metadata) + sizeof(Entry) = 16 byte "
       "+ sizeof(Entry) to fit at least a single line in each page.");
 
-  // Creates a new, empty page.
-  HashPage() { Clear(); }
-
   // Resets the size and the next-page reference to zero.
   void Clear() {
     auto& metadata = GetMetadata();

--- a/cpp/backend/index/file/hash_page_test.cc
+++ b/cpp/backend/index/file/hash_page_test.cc
@@ -25,18 +25,21 @@ TEST(HashPageTest, SizeOfFitsPageConstraints) {
 
 using TestPage = HashPage<std::size_t, int, int, 64>;
 
-TEST(HashPageTest, NewPageIsEmpty) {
+TEST(HashPageTest, ClearedPageIsEmpty) {
   TestPage page;
+  page.Clear();
   EXPECT_EQ(0, page.Size());
 }
 
-TEST(HashPageTest, NewPageHasNoSuccessor) {
+TEST(HashPageTest, ClearedPageHasNoSuccessor) {
   TestPage page;
+  page.Clear();
   EXPECT_EQ(0, page.GetNext());
 }
 
 TEST(HashPageTest, InsertedElementsCanBeFound) {
   TestPage page;
+  page.Clear();
   EXPECT_THAT(page.Find(0, 1), IsNull());
   EXPECT_THAT(page.Find(2, 3), IsNull());
   EXPECT_THAT(page.Find(4, 5), IsNull());
@@ -59,6 +62,7 @@ TEST(HashPageTest, InsertedElementsCanBeFound) {
 
 TEST(HashPageTest, InsertFailsIfSizeLimitIsReached) {
   TestPage page;
+  page.Clear();
   const auto limit = TestPage::kNumEntries;
   for (std::size_t i = 0; i < limit; i++) {
     EXPECT_THAT(page.Insert(i, i, i), Pointee(FieldsAre(i, i, i)));


### PR DESCRIPTION
This PR ..
- requires pages to be trivially construct and destructible
- replaces the `std::vector<Page>` store in the page pool by a raw pointer, eliminating initialization overhead

By doing so, the creation time of a file-based state is reduced by 93%, speeding up unit testing significantly.
```
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
BM_OpenClose<FileBasedState>                   -0.9305         -0.9305    1853117704     128783894    1852735217     128775825
```
