### PR TITLE
Make C++ in-memory multimap optionally persistent.

### DIFF
--- a/cpp/backend/multimap/memory/BUILD
+++ b/cpp/backend/multimap/memory/BUILD
@@ -3,7 +3,9 @@ cc_library(
     name = "multimap",
     hdrs = ["multimap.h"],
     deps = [
+        "//backend/common:file",
         "//common:type",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/container:btree",
     ],
     visibility = ["//visibility:public"],
@@ -16,6 +18,7 @@ cc_test(
         ":multimap",
         "//backend/multimap",
         "//common:type",
+        "//common:file_util",
         "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cpp/backend/multimap/memory/multimap.h
+++ b/cpp/backend/multimap/memory/multimap.h
@@ -1,30 +1,65 @@
 #pragma once
 
 #include <concepts>
+#include <filesystem>
+#include <fstream>
+#include <utility>
 
 #include "absl/container/btree_set.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "backend/common/file.h"
 #include "backend/structure.h"
 #include "common/memory_usage.h"
+#include "common/status_util.h"
 #include "common/type.h"
 
 namespace carmen::backend::multimap {
 
 // Implements an in-memory version of a MultiMap using a btree based set.
 // To facilitate effecient search, only integral key types are supported.
-// As a in-memory implementation no internal state is persisted at any point
-// nor can persistent state be loaded from disk.
+// All index data for this implementation is loaded upon opening and resides
+// fully in memory.
 template <std::integral K, Trivial V>
 class InMemoryMultiMap {
  public:
   using key_type = K;
   using value_type = V;
 
-  // Opens a new, empty in-memory instance for this type, ignoring the
-  // filesystem content. This operation never fails.
-  static absl::StatusOr<InMemoryMultiMap> Open(Context&,
-                                               const std::filesystem::path&) {
-    return InMemoryMultiMap();
+  // Loads the multimap stored in the given directory.
+  static absl::StatusOr<InMemoryMultiMap> Open(
+      Context&, const std::filesystem::path& directory) {
+    auto file = directory / "data.dat";
+
+    // If there is no such file,
+    if (!std::filesystem::exists(file)) {
+      return InMemoryMultiMap({}, std::move(file));
+    }
+
+    // Load data from file.
+    std::fstream in(file, std::ios::binary | std::ios::in);
+    auto check_stream = [&]() -> absl::Status {
+      if (in.good()) return absl::OkStatus();
+      return absl::InternalError(absl::StrFormat(
+          "Failed to read data from file %s: %s", file, std::strerror(errno)));
+    };
+
+    uint64_t size;
+    in.read(reinterpret_cast<char*>(&size), 8);
+    RETURN_IF_ERROR(check_stream());
+
+    absl::btree_set<std::pair<K, V>> set;
+    for (uint64_t i = 0; i < size; i++) {
+      std::pair<K, V> entry;
+      in.read(reinterpret_cast<char*>(&entry), sizeof(entry));
+      RETURN_IF_ERROR(check_stream());
+      set.emplace(std::move(entry));
+    }
+
+    in.close();
+    RETURN_IF_ERROR(check_stream());
+
+    return InMemoryMultiMap(std::move(set), std::move(file));
   }
 
   // Inserts the given key/value pair and returns true if the element has not
@@ -63,13 +98,38 @@ class InMemoryMultiMap {
     return absl::OkStatus();
   }
 
-  // Does nothing.
-  absl::Status Flush() { return absl::OkStatus(); }
+  // Writes all data to the underlying file.
+  absl::Status Flush() {
+    // Start by creating the directory.
+    if (!CreateDirectory(file_.parent_path())) {
+      return absl::InternalError(absl::StrFormat(
+          "Unable to create parent directory: %s", file_.parent_path()));
+    }
 
-  // Does nothing.
-  absl::Status Close() { return absl::OkStatus(); }
+    std::fstream out(file_, std::ios::binary | std::ios::out);
+    auto check_stream = [&]() -> absl::Status {
+      if (out.good()) return absl::OkStatus();
+      return absl::InternalError(absl::StrFormat(
+          "Failed to write data to file %s: %s", file_, std::strerror(errno)));
+    };
 
-  // Computes the memory footprint of the
+    uint64_t num_elements = set_.size();
+    out.write(reinterpret_cast<const char*>(&num_elements), 8);
+    RETURN_IF_ERROR(check_stream());
+
+    for (const auto& cur : set_) {
+      out.write(reinterpret_cast<const char*>(&cur), sizeof(cur));
+      RETURN_IF_ERROR(check_stream());
+    }
+
+    out.close();
+    return check_stream();
+  }
+
+  // Flushes all data to the underlying file.
+  absl::Status Close() { return Flush(); }
+
+  // Estimates the memory footprint of this map.
   MemoryFootprint GetMemoryFootprint() const {
     MemoryFootprint res(*this);
     res.Add("data", SizeOf<std::pair<K, V>>() * set_.size());
@@ -85,6 +145,12 @@ class InMemoryMultiMap {
   }
 
  private:
+  // Internal constructor for the in-memory map accepting its data set and
+  // backup file.
+  InMemoryMultiMap(absl::btree_set<std::pair<K, V>> set,
+                   std::filesystem::path file)
+      : set_(std::move(set)), file_(std::move(file)) {}
+
   // A internal utility to get the range of the given key. The result is a pair
   // of iterators ranging from the begin (inclusive) to the end (exclusive) of
   // the corresponding key range.
@@ -95,6 +161,9 @@ class InMemoryMultiMap {
 
   // The actual storage of the key/value pairs, sorted in lexicographical order.
   absl::btree_set<std::pair<K, V>> set_;
+
+  // The file this index is backed up to.
+  std::filesystem::path file_;
 };
 
 }  // namespace carmen::backend::multimap


### PR DESCRIPTION
To be reviewed after #268

Adds a Load/Store implementation to the in-memory multimap to support persistent usage.

Related to #266