### PR TITLE
Fix formatting of all BUILD files using automated tooling

### DIFF
--- a/cpp/backend/BUILD
+++ b/cpp/backend/BUILD
@@ -1,12 +1,12 @@
 cc_library(
     name = "structure",
     hdrs = ["structure.h"],
+    visibility = ["//visibility:public"],
     deps = [
+        "//common:heterogenous_map",
         "//common:memory_usage",
         "//common:type",
-        "//common:heterogenous_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/cpp/backend/common/BUILD
+++ b/cpp/backend/common/BUILD
@@ -1,17 +1,17 @@
-
 cc_library(
     name = "page_id",
     hdrs = ["page_id.h"],
     visibility = ["//backend:__subpackages__"],
 )
+
 cc_library(
     name = "page",
     hdrs = ["page.h"],
-    deps = [
-        "//common:type",
-        "//common:hash",
-    ],
     visibility = ["//backend:__subpackages__"],
+    deps = [
+        "//common:hash",
+        "//common:type",
+    ],
 )
 
 cc_test(
@@ -30,13 +30,13 @@ cc_library(
 
 cc_library(
     name = "file",
-    hdrs = ["file.h"],
     srcs = ["file.cc"],
-    deps = [
-        ":page_id",
-        ":page",
-    ],
+    hdrs = ["file.h"],
     visibility = ["//backend:__subpackages__"],
+    deps = [
+        ":page",
+        ":page_id",
+    ],
 )
 
 cc_test(
@@ -51,24 +51,24 @@ cc_test(
 
 cc_binary(
     name = "file_benchmark",
+    testonly = True,
     srcs = ["file_benchmark.cc"],
     deps = [
         ":file",
         "//common:file_util",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )
 
 cc_library(
     name = "eviction_policy",
-    hdrs = ["eviction_policy.h"],
     srcs = ["eviction_policy.cc"],
+    hdrs = ["eviction_policy.h"],
     deps = [
         ":access_pattern",
         "@com_google_absl//absl/container:btree",
-    ]
+    ],
 )
 
 cc_test(
@@ -86,14 +86,15 @@ cc_binary(
     deps = [
         ":access_pattern",
         ":eviction_policy",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
 )
 
 cc_library(
     name = "page_pool",
     hdrs = ["page_pool.h"],
+    visibility = ["//backend:__subpackages__"],
     deps = [
         ":eviction_policy",
         ":file",
@@ -101,7 +102,6 @@ cc_library(
         "//common:memory_usage",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
-    visibility = ["//backend:__subpackages__"],
 )
 
 cc_test(
@@ -121,20 +121,20 @@ cc_binary(
         ":access_pattern",
         ":eviction_policy",
         ":page_pool",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
 )
 
 cc_library(
     name = "page_manager",
     hdrs = ["page_manager.h"],
+    visibility = ["//backend:__subpackages__"],
     deps = [
         ":page",
         ":page_id",
         ":page_pool",
     ],
-    visibility = ["//backend:__subpackages__"],
 )
 
 cc_test(

--- a/cpp/backend/common/cache/BUILD
+++ b/cpp/backend/common/cache/BUILD
@@ -1,30 +1,30 @@
 cc_library(
     name = "lru_cache",
     hdrs = ["lru_cache.h"],
+    visibility = ["//backend:__subpackages__"],
     deps = [
         "//common:memory_usage",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
-    visibility = ["//backend:__subpackages__"],
 )
 
 cc_test(
     name = "lru_cache_test",
     srcs = ["lru_cache_test.cc"],
     deps = [
-        ":lru_cache", 
+        ":lru_cache",
         "@com_google_googletest//:gtest_main",
     ],
 )
 
 cc_binary(
     name = "lru_cache_benchmark",
+    testonly = True,
     srcs = ["lru_cache_benchmark.cc"],
     deps = [
         ":lru_cache",
         "//common:benchmark",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )

--- a/cpp/backend/common/leveldb/BUILD
+++ b/cpp/backend/common/leveldb/BUILD
@@ -1,14 +1,14 @@
 cc_library(
     name = "leveldb",
-    hdrs = ["leveldb.h"],
     srcs = ["leveldb.cc"],
-    deps = [
-        "//common:status_util",
-        "//common:memory_usage",
-        "@com_github_google_leveldb//:leveldb",
-        "@com_google_absl//absl/status:statusor"
-    ],
+    hdrs = ["leveldb.h"],
     visibility = ["//backend:__subpackages__"],
+    deps = [
+        "//common:memory_usage",
+        "//common:status_util",
+        "@com_github_google_leveldb//:leveldb",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
 
 cc_test(
@@ -18,7 +18,7 @@ cc_test(
         ":leveldb",
         "//common:file_util",
         "//common:status_test_util",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/status:statusor"
     ],
 )

--- a/cpp/backend/depot/BUILD
+++ b/cpp/backend/depot/BUILD
@@ -1,37 +1,37 @@
 cc_library(
     name = "depot",
     hdrs = ["depot.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend:structure",
         "//common:type",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "depot_handler",
+    testonly = True,
     hdrs = ["depot_handler.h"],
     deps = [
         ":depot",
+        "//backend/depot/cache",
         "//backend/depot/memory:depot",
-        "//backend/depot/cache:cache",
-        "//common:file_util"
+        "//common:file_util",
     ],
-    testonly = True,
 )
 
 cc_library(
     name = "test_util",
+    testonly = True,
     hdrs = ["test_util.h"],
+    visibility = ["//backend/depot:__subpackages__"],
     deps = [
-        "//common:type",
         "//common:memory_usage",
+        "//common:type",
         "@com_google_googletest//:gtest",
     ],
-    visibility = ["//backend/depot:__subpackages__"],
-    testonly = True,
 )
 
 cc_test(
@@ -40,10 +40,10 @@ cc_test(
     deps = [
         ":depot",
         ":depot_handler",
-        "//backend/depot/cache:cache",
-        "//backend/depot/memory:depot",
-        "//backend/depot/leveldb:depot",
+        "//backend/depot/cache",
         "//backend/depot/file:depot",
+        "//backend/depot/leveldb:depot",
+        "//backend/depot/memory:depot",
         "//common:status_test_util",
         "//common:test_util",
         "@com_google_googletest//:gtest_main",
@@ -52,16 +52,16 @@ cc_test(
 
 cc_binary(
     name = "depot_benchmark",
+    testonly = True,
     srcs = ["depot_benchmark.cc"],
     deps = [
         ":depot_handler",
-        "//backend/depot/memory:depot",
+        "//backend/depot/cache",
         "//backend/depot/file:depot",
         "//backend/depot/leveldb:depot",
-        "//backend/depot/cache:cache",
+        "//backend/depot/memory:depot",
         "//common:benchmark",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )

--- a/cpp/backend/depot/cache/BUILD
+++ b/cpp/backend/depot/cache/BUILD
@@ -1,17 +1,17 @@
 cc_library(
     name = "cache",
     hdrs = ["cache.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend/common/cache:lru_cache",
         "//backend/depot",
-        "//common:type",
         "//common:memory_usage",
         "//common:status_util",
+        "//common:type",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -21,8 +21,8 @@ cc_test(
         ":cache",
         "//backend/depot:test_util",
         "//common:status_test_util",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/backend/depot/file/BUILD
+++ b/cpp/backend/depot/file/BUILD
@@ -1,18 +1,18 @@
 cc_library(
     name = "depot",
     hdrs = ["depot.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend/common:file",
         "//backend/store:hash_tree",
         "//common:hash",
-        "//common:type",
         "//common:status_util",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/status:status",
-        "@com_google_absl//absl/status:statusor",
+        "//common:type",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -21,9 +21,9 @@ cc_test(
     deps = [
         ":depot",
         "//backend/depot",
-        "//common:status_test_util",
         "//backend/depot/memory:depot",
         "//common:file_util",
+        "//common:status_test_util",
         "//common:type",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cpp/backend/depot/leveldb/BUILD
+++ b/cpp/backend/depot/leveldb/BUILD
@@ -1,17 +1,17 @@
 cc_library(
     name = "depot",
     hdrs = ["depot.h"],
+    visibility = ["//visibility:public"],
     deps = [
+        "//backend/common/leveldb",
         "//backend/store:hash_tree",
-        "//common:hash",
-        "//common:type",
         "//common:byte_util",
+        "//common:hash",
         "//common:status_util",
-        "//backend/common/leveldb:leveldb",
-        "@com_google_absl//absl/status:status",
+        "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -20,10 +20,9 @@ cc_test(
     deps = [
         ":depot",
         "//backend/depot",
-        "//common:status_test_util",
         "//common:file_util",
+        "//common:status_test_util",
         "//common:type",
         "@com_google_googletest//:gtest_main",
     ],
 )
-

--- a/cpp/backend/depot/memory/BUILD
+++ b/cpp/backend/depot/memory/BUILD
@@ -1,15 +1,15 @@
 cc_library(
     name = "depot",
     hdrs = ["depot.h"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//backend/store:hash_tree",
         "//backend:structure",
+        "//backend/store:hash_tree",
         "//common:hash",
         "//common:type",
-        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/cpp/backend/index/BUILD
+++ b/cpp/backend/index/BUILD
@@ -1,11 +1,11 @@
 cc_library(
     name = "index",
     hdrs = ["index.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend:structure",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -13,29 +13,29 @@ cc_test(
     srcs = ["index_test.cc"],
     deps = [
         "//backend/index/memory:index",
+        "//common:status_test_util",
         "//common:test_util",
         "//common:type",
-        "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],
 )
 
 cc_library(
     name = "test_util",
+    testonly = True,
     hdrs = ["test_util.h"],
+    visibility = ["//backend/index:__subpackages__"],
     deps = [
         ":index",
         "//backend:structure",
-        "//common:hash",
         "//backend/index:index_handler",
         "//backend/index/memory:index",
+        "//common:hash",
         "//common:status_test_util",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
         "@com_google_googletest//:gtest",
     ],
-    visibility = ["//backend/index:__subpackages__"],
-    testonly = True,
 )
 
 cc_test(
@@ -50,22 +50,23 @@ cc_test(
 
 cc_library(
     name = "index_handler",
+    testonly = True,
     hdrs = ["index_handler.h"],
+    visibility = ["//backend/index:__subpackages__"],
     deps = [
         ":index",
-        "//common:type",
-        "//backend/index/leveldb/single_db:index",
-        "//backend/index/leveldb/multi_db:index",
-        "//backend/index/cache:cache",
+        "//backend/index/cache",
         "//backend/index/file:index",
+        "//backend/index/leveldb/multi_db:index",
+        "//backend/index/leveldb/single_db:index",
         "//common:file_util",
+        "//common:type",
     ],
-    visibility = ["//backend/index:__subpackages__"],
-    testonly = True,
 )
 
 cc_binary(
     name = "index_benchmark",
+    testonly = True,
     srcs = ["index_benchmark.cc"],
     deps = [
         ":index_handler",
@@ -73,11 +74,10 @@ cc_binary(
         "//backend/index/cache",
         "//backend/index/file:index",
         "//backend/index/memory:index",
-        "//common:status_test_util",
         "//backend/index/memory:linear_hash_index",
         "//common:benchmark",
-        "@com_github_google_benchmark//:benchmark_main",
+        "//common:status_test_util",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )

--- a/cpp/backend/index/cache/BUILD
+++ b/cpp/backend/index/cache/BUILD
@@ -1,30 +1,30 @@
 cc_library(
     name = "cache",
     hdrs = ["cache.h"],
+    visibility = ["//visibility:public"],
     deps = [
+        "//backend:structure",
         "//backend/common/cache:lru_cache",
         "//backend/index",
-        "//backend:structure",
-        "//common:type",
         "//common:hash",
         "//common:memory_usage",
         "//common:status_util",
+        "//common:type",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "cache_test",
     srcs = ["cache_test.cc"],
     deps = [
-        ":cache", 
+        ":cache",
         "//backend/index:test_util",
         "//backend/index/memory:index",
         "//common:status_test_util",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/backend/index/file/BUILD
+++ b/cpp/backend/index/file/BUILD
@@ -11,7 +11,7 @@ cc_test(
     name = "hash_page_test",
     srcs = ["hash_page_test.cc"],
     deps = [
-        ":hash_page", 
+        ":hash_page",
         "//backend/common:page",
         "@com_google_googletest//:gtest_main",
     ],
@@ -30,7 +30,7 @@ cc_test(
     name = "stable_hash_test",
     srcs = ["stable_hash_test.cc"],
     deps = [
-        ":stable_hash", 
+        ":stable_hash",
         "//backend/common:page",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/hash",
@@ -44,36 +44,36 @@ cc_binary(
     deps = [
         ":stable_hash",
         "//common:type",
-        "@com_google_absl//absl/hash",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
+        "@com_google_absl//absl/hash",
     ],
 )
 
 cc_library(
     name = "index",
     hdrs = ["index.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":hash_page",
         ":stable_hash",
-        "//backend/common:file",
-        "//backend/common:page_pool", 
         "//backend:structure",
-        "//common:type",
+        "//backend/common:file",
+        "//backend/common:page_pool",
         "//common:hash",
-        "//common:status_util",
         "//common:memory_usage",
-        "@com_google_absl//absl/status:status",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "index_test",
     srcs = ["index_test.cc"],
     deps = [
-        ":index", 
+        ":index",
         "//backend/index:test_util",
         "//common:status_test_util",
         "@com_google_googletest//:gtest_main",

--- a/cpp/backend/index/leveldb/BUILD
+++ b/cpp/backend/index/leveldb/BUILD
@@ -1,28 +1,28 @@
 cc_library(
     name = "index",
     hdrs = ["index.h"],
-    deps = [
-        "//common:type",
-        "//common:hash",
-        "//backend/common/leveldb:leveldb",
-        "//backend:structure",
-        "//common:status_util",
-        "//common:memory_usage",
-        "@com_google_absl//absl/status:statusor"
-    ],
     visibility = ["//backend/index/leveldb:__subpackages__"],
+    deps = [
+        "//backend:structure",
+        "//backend/common/leveldb",
+        "//common:hash",
+        "//common:memory_usage",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
 
 cc_binary(
     name = "index_benchmark",
+    testonly = True,
     srcs = ["index_benchmark.cc"],
     deps = [
-        "//backend/index/leveldb/single_db:index",
         "//backend/index/leveldb/multi_db:index",
+        "//backend/index/leveldb/single_db:index",
         "//common:file_util",
         "//common:type",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )

--- a/cpp/backend/index/leveldb/multi_db/BUILD
+++ b/cpp/backend/index/leveldb/multi_db/BUILD
@@ -1,11 +1,11 @@
 cc_library(
     name = "index",
     hdrs = ["index.h"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//backend/common/leveldb:leveldb",
+        "//backend/common/leveldb",
         "//backend/index/leveldb:index",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -13,11 +13,11 @@ cc_test(
     srcs = ["index_test.cc"],
     deps = [
         ":index",
-        "//common:file_util",
         "//backend/index",
-        "//common:status_test_util",
         "//backend/index:test_util",
+        "//common:file_util",
+        "//common:status_test_util",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/status:statusor"
     ],
 )

--- a/cpp/backend/index/leveldb/single_db/BUILD
+++ b/cpp/backend/index/leveldb/single_db/BUILD
@@ -1,16 +1,16 @@
 cc_library(
     name = "index",
-    hdrs = ["index.h"],
     srcs = ["index.cc"],
-    deps = [
-        "//common:type",
-        "//common:hash",
-        "//backend/common/leveldb:leveldb",
-        "//backend/index/leveldb:index",
-        "//common:status_util",
-        "@com_google_absl//absl/status:statusor"
-    ],
+    hdrs = ["index.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//backend/common/leveldb",
+        "//backend/index/leveldb:index",
+        "//common:hash",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
 
 cc_test(
@@ -18,23 +18,23 @@ cc_test(
     srcs = ["index_test.cc"],
     deps = [
         ":index",
-        "//common:file_util",
         "//backend/index",
         "//backend/index:test_util",
+        "//common:file_util",
         "//common:status_test_util",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/status:statusor"
     ],
 )
 
 cc_binary(
     name = "index_benchmark",
+    testonly = True,
     srcs = ["index_benchmark.cc"],
     deps = [
         "//backend/index/leveldb/single_db:index",
         "//common:type",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )

--- a/cpp/backend/index/memory/BUILD
+++ b/cpp/backend/index/memory/BUILD
@@ -1,27 +1,27 @@
 cc_library(
     name = "index",
     hdrs = ["index.h"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//backend/index",
         "//backend:structure",
-        "//common:type",
+        "//backend/index",
         "//common:hash",
         "//common:memory_usage",
+        "//common:type",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "index_test",
     srcs = ["index_test.cc"],
     deps = [
-        ":index", 
+        ":index",
         "//backend/index",
-        "//common:status_test_util",
         "//backend/index:test_util",
+        "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -29,17 +29,17 @@ cc_test(
 cc_library(
     name = "linear_hash_index",
     hdrs = ["linear_hash_index.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":linear_hash_map",
         "//backend:structure",
-        "//common:type",
         "//common:hash",
         "//common:memory_usage",
+        "//common:type",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/cpp/backend/multimap/BUILD
+++ b/cpp/backend/multimap/BUILD
@@ -1,9 +1,9 @@
 cc_library(
     name = "multimap",
     hdrs = ["multimap.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend:structure",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/cpp/backend/multimap/memory/BUILD
+++ b/cpp/backend/multimap/memory/BUILD
@@ -1,14 +1,13 @@
-
 cc_library(
     name = "multimap",
     hdrs = ["multimap.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend/common:file",
         "//common:type",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/strings",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -17,9 +16,9 @@ cc_test(
     deps = [
         ":multimap",
         "//backend/multimap",
-        "//common:type",
         "//common:file_util",
         "//common:status_test_util",
+        "//common:type",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/backend/store/BUILD
+++ b/cpp/backend/store/BUILD
@@ -1,25 +1,25 @@
 cc_library(
     name = "store",
     hdrs = ["store.h"],
-    deps = [
-        "//backend/common:page_id",
-        "//backend:structure",
-        "//common:status_util",
-        "@com_google_absl//absl/status:status",
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//backend:structure",
+        "//backend/common:page_id",
+        "//common:status_util",
+        "@com_google_absl//absl/status",
+    ],
 )
 
 cc_library(
     name = "store_handler",
+    testonly = True,
     hdrs = ["store_handler.h"],
     deps = [
-        "//backend/store/memory:store",
         "//backend/store/file:store",
+        "//backend/store/memory:store",
         "//common:file_util",
-        "//common:type", 
+        "//common:type",
     ],
-    testonly = True,
 )
 
 cc_test(
@@ -27,49 +27,49 @@ cc_test(
     srcs = ["store_test.cc"],
     deps = [
         ":store_handler",
-        "//backend/store/memory:store",
-        "//backend/store/leveldb:store",
         "//backend/store/file:store",
+        "//backend/store/leveldb:store",
+        "//backend/store/memory:store",
+        "//common:status_test_util",
         "//common:test_util",
         "//common:type",
-        "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],
 )
 
 cc_binary(
     name = "store_benchmark",
+    testonly = True,
     srcs = ["store_benchmark.cc"],
     deps = [
         ":store_handler",
-        "//backend/store/memory:store",
         "//backend/store/file:store",
         "//backend/store/leveldb:store",
+        "//backend/store/memory:store",
         "//common:benchmark",
         "//common:status_test_util",
-        "@com_github_google_benchmark//:benchmark_main",
         "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )
 
 cc_library(
     name = "hash_tree",
-    hdrs = ["hash_tree.h"],
     srcs = ["hash_tree.cc"],
+    hdrs = ["hash_tree.h"],
+    visibility = ["//backend:__subpackages__"],
     deps = [
         "//backend/common:page",
         "//backend/common:page_id",
-        "//backend/common/leveldb:leveldb",
-        "//common:type",
-        "//common:hash",
-        "//common:status_util",
+        "//backend/common/leveldb",
         "//common:byte_util",
+        "//common:hash",
         "//common:memory_usage",
+        "//common:status_util",
+        "//common:type",
         "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/status:status",
+        "@com_google_absl//absl/status",
     ],
-    visibility = ["//backend:__subpackages__"],
 )
 
 cc_test(
@@ -77,10 +77,10 @@ cc_test(
     srcs = ["hash_tree_test.cc"],
     deps = [
         ":hash_tree",
-        "//common:type",
-        "//common:hash",
         "//common:file_util",
+        "//common:hash",
         "//common:status_test_util",
+        "//common:type",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/backend/store/file/BUILD
+++ b/cpp/backend/store/file/BUILD
@@ -1,19 +1,19 @@
 cc_library(
     name = "store",
     hdrs = ["store.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend:structure",
         "//backend/common:file",
         "//backend/common:page_pool",
         "//backend/store:hash_tree",
-        "//common:type",
         "//common:hash",
         "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
         "@com_google_absl//absl/strings:str_format",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -21,8 +21,8 @@ cc_test(
     srcs = ["store_test.cc"],
     deps = [
         ":store",
-        "//common:file_util",
         "//backend:structure",
+        "//common:file_util",
         "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],

--- a/cpp/backend/store/leveldb/BUILD
+++ b/cpp/backend/store/leveldb/BUILD
@@ -1,18 +1,18 @@
 cc_library(
     name = "store",
     hdrs = ["store.h"],
+    visibility = ["//visibility:public"],
     deps = [
+        "//backend/common/leveldb",
         "//backend/store",
         "//backend/store:hash_tree",
-        "//common:type",
-        "//common:hash",
-        "//backend/common/leveldb:leveldb",
-        "//common:status_util",
         "//common:byte_util",
-        "@com_google_absl//absl/status:status",
+        "//common:hash",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(
@@ -20,9 +20,9 @@ cc_test(
     srcs = ["store_test.cc"],
     deps = [
         ":store",
+        "//backend:structure",
         "//common:file_util",
         "//common:status_test_util",
-        "//backend:structure",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cpp/backend/store/memory/BUILD
+++ b/cpp/backend/store/memory/BUILD
@@ -1,16 +1,16 @@
 cc_library(
     name = "store",
     hdrs = ["store.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//backend/store",
         "//backend/store:hash_tree",
-        "//common:type",
         "//common:hash",
         "//common:memory_usage",
+        "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -5,50 +5,50 @@ cc_library(
         "//backend:structure",
         "//common:account_state",
         "//common:type",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/status:status",
-    ]
+    ],
 )
 
 cc_test(
     name = "state_test",
     srcs = ["state_test.cc"],
     deps = [
-        ":state",
         ":configurations",
-        "//common:status_test_util",
+        ":state",
         "//common:file_util",
+        "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],
 )
 
 cc_library(
     name = "configurations",
+    hdrs = ["configurations.h"],
     deps = [
         ":state",
-        "//backend/index/cache",
-        "//backend/index/file:index",
-        "//backend/index/memory:index",
-        "//backend/store/file:store",
-        "//backend/store/memory:store",
-        "//backend/store/leveldb:store",
-        "//backend/index/leveldb/multi_db:index",
-        "//backend/depot/memory:depot",
         "//backend/depot/file:depot",
         "//backend/depot/leveldb:depot",
+        "//backend/depot/memory:depot",
+        "//backend/index/cache",
+        "//backend/index/file:index",
+        "//backend/index/leveldb/multi_db:index",
+        "//backend/index/memory:index",
         "//backend/multimap/memory:multimap",
+        "//backend/store/file:store",
+        "//backend/store/leveldb:store",
+        "//backend/store/memory:store",
     ],
-    hdrs = ["configurations.h"],
 )
 
 cc_library(
     name = "c_state",
-    hdrs = ["c_state.h"],
     srcs = ["c_state.cc"],
+    hdrs = ["c_state.h"],
     deps = [
-        ":state",
         ":configurations",
-        "@com_google_absl//absl/status:status",
+        ":state",
+        "@com_google_absl//absl/status",
     ],
     alwayslink = True,
 )
@@ -67,6 +67,7 @@ cc_test(
 
 cc_binary(
     name = "state_benchmark",
+    testonly = True,
     srcs = ["state_benchmark.cc"],
     deps = [
         ":configurations",
@@ -76,20 +77,19 @@ cc_binary(
         "//third_party/gperftools:profiler",
         "@com_github_google_benchmark//:benchmark_main",
     ],
-    testonly = True,
 )
 
 cc_binary(
-  name = "libcarmen.so",
-  linkshared = True,
-  linkopts = select({
-    "@platforms//os:osx": [
-        # Needed to make resulting library moveable
-        "-install_name @rpath/libcarmen.so",
+    name = "libcarmen.so",
+    linkopts = select({
+        "@platforms//os:osx": [
+            # Needed to make resulting library moveable
+            "-install_name @rpath/libcarmen.so",
+        ],
+        "//conditions:default": [],
+    }),
+    linkshared = True,
+    deps = [
+        ":c_state",
     ],
-    "//conditions:default": [],
-  }),
-  deps = [
-     ":c_state",
-  ],
 )

--- a/cpp/third_party/crc32c/crc32c.BUILD
+++ b/cpp/third_party/crc32c/crc32c.BUILD
@@ -27,9 +27,9 @@ cc_library(
         "src/crc32c_internal.h",
         "src/crc32c_prefetch.h",
         "src/crc32c_read_le.h",
+        "src/crc32c_round_up.h",
         "src/crc32c_sse42.h",
         "src/crc32c_sse42_check.h",
-        "src/crc32c_round_up.h",
     ],
     includes = ["include"],
 )

--- a/cpp/third_party/ethash/ethash.BUILD
+++ b/cpp/third_party/ethash/ethash.BUILD
@@ -1,14 +1,13 @@
-
 cc_library(
     name = "keccak",
+    srcs = [
+        "lib/keccak/keccak.c",
+        "lib/support/attributes.h",
+    ],
     hdrs = [
         "include/ethash/hash_types.h",
         "include/ethash/keccak.h",
         "include/ethash/keccak.hpp",
-    ],
-    srcs = [
-        "lib/support/attributes.h",
-        "lib/keccak/keccak.c",
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/cpp/third_party/gperftools/BUILD
+++ b/cpp/third_party/gperftools/BUILD
@@ -2,13 +2,13 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 cmake(
     name = "profiler",
-    generate_args = [
-        "-Dgperftools_build_benchmark=OFF",
-    ],
     build_args = [
         "--verbose",
         "--",  # <- Pass remaining options to the native tool.
         "-j 8",
+    ],
+    generate_args = [
+        "-Dgperftools_build_benchmark=OFF",
     ],
     lib_source = "@gperftools//:all_srcs",
     out_shared_libs = select({

--- a/cpp/third_party/leveldb/leveldb.BUILD
+++ b/cpp/third_party/leveldb/leveldb.BUILD
@@ -30,7 +30,7 @@ cc_library(
             "util/testutil.cc",
             "benchmarks/**",
             "util/*windows*",
-            "db/leveldbutil.cc"
+            "db/leveldbutil.cc",
         ],
     ),
     hdrs = glob(
@@ -39,22 +39,25 @@ cc_library(
             "doc/**",
             "util/*windows*",
             "util/testutil.h",
-            "port/port.h"
+            "port/port.h",
         ],
     ) + [
         ":port_h",
         ":port_config_h",
     ],
-    includes = ["include", "."],
+    copts = ["-Wno-unused-parameter"],
     defines = [
         "LEVELDB_PLATFORM_POSIX=1",
         "LEVELDB_IS_BIG_ENDIAN=0",
-        "NDEBUG"
+        "NDEBUG",
     ],
+    includes = [
+        ".",
+        "include",
+    ],
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_crc32c//:crc32c",
         "@com_github_google_snappy//:snappy",
     ],
-    copts = ["-Wno-unused-parameter"],
-    visibility = ["//visibility:public"],
 )

--- a/cpp/third_party/snappy/snappy.BUILD
+++ b/cpp/third_party/snappy/snappy.BUILD
@@ -30,12 +30,12 @@ cc_library(
             "snappy_benchmark.cc",
             "snappy_test_data.cc",
             "snappy_test_tool.cc",
-            "snappy_uncompress_fuzzer.cc"
+            "snappy_uncompress_fuzzer.cc",
         ],
     ),
     hdrs = glob(
         ["**/*.h"],
-	    exclude = ["snappy-test.h"],
+        exclude = ["snappy-test.h"],
     ) + [
         ":config_h",
         ":snappy_stubs_public_h",


### PR DESCRIPTION
This PR applied the automated formatting rules on all BUILD files.