### PR TITLE
Add PageManager utility acting like a simple memory manager for page files

### DIFF
--- a/cpp/backend/common/BUILD
+++ b/cpp/backend/common/BUILD
@@ -125,3 +125,24 @@ cc_binary(
         "//third_party/gperftools:profiler",
     ],
 )
+
+cc_library(
+    name = "page_manager",
+    hdrs = ["page_manager.h"],
+    deps = [
+        ":page",
+        ":page_id",
+        ":page_pool",
+    ],
+    visibility = ["//backend:__subpackages__"],
+)
+
+cc_test(
+    name = "page_manager_test",
+    srcs = ["page_manager_test.cc"],
+    deps = [
+        ":page_manager",
+        "//common:status_test_util",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/cpp/backend/common/page_manager.h
+++ b/cpp/backend/common/page_manager.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "absl/status/statusor.h"
+#include "backend/common/page.h"
+#include "backend/common/page_id.h"
+#include "backend/common/page_pool.h"
+#include "common/status_util.h"
+
+namespace carmen::backend {
+
+// A page manager is like a memory manager organizing the life cycle of pages in
+// a single file, accessed through a page pool. It allows to create (=allocate)
+// new pages, resolve PageIDs to Pages (=dereferencign), and the freeing and
+// reusing of pages.
+//
+// NOTE: this is still work in progress; missing features:
+//  - free lists, for releasing and re-using pages
+//  - support for serializing the page managers state
+//  - support for computing the managers memory footprint
+//  - pinning of pages
+//
+template <typename PagePool>
+class PageManager {
+ public:
+  // The type returned when allocating a new page, including the new page's id
+  // and a reference to the new page.
+  template <Page Page>
+  struct NewPage {
+    operator Page&() { return page; }
+    operator PageId() { return id; }
+    PageId id;
+    Page& page;
+  };
+
+  // Creates a new page and returns the new page's ID and a page reference.
+  template <Page Page>
+  absl::StatusOr<NewPage<Page>> New() {
+    PageId id = next_++;
+    return NewPage<Page>{id, pool_.template Get<Page>(id)};
+  }
+
+  // Resolves a page ID to a page reference. It is the task of the caller to
+  // ensure the consistent usage of page types.
+  template <Page Page>
+  StatusOrRef<Page> Get(PageId id) const {
+    return pool_.template Get<Page>(id);
+  }
+
+ private:
+  // The next page ID to be used for allocating a page.
+  PageId next_ = 0;
+
+  // The underlying page pool managing the actual file accesses.
+  mutable PagePool pool_;
+};
+
+}  // namespace carmen::backend

--- a/cpp/backend/common/page_manager_test.cc
+++ b/cpp/backend/common/page_manager_test.cc
@@ -1,0 +1,52 @@
+#include "backend/common/page_manager.h"
+
+#include "backend/common/file.h"
+#include "backend/common/page.h"
+#include "backend/common/page_id.h"
+#include "common/status_test_util.h"
+#include "gtest/gtest.h"
+
+namespace carmen::backend {
+namespace {
+
+using Page = RawPage<>;
+using TestPagePool = PagePool<InMemoryFile<kFileSystemPageSize>>;
+using TestPageManager = PageManager<TestPagePool>;
+
+TEST(PageManager, AllocatedPagesAreDistinct) {
+  TestPageManager manager;
+  ASSERT_OK_AND_ASSIGN((auto [id1, page1]), manager.New<Page>());
+  ASSERT_OK_AND_ASSIGN((auto [id2, page2]), manager.New<Page>());
+  EXPECT_NE(id1, id2);
+  EXPECT_NE(&page1, &page2);
+}
+
+TEST(PageManager, AllocationsCanReturnPageIdsDirectly) {
+  TestPageManager manager;
+  ASSERT_OK_AND_ASSIGN(PageId id1, manager.New<Page>());
+  ASSERT_OK_AND_ASSIGN(PageId id2, manager.New<Page>());
+  EXPECT_NE(id1, id2);
+}
+
+TEST(PageManager, AllocationsCanReturnPageReferencesDirectly) {
+  TestPageManager manager;
+  ASSERT_OK_AND_ASSIGN(Page & page1, manager.New<Page>());
+  ASSERT_OK_AND_ASSIGN(Page & page2, manager.New<Page>());
+  EXPECT_NE(&page1, &page2);
+}
+
+TEST(PageManager, PageIdsAreResolvedToCorrespondingPages) {
+  TestPageManager manager;
+  ASSERT_OK_AND_ASSIGN((auto [id1, page1]), manager.New<Page>());
+  ASSERT_OK_AND_ASSIGN((auto [id2, page2]), manager.New<Page>());
+
+  // This assumes that pages are not evicted during the test.
+  ASSERT_OK_AND_ASSIGN(Page & reload1, manager.Get<Page>(id1));
+  ASSERT_OK_AND_ASSIGN(Page & reload2, manager.Get<Page>(id2));
+
+  EXPECT_EQ(&page1, &reload1);
+  EXPECT_EQ(&page2, &reload2);
+}
+
+}  // namespace
+}  // namespace carmen::backend

--- a/cpp/common/status_test_util.h
+++ b/cpp/common/status_test_util.h
@@ -118,7 +118,7 @@ namespace internal {
 
 // A concept identifying types that can be written to an output stream.
 template <typename T>
-concept StreamableToOutputStream = requires(T a) {
+concept StreamableToOutputStream = requires(const T a) {
   { std::declval<std::ostream&>() << a } -> std::same_as<std::ostream&>;
 };
 
@@ -139,7 +139,7 @@ std::ostream& operator<<(std::ostream& out, const StatusOr<T>& status) {
   }
   // If there is no output format defined, use gunit's universal printing
   // format.
-  return out << testing::PrintToString(*status);
+  return out << testing::PrintToString<T>(*status);
 }
 
 }  // namespace absl


### PR DESCRIPTION
The introduced page manager will be used in various BTree flavors and maybe other structures to keep track of allocated and freed pages.