### PR TITLE
Clear cached values in StateDB upon account destruction

### DIFF
--- a/go/common/cache.go
+++ b/go/common/cache.go
@@ -1,8 +1,7 @@
 package common
 
-import "fmt"
-
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -30,6 +29,15 @@ func NewCache[K comparable, V any](capacity int) *Cache[K, V] {
 func (c *Cache[K, V]) Iterate(callback func(K, V) bool) {
 	for key, value := range c.cache {
 		if !callback(key, value.val) {
+			return // terminate iteration if false returned from the callback
+		}
+	}
+}
+
+// Iterate all cached entries by passing a mutable value reference to the provided callback.
+func (c *Cache[K, V]) IterateMutable(callback func(K, *V) bool) {
+	for key, value := range c.cache {
+		if !callback(key, &value.val) {
 			return // terminate iteration if false returned from the callback
 		}
 	}

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -339,7 +339,6 @@ func TestGetMemoryFootprint(t *testing.T) {
 			if !strings.Contains(str, "hashTree") {
 				t.Errorf("memory footprint string does not contain any hashTree")
 			}
-			fmt.Printf("Memory footprint:\n%s", str)
 		})
 	}
 }


### PR DESCRIPTION
This PR enforces the following operations:
- accounts that are destroyed during a block (and potentially reinitiated) are deleted at End-of-Block to clear the storage
- the storage-data cache in the StateDB is cleared for deleted accounts at the beginning of the End-of-Block operation
- the per-transaction cache of state values is updated when an account is destroyed such that cached values from a deleted account are zero; this operation supports rollbacks

This is part of #266 
