### PR TITLE
Add support for struct decomposition in status macros

### DIFF
--- a/cpp/common/BUILD
+++ b/cpp/common/BUILD
@@ -190,6 +190,7 @@ cc_library(
     name="status_util",
     hdrs=["status_util.h"],
     deps=[
+        ":macro_utils",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/status:status",
         "@com_google_absl//absl/status:statusor"

--- a/cpp/common/macro_utils.h
+++ b/cpp/common/macro_utils.h
@@ -61,3 +61,31 @@
   EVAL(MAP_LIST1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
 
 #endif
+
+// ----------------------------------------------------------------------------
+
+// The following is not related to the content above, but provides additional
+// common macro utilities.
+
+// The following set of macros will remove optional paranthesis from an
+// expression, by following one of the two expansion paths:
+//
+//  Without parenthesis:
+//    REMOVE_OPTIONAL_PARENTHESIS(expr)
+//      -> INTERNAL_REMOVE_PARENT(PEAR expr)
+//      -> INTERNAL_REMOVE_PARENT_(PEAR expr)
+//      -> INTERNAL_DISAPPEAR expr
+//      -> expr
+//
+//  With parenthesis:
+//    REMOVE_OPTIONAL_PARENTHESIS((expr))
+//      -> INTERNAL_REMOVE_PARENT(PEAR(expr))
+//      -> INTERNAL_REMOVE_PARENT_(PEAR expr)
+//      -> INTERNAL_DISAPPEAR expr
+//      -> expr
+
+#define REMOVE_OPTIONAL_PARENTHESIS(expr) INTERNAL_REMOVE_PARENT(PEAR expr)
+#define PEAR(...) PEAR __VA_ARGS__
+#define INTERNAL_REMOVE_PARENT(...) INTERNAL_REMOVE_PARENT_(__VA_ARGS__)
+#define INTERNAL_REMOVE_PARENT_(...) INTERNAL_DISAP##__VA_ARGS__
+#define INTERNAL_DISAPPEAR

--- a/cpp/common/status_test_util.h
+++ b/cpp/common/status_test_util.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "absl/strings/str_cat.h"
+#include "common/macro_utils.h"
 #include "common/status_util.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 // A few additional gtest expectations and assertions.
-#define EXPECT_OK(expr) EXPECT_TRUE((expr).ok())
-#define ASSERT_OK(expr) ASSERT_TRUE((expr).ok())
+#define EXPECT_OK(expr) EXPECT_THAT((expr), ::testing::IsOk())
+#define ASSERT_OK(expr) ASSERT_THAT((expr), ::testing::IsOk())
 
 // The implementation of ASSERT_OK_AND_ASSIGN below, more compact as if it would
 // be if it would be written inline.
@@ -35,8 +36,10 @@
 //
 // to declare and initialize a new variable x in the current scope. The variable
 // X will be of the value type stored inside the StatusOr type.
-#define ASSERT_OK_AND_ASSIGN(lhs, expr) \
-  INTERNAL_ASSERT_OK_AND_ASSIGN_IMPL(lhs, expr, CONCAT(_status_, __LINE__))
+#define ASSERT_OK_AND_ASSIGN(lhs, expr)                                 \
+  INTERNAL_ASSERT_OK_AND_ASSIGN_IMPL(REMOVE_OPTIONAL_PARENTHESIS(lhs),  \
+                                     REMOVE_OPTIONAL_PARENTHESIS(expr), \
+                                     CONCAT(_status_, __LINE__))
 
 namespace testing {
 

--- a/cpp/common/status_test_util_test.cc
+++ b/cpp/common/status_test_util_test.cc
@@ -56,6 +56,13 @@ TEST(StatusTestUtilTest, AssertOkAndAssingWorks) {
   EXPECT_EQ(x, 14);
 }
 
+TEST(StatusTestUtilTest, AssertOkAndAssingWorksWithDecomposition) {
+  ASSERT_OK_AND_ASSIGN((auto [a, b]),
+                       (absl::StatusOr<std::pair<int, int>>({12, 14})));
+  EXPECT_EQ(a, 12);
+  EXPECT_EQ(b, 14);
+}
+
 TEST(StatusTestUtilTest, IsOkAndHoldsAcceptsMatcher) {
   absl::StatusOr<std::pair<int, char>> example(std::make_pair(12, 'a'));
   EXPECT_THAT(example, IsOkAndHolds(std::make_pair(12, 'a')));

--- a/cpp/common/status_util.h
+++ b/cpp/common/status_util.h
@@ -5,6 +5,7 @@
 #include "absl/base/optimization.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "common/macro_utils.h"
 
 // This header provides a few utility macros for dealing with absl::Status and
 // absl::StatusOr values. The main intention is to make code using Status codes
@@ -85,5 +86,7 @@ using StatusOrRef = absl::StatusOr<std::reference_wrapper<T>>;
 //
 // Note, for this to work, the enclosing function must return a Status or a
 // StatusOr.
-#define ASSIGN_OR_RETURN(lhs, expr) \
-  INTERNAL_ASSIGN_OR_RETURN_IMPL(lhs, expr, CONCAT(_status_, __LINE__))
+#define ASSIGN_OR_RETURN(lhs, expr)                                 \
+  INTERNAL_ASSIGN_OR_RETURN_IMPL(REMOVE_OPTIONAL_PARENTHESIS(lhs),  \
+                                 REMOVE_OPTIONAL_PARENTHESIS(expr), \
+                                 CONCAT(_status_, __LINE__))

--- a/cpp/common/status_util_test.cc
+++ b/cpp/common/status_util_test.cc
@@ -89,4 +89,15 @@ TEST(StatusMacroTest, AssignOrReturnCanReturnPlainStatus) {
               StatusIs(absl::StatusCode::kInternal, _));
 }
 
+absl::StatusOr<std::pair<int, int>> CreatePair() { return std::pair{1, 2}; }
+
+absl::StatusOr<int> AssignOrReturnWithDecomposition() {
+  ASSIGN_OR_RETURN((auto [a, b]), CreatePair());
+  return a + b;
+}
+
+TEST(StatusMacroTest, AssignCanHandleDecomposition) {
+  EXPECT_THAT(AssignOrReturnWithDecomposition(), 3);
+}
+
 }  // namespace


### PR DESCRIPTION
Adds support for decomposing structs in `ASSIGN_OR_RETURN` macro usages.

For instance, if a function `Insert` returns a value of type `absl::StatusOr<std::pair<int,bool>>` where the first defines the new size and the second whether the insert caused a change. So far one would have had to write
```
ASSIGN_OR_RETURN(auto size_and_changed, Insert());
auto size = size_and_changed.first;
auto changed = size_and_changed.second;
```

With this change, it is possible to write
```
ASSIGN_OR_RETURN((auto [size,changed]), create());
```
to check the error and to perform the composition in one step. 

This should help reduce the code overhead of using `absl::Status` in functions with more complex return parameters.