### PR TITLE
Add support for clean printing of StatusOr in test cases

### DIFF
--- a/cpp/common/BUILD
+++ b/cpp/common/BUILD
@@ -167,6 +167,7 @@ cc_library(
     deps=[
         ":status_util",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/functional:function_ref",

--- a/cpp/common/status_test_util_test.cc
+++ b/cpp/common/status_test_util_test.cc
@@ -11,6 +11,7 @@ using ::testing::IsOk;
 using ::testing::IsOkAndHolds;
 using ::testing::Not;
 using ::testing::Pair;
+using ::testing::PrintToString;
 using ::testing::StatusIs;
 using ::testing::StrEq;
 
@@ -60,6 +61,38 @@ TEST(StatusTestUtilTest, IsOkAndHoldsAcceptsMatcher) {
   EXPECT_THAT(example, IsOkAndHolds(std::make_pair(12, 'a')));
   EXPECT_THAT(example, IsOkAndHolds(Pair(12, 'a')));
   EXPECT_THAT(example, IsOkAndHolds(Pair(12, _)));
+}
+
+TEST(StatusPrinting, StatusCanBePrinted) {
+  absl::Status status = absl::OkStatus();
+  EXPECT_THAT(PrintToString(status), StrEq("OK"));
+  status = absl::InternalError("something went wrong");
+  EXPECT_THAT(PrintToString(status), StrEq("INTERNAL: something went wrong"));
+}
+
+TEST(StatusPrinting, StatusOrCanBePrinted) {
+  absl::StatusOr<int> status = 12;
+  EXPECT_THAT(PrintToString(status), StrEq("OK: 12"));
+  status = absl::InternalError("something went wrong");
+  EXPECT_THAT(PrintToString(status), StrEq("INTERNAL: something went wrong"));
+}
+
+TEST(StatusPrinting, StatusOrNonPrintableCanBePrinted) {
+  struct NonPrintable {
+    char x;
+  };
+  absl::StatusOr<NonPrintable> status = NonPrintable{12};
+  EXPECT_THAT(PrintToString(status), StrEq("OK: 1-byte object <0C>"));
+  status = absl::InternalError("something went wrong");
+  EXPECT_THAT(PrintToString(status), StrEq("INTERNAL: something went wrong"));
+}
+
+TEST(StatusPrinting, StatusOrRefCanBePrinted) {
+  int value = 12;
+  StatusOrRef<int> status = value;
+  EXPECT_THAT(PrintToString(status), StrEq("OK: 12"));
+  status = absl::InternalError("something went wrong");
+  EXPECT_THAT(PrintToString(status), StrEq("INTERNAL: something went wrong"));
 }
 
 }  // namespace


### PR DESCRIPTION
Improves the printing of `StatusOr` values in unit tests by printing them in a human-readable manner, as long as this is supported by the nested type.

For instance, a `StatusOr<int>(12)` is printed as follows:
Before "16-byte object <00-00 00-00 00-00 00-00 0C-00 00-00 FF-0F 00-00>"
After: "OK: 12"
