### PR TITLE
Implement EIP-158 State clearing

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -139,7 +139,7 @@ type stateDB struct {
 	// the storedDataCache upon account deletion. The maintained values are internal information only.
 	reincarnation map[common.Address]uint64
 
-	// A set of addresses, which possibly become empty in this transaction
+	// A list of addresses, which have possibly become empty in the transaction
 	emptyCandidates []common.Address
 }
 


### PR DESCRIPTION
As defined in [EIP-158](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-158.md) and justified in [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md):
> d. At the end of the transaction, any account touched by the execution of that transaction which is now empty SHALL instead become non-existent (i.e. deleted).