### PR TITLE
Switch to stable hashing for C++ file index

### DIFF
--- a/cpp/backend/index/file/BUILD
+++ b/cpp/backend/index/file/BUILD
@@ -18,10 +18,44 @@ cc_test(
 )
 
 cc_library(
+    name = "stable_hash",
+    hdrs = ["stable_hash.h"],
+    deps = [
+        "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/numeric:int128",
+    ],
+)
+
+cc_test(
+    name = "stable_hash_test",
+    srcs = ["stable_hash_test.cc"],
+    deps = [
+        ":stable_hash", 
+        "//backend/common:page",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/hash",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "stable_hash_benchmark",
+    srcs = ["stable_hash_benchmark.cc"],
+    deps = [
+        ":stable_hash",
+        "//common:type",
+        "@com_google_absl//absl/hash",
+        "@com_github_google_benchmark//:benchmark_main",
+        "//third_party/gperftools:profiler",
+    ],
+)
+
+cc_library(
     name = "index",
     hdrs = ["index.h"],
     deps = [
         ":hash_page",
+        ":stable_hash",
         "//backend/common:file",
         "//backend/common:page_pool", 
         "//backend:structure",

--- a/cpp/backend/index/file/index.h
+++ b/cpp/backend/index/file/index.h
@@ -8,12 +8,12 @@
 #include <queue>
 #include <vector>
 
-#include "absl/hash/hash.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "backend/common/file.h"
 #include "backend/common/page_pool.h"
 #include "backend/index/file/hash_page.h"
+#include "backend/index/file/stable_hash.h"
 #include "backend/structure.h"
 #include "common/hash.h"
 #include "common/memory_usage.h"
@@ -188,7 +188,7 @@ class FileIndex {
   std::unique_ptr<std::filesystem::path> metadata_file_;
 
   // A hasher to compute hashes for keys.
-  absl::Hash<K> key_hasher_;
+  StableHash<K> key_hasher_;
 
   // The number of elements in this index.
   std::size_t size_ = 0;

--- a/cpp/backend/index/file/stable_hash.h
+++ b/cpp/backend/index/file/stable_hash.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <utility>
+
+#include "absl/numeric/int128.h"
+
+namespace carmen::backend::index {
+
+namespace internal {
+
+// Implements a stable hash that will not change over time. This can be used
+// for computing hashes of values required for indexing data objects in
+// persistent storage.
+//
+// The implementation is derived from the absl::Hash infrastructure.
+class StableHashState {
+ public:
+  // --------------------------------------------------------------------------
+  //                        hashing of individual types
+  // --------------------------------------------------------------------------
+
+  // Support hashing for integral types.
+  template <std::integral I>
+  static std::size_t hash(I value) {
+    return Mix(0, static_cast<uint64_t>(value));
+  }
+
+  // Support hashing for arrays of types.
+  template <typename A, typename B>
+  static std::size_t hash(const std::pair<A, B>& value) {
+    return combine(StableHashState(), value.first, value.second).state_;
+  }
+
+  // Support hashing for arrays of types.
+  template <typename T, std::size_t N>
+  static std::size_t hash(const std::array<T, N>& value) {
+    std::uint64_t res = 0;
+    for (const T& cur : value) {
+      res = Mix(res, hash(cur));
+    }
+    return res;
+  }
+
+  // The fall-back support for types implementing the Absl hashing interface.
+  template <typename T>
+  static std::size_t hash(const T& value) {
+    return AbslHashValue(internal::StableHashState(), value).state_;
+  }
+
+  // --------------------------------------------------------------------------
+  //                        combination of hashes
+  // --------------------------------------------------------------------------
+
+  static StableHashState combine(StableHashState state) { return state; }
+
+  template <typename T>
+  static StableHashState combine(StableHashState state, const T& value) {
+    state.state_ = Mix(state.state_, hash(value));
+    return state;
+  }
+
+  template <typename V, typename... Vs>
+  static StableHashState combine(StableHashState state, const V& value,
+                                 const Vs&... values) {
+    return combine(combine(state, value), values...);
+  }
+
+ private:
+  // A magic constant taken from asl::Hash used to produce value spread when
+  // hashing integers.
+  static constexpr std::uint64_t kMul = sizeof(std::size_t) == 4
+                                            ? std::uint64_t{0xcc9e2d51}
+                                            : std::uint64_t{0x9ddfea08eb382d69};
+
+  static std::uint64_t Mix(std::uint64_t a, std::uint64_t b) {
+    // Taken from absl's MixingHashState implementation.
+    // Though the 128-bit product on AArch64 needs two instructions, it is
+    // still a good balance between speed and hash quality.
+    using MultType =
+        std::conditional_t<sizeof(std::size_t) == 4, uint64_t, absl::uint128>;
+    // We do the addition in 64-bit space to make sure the 128-bit
+    // multiplication is fast. If we were to do it as MultType the compiler has
+    // to assume that the high word is non-zero and needs to perform 2
+    // multiplications instead of one.
+    MultType m = a + b;
+    m *= kMul;
+    return static_cast<uint64_t>(m ^ (m >> (sizeof(m) * 8 / 2)));
+  }
+
+  // The hash tracked by this class while being used through the Absl hash
+  // infrastructure.
+  std::uint64_t state_ = 0;
+};
+
+}  // namespace internal
+
+// A utility class implementing the hashing of type T. The provided hash is
+// stable, thus it will not change over time and can be used for hash based
+// persistent storage.
+template <typename T>
+struct StableHash {
+  std::size_t operator()(const T& value) const {
+    return internal::StableHashState::hash(value);
+  }
+};
+
+}  // namespace carmen::backend::index

--- a/cpp/backend/index/file/stable_hash_benchmark.cc
+++ b/cpp/backend/index/file/stable_hash_benchmark.cc
@@ -1,0 +1,41 @@
+#include "absl/hash/hash.h"
+#include "backend/index/file/stable_hash.h"
+#include "benchmark/benchmark.h"
+#include "common/type.h"
+
+namespace carmen::backend::index {
+namespace {
+
+// To run benchmarks, use the following command:
+//    bazel run -c opt //backend/index/file:stable_hash_benchmark
+
+// Evaluates the performance of hashing integers.
+template <template <typename T> class Hasher>
+void BM_IntegerHash(benchmark::State& state) {
+  Hasher<int> hasher;
+  int i = 0;
+  for (auto _ : state) {
+    auto hash = hasher(i++);
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+BENCHMARK(BM_IntegerHash<StableHash>);
+BENCHMARK(BM_IntegerHash<absl::Hash>);
+
+// Evaluates the performance of hashing Addresses.
+template <template <typename T> class Hasher>
+void BM_AddressHash(benchmark::State& state) {
+  Hasher<Address> hasher;
+  Address addr;
+  for (auto _ : state) {
+    auto hash = hasher(addr);
+    benchmark::DoNotOptimize(hash);
+  }
+}
+
+BENCHMARK(BM_AddressHash<StableHash>);
+BENCHMARK(BM_AddressHash<absl::Hash>);
+
+}  // namespace
+}  // namespace carmen::backend::index

--- a/cpp/backend/index/file/stable_hash_test.cc
+++ b/cpp/backend/index/file/stable_hash_test.cc
@@ -1,0 +1,60 @@
+#include "backend/index/file/stable_hash.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "backend/common/page.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace carmen::backend::index {
+namespace {
+
+TEST(StableHash, HashHasLimitedCollisionsForIntegers) {
+  // Check the number of collisions for the first N integers.
+  constexpr int N = 1000000;
+  StableHash<int> hash;
+  int collisions = 0;
+  absl::flat_hash_set<std::size_t> seen;
+  for (int i = 0; i < N; i++) {
+    if (!seen.insert(hash(i)).second) {
+      collisions++;
+    }
+  }
+  EXPECT_EQ(collisions, 0);  // < no collisions
+}
+
+TEST(StableHash, HashHasLimitedCollisionsForPairsOfIntegers) {
+  // Check the number of collisions for the integers in N^2.
+  constexpr int N = 1000;
+  StableHash<std::pair<int, int>> hash;
+  int collisions = 0;
+  absl::flat_hash_set<std::size_t> seen;
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      if (!seen.insert(hash({i, j})).second) {
+        collisions++;
+      }
+    }
+  }
+  EXPECT_EQ(collisions, 0);  // < no collisions
+}
+
+TEST(StableHash, HashHasLimitedCollisionsForArraysOfIntegers) {
+  // Check the number of collisions for the integers in N^3.
+  constexpr int N = 100;
+  StableHash<std::array<int, 3>> hash;
+  int collisions = 0;
+  absl::flat_hash_set<std::size_t> seen;
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < N; k++) {
+        if (!seen.insert(hash({i, j, k})).second) {
+          collisions++;
+        }
+      }
+    }
+  }
+  EXPECT_EQ(collisions, 0);  // < no collisions
+}
+
+}  // namespace
+}  // namespace carmen::backend::index


### PR DESCRIPTION
Stable hashing lacks some optimizations employed by absl::Hash, thus it is a bit slower for addresses and keys:
```
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_IntegerHash<StableHash>      0.652 ns        0.652 ns    840062585
BM_IntegerHash<absl::Hash>      0.600 ns        0.600 ns   1000000000
BM_AddressHash<StableHash>       24.7 ns         24.7 ns     27250279
BM_AddressHash<absl::Hash>       5.14 ns         5.14 ns    125644236
```

If this turns out to be an issue, this can be improved later.


Overall, The change tends to slow down the file index by a few nanoseconds:
```
Benchmark                                                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Insert<FileIndexOnDisk>/1048576                                     +0.0450         +0.0449           755           789           755           789
BM_Insert<CachedFileIndexOnDisk>/1048576                               +0.0935         +0.0936          1048          1146          1048          1146
BM_SequentialRead<FileIndexOnDisk>/1048576                             +0.0805         +0.0805           383           414           383           414
BM_SequentialRead<CachedFileIndexOnDisk>/1048576                       +0.0259         +0.0260           161           165           161           165
BM_UniformRandomRead<FileIndexOnDisk>/1048576                          +0.1198         +0.1197           380           426           380           425
BM_UniformRandomRead<CachedFileIndexOnDisk>/1048576                    -0.0030         -0.0031           326           325           326           325
BM_ExponentialRandomRead<FileIndexOnDisk>/1048576                      +0.0964         +0.0965           469           514           469           514
BM_ExponentialRandomRead<CachedFileIndexOnDisk>/1048576                -0.1005         -0.1005           381           343           381           343
BM_Hash<FileIndexOnDisk>/1048576                                       +0.0178         +0.0180         38948         39643         38840         39539
BM_Hash<CachedFileIndexOnDisk>/1048576                                 -0.0098         -0.0091         39292         38906         39057         38700
OVERALL_GEOMEAN                                                        +0.0346         +0.0347             0             0             0             0
```