### PR TITLE
Kjezek/optimise file index get or add method

### DIFF
--- a/go/backend/index/file/file.go
+++ b/go/backend/index/file/file.go
@@ -106,15 +106,11 @@ func NewParamIndex[K comparable, I common.Identifier](
 
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *Index[K, I]) GetOrAdd(key K) (val I, err error) {
-	val, exists, err := m.table.Get(key)
+	val, exists, err := m.table.GetOrAdd(key, m.maxIndex)
 	if err != nil {
 		return
 	}
 	if !exists {
-		if err = m.table.Put(key, m.maxIndex); err != nil {
-			return val, err
-		}
-
 		val = m.maxIndex
 		m.maxIndex += 1 // increment to next index
 		m.hashIndex.AddKey(key)

--- a/go/backend/index/memory/linearhash.go
+++ b/go/backend/index/memory/linearhash.go
@@ -42,12 +42,13 @@ func NewLinearHashParamsIndex[K comparable, I common.Identifier](numBuckets int,
 
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *LinearHashIndex[K, I]) GetOrAdd(key K) (val I, err error) {
-	val, exists, _ := m.table.Get(key)
+	val, exists, err := m.table.GetOrAdd(key, m.maxIndex)
+	if err != nil {
+		return
+	}
 	if !exists {
-		_ = m.table.Put(key, m.maxIndex)
 		val = m.maxIndex
 		m.maxIndex += 1 // increment to next index
-
 		m.hashIndex.AddKey(key)
 	}
 	return

--- a/go/backend/pagepool/page.go
+++ b/go/backend/pagepool/page.go
@@ -81,6 +81,7 @@ func (c *Page[K, V]) get(index int) V {
 // items occupying this position and following items are shifted one position
 // towards the end of the page
 func (c *Page[K, V]) insert(index int, key K, val V) {
+	c.isDirty = true
 	// found insert
 	if index < c.size {
 
@@ -101,8 +102,6 @@ func (c *Page[K, V]) insert(index int, key K, val V) {
 	c.list[c.size].Val = val
 
 	c.size += 1
-
-	c.isDirty = true
 }
 
 func (c *Page[K, V]) SetNext(next PageId) {
@@ -133,6 +132,7 @@ func (c *Page[K, V]) Remove(key K) (exists bool) {
 			c.list[j] = c.list[j+1]
 		}
 		c.size -= 1
+		c.isDirty = true
 
 		return true
 	}
@@ -152,6 +152,7 @@ func (c *Page[K, V]) removeAll(key K) (start, end int, exists bool) {
 			c.list[j] = c.list[j+window]
 		}
 		c.size -= window
+		c.isDirty = true
 	}
 
 	return

--- a/go/backend/pagepool/pagelist.go
+++ b/go/backend/pagepool/pagelist.go
@@ -24,6 +24,7 @@ type opType int
 const (
 	put opType = iota
 	add
+	getOrAdd
 	remove
 	removeAll
 	unknown
@@ -77,6 +78,13 @@ func (m *PageList[K, V]) Get(key K) (val V, exists bool, err error) {
 	}
 	return
 }
+
+func (m *PageList[K, V]) GetOrAdd(key K, val V) (V, bool, error) {
+	return m.addOrPut(key, val, getOrAdd)
+}
+
+// Put associates a key to the list.
+// If the key is already present, the value is updated.
 func (m *PageList[K, V]) Put(key K, val V) error {
 	_, _, err := m.addOrPut(key, val, put)
 	return err
@@ -113,6 +121,11 @@ func (m *PageList[K, V]) addOrPut(key K, val V, op opType) (V, bool, error) {
 			// will be added at the end of this method
 			if position, exists = page.findValue(key, val); exists {
 				return val, true, nil
+			}
+		case getOrAdd:
+			// getOrAdd operation: when the key exists, its value is just returned
+			if position, exists = page.findItem(key); exists {
+				return page.get(position), true, nil
 			}
 		}
 

--- a/go/backend/pagepool/pagelist_test.go
+++ b/go/backend/pagepool/pagelist_test.go
@@ -9,6 +9,7 @@ var (
 	A = common.Address{0xAA}
 	B = common.Address{0xBB}
 	C = common.Address{0xCC}
+	D = common.Address{0xDD}
 )
 
 const (

--- a/go/common/interfaces.go
+++ b/go/common/interfaces.go
@@ -53,6 +53,11 @@ type ErrMap[K comparable, V any] interface {
 	// Get returns a value associated with the key
 	Get(key K) (val V, exists bool, err error)
 
+	// GetOrAdd either returns a value stored under input key, or it associates the input value
+	// when the key is not stored yet.
+	// It returns true if the key was present, or false otherwise.
+	GetOrAdd(key K, newVal V) (val V, exists bool, err error)
+
 	// Put associates a new value to the key.
 	Put(key K, val V) error
 

--- a/go/common/linearhash.go
+++ b/go/common/linearhash.go
@@ -86,6 +86,19 @@ func (h *LinearHashMap[K, V]) Get(key K) (value V, exists bool, err error) {
 	return
 }
 
+func (h *LinearHashMap[K, V]) GetOrAdd(key K, val V) (value V, exists bool, err error) {
+	bucket := h.bucket(key, uint(len(h.list)))
+	value, exists, err = h.list[bucket].GetOrAdd(key, val)
+	if err != nil {
+		return
+	}
+	if !exists {
+		h.records += 1
+		return value, exists, h.checkSplit()
+	}
+	return
+}
+
 func (h *LinearHashMap[K, V]) GetAll(key K) ([]V, error) {
 	bucket := h.bucket(key, uint(len(h.list)))
 	return h.list[bucket].GetAll(key)


### PR DESCRIPTION
Note: this change has a low priority. 

This PR extends linear hash structures of method GetOrAdd(), which implements following semantics: 

```
	existingVal, exists = c.m.Get(key)
	if !exists {
		c.m.Put(key, val)
	}
        return existingVal, exists
```

It is used for faster insert of data into file/index. Originally, the linearhash had to be iterated first by calling Get() to locate an index for a key, if the key was not found, Put() was called to associate a new key. It needed to iterate the structures twice, computing hash of the key twice, accessing pagepool twice, etc. 

The results: 
* Insert to FileIndex - up to 25% better
* insert to Memory Index - above 30% faster
* read from indexes - not impacted (expected)

Benchmark before:
```
BenchmarkInsert/Index_MemoryLinearHash_initialSize_1048576-32         	 3161930	       370.4 ns/op
BenchmarkInsert/Index_File_initialSize_1048576-32                     	 2626447	       603.9 ns/op

BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Sequential-32         	 7695990	       143.1 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Uniform-32            	 3417888	       327.3 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Exponential-32        	 4920434	       227.1 ns/op

BenchmarkRead/Index_File_initialSize_1048576_dist_Sequential-32                     	 6137490	       174.6 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Uniform-32                        	 3034544	       357.6 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Exponential-32                    	 4587468	       264.4 ns/op
```

Benchmark after
```
BenchmarkInsert/Index_MemoryLinearHash_initialSize_1048576-32         	 4447962	       231.4 ns/op
BenchmarkInsert/Index_File_initialSize_1048576-32                     	 5021059	       417.7 ns/op

BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Sequential-32         	 7411572	       137.6 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Uniform-32            	 3304756	       324.6 ns/op
BenchmarkRead/Index_MemoryLinearHash_initialSize_1048576_dist_Exponential-32        	 4560258	       230.5 ns/op

BenchmarkRead/Index_File_initialSize_1048576_dist_Sequential-32                     	 6483582	       172.5 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Uniform-32                        	 3162417	       367.5 ns/op
BenchmarkRead/Index_File_initialSize_1048576_dist_Exponential-32                    	 4400833	       264.1 ns/op
```