### PR TITLE
Kjezek/make page store generic

### DIFF
--- a/go/backend/index/file/linearhashmap.go
+++ b/go/backend/index/file/linearhashmap.go
@@ -15,7 +15,7 @@ import (
 // The capacity is verified on each insert and potentially the split is triggered.
 // It is inspired by: https://hackthology.com/linear-hashing.html#fn-5
 type LinearHashMap[K comparable, V comparable] struct {
-	pagePool *pagepool.PagePool[*IndexPage[K, V]]
+	pagePool *pagepool.PagePool[PageId, *IndexPage[K, V]]
 
 	size         uint // total number of keys in the whole map
 	pageCapacity int  //maximal number of elements per block
@@ -26,7 +26,7 @@ type LinearHashMap[K comparable, V comparable] struct {
 
 // NewLinearHashMap creates a new instance with the initial number of buckets and constant bucket size.
 // The number of buckets will grow as this table grows.
-func NewLinearHashMap[K comparable, V comparable](pageCapacity, numBuckets, size int, pagePool *pagepool.PagePool[*IndexPage[K, V]], hasher common.Hasher[K], comparator common.Comparator[K]) *LinearHashMap[K, V] {
+func NewLinearHashMap[K comparable, V comparable](pageCapacity, numBuckets, size int, pagePool *pagepool.PagePool[PageId, *IndexPage[K, V]], hasher common.Hasher[K], comparator common.Comparator[K]) *LinearHashMap[K, V] {
 	return &LinearHashMap[K, V]{
 		pagePool:       pagePool,
 		size:           uint(size),

--- a/go/backend/index/file/linearhashmap_test.go
+++ b/go/backend/index/file/linearhashmap_test.go
@@ -190,6 +190,6 @@ func TestLinearHashRemove(t *testing.T) {
 func initLinearHashMap() *LinearHashMap[common.Address, uint32] {
 	sizeBytes := byteSizePage[common.Address, uint32](maxItems, common.AddressSerializer{}, common.Identifier32Serializer{})
 	pageFactory := PageFactory[common.Address, uint32](sizeBytes, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
-	pagePool := pagepool.NewPagePool[*IndexPage[common.Address, uint32]](pagePoolSize, nil, pagepool.NewMemoryPageStore(), pageFactory)
+	pagePool := pagepool.NewPagePool[PageId, *IndexPage[common.Address, uint32]](pagePoolSize, pagepool.NewMemoryPageStore[PageId](NextPageIdGenerator()), pageFactory)
 	return NewLinearHashMap[common.Address, uint32](maxItems, NumBuckets, 0, pagePool, common.AddressHasher{}, common.AddressComparator{})
 }

--- a/go/backend/index/file/pageid.go
+++ b/go/backend/index/file/pageid.go
@@ -1,4 +1,4 @@
-package pagepool
+package file
 
 import "fmt"
 
@@ -43,4 +43,13 @@ type PageIdComparator struct{}
 
 func (c PageIdComparator) Compare(a, b PageId) int {
 	return a.Compare(b)
+}
+
+func NextPageIdGenerator() func() PageId {
+	var id int
+	return func() PageId {
+		id += 1
+		pageId := NewPageId(0, id)
+		return pageId
+	}
 }

--- a/go/backend/index/file/pagelist_test.go
+++ b/go/backend/index/file/pagelist_test.go
@@ -58,21 +58,21 @@ func TestPageListOverflow(t *testing.T) {
 		_ = p.Put(address, i+1)
 	}
 
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.sizeKeys(), maxItems)
 	}
 
 	// add overflow page
 	_ = p.Put(B, 199)
 
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.sizeKeys(), maxItems)
 	}
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); !page.hasNext || page.next == 0 {
-		t.Errorf("Wrong has next link: %d ", page.next)
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); !page.hasNext || page.next == 0 {
+		t.Errorf("Wrong has getNextPage link: %d ", page.next)
 	}
 	// since we have a fresh page pool, next page ID will be one
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 1)); page.sizeKeys() != 1 {
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 1)); page.sizeKeys() != 1 {
 		t.Errorf("Wrong page size: %d != %d", page.sizeKeys(), 1)
 	}
 
@@ -81,12 +81,12 @@ func TestPageListOverflow(t *testing.T) {
 		t.Errorf("Item not removed")
 	}
 
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.sizeKeys(), maxItems)
 	}
 	// link to next page must be removed
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.hasNext || page.next != 0 {
-		t.Errorf("Wrong has next link: %d ", page.next)
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); page.hasNext || page.next != 0 {
+		t.Errorf("Wrong has getNextPage link: %d ", page.next)
 	}
 
 	// remove yet one item
@@ -95,7 +95,7 @@ func TestPageListOverflow(t *testing.T) {
 		t.Errorf("Item not removed")
 	}
 
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems-1 {
+	if page, _ := p.pagePool.Get(NewPageId(randomBucket, 0)); page.sizeKeys() != maxItems-1 {
 		t.Errorf("Wrong page size: %d != %d", page.sizeKeys(), maxItems-1)
 	}
 }
@@ -103,6 +103,6 @@ func TestPageListOverflow(t *testing.T) {
 func initPageList() PageList[common.Address, uint32] {
 	sizeBytes := byteSizePage[common.Address, uint32](maxItems, common.AddressSerializer{}, common.Identifier32Serializer{})
 	pageFactory := PageFactory[common.Address, uint32](sizeBytes, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
-	pagePool := pagepool.NewPagePool[*IndexPage[common.Address, uint32]](pagePoolSize, nil, pagepool.NewMemoryPageStore(), pageFactory)
+	pagePool := pagepool.NewPagePool[PageId, *IndexPage[common.Address, uint32]](pagePoolSize, pagepool.NewMemoryPageStore[PageId](NextPageIdGenerator()), pageFactory)
 	return NewPageList[common.Address, uint32](33, maxItems, pagePool)
 }

--- a/go/backend/index/file/pagestorage.go
+++ b/go/backend/index/file/pagestorage.go
@@ -1,0 +1,114 @@
+package file
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/pagepool"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
+)
+
+// TwoFilesPageStorage receives requests to Load or Store pages identified by PageId.
+// The PageId contains two integer IDs and the pages are distributed into two files - primary and overflow.
+// It allows for distinguishing between primary pages, which have the overflow component of the ID set to zero
+// and overflow pages of a primary page.
+// Pages are fixed size and are stored in the files at positions corresponding to their IDs either to the primary
+// secondary files.
+// The TwoFilesPageStorage maintains a fixed size byte buffer used for reading
+// and storing pages not to allocate new memory every-time.
+type TwoFilesPageStorage struct {
+	path string // directory to store the files in
+
+	primaryFile  *pagepool.FilePageStorage // primary file contains first pages for the bucket, directly indexed by the bucket number
+	overflowFile *pagepool.FilePageStorage // overflow file contains next pages for the bucket, indexed by the page id computed by the page pool
+}
+
+func NewTwoFilesPageStorage(
+	path string,
+	pageSize int,
+) (storage *TwoFilesPageStorage, err error) {
+
+	primaryFile, err := pagepool.NewFilePageStorage(path+"/primaryPages.dat", pageSize)
+	if err != nil {
+		return
+	}
+
+	overflowFile, err := pagepool.NewFilePageStorage(path+"/overflowPages.dat", pageSize)
+	if err != nil {
+		return
+	}
+
+	storage = &TwoFilesPageStorage{
+		path:         path,
+		primaryFile:  primaryFile,
+		overflowFile: overflowFile,
+	}
+
+	return
+}
+
+// Load reads a page of the input ID from the persistent storage.
+func (c *TwoFilesPageStorage) Load(pageId PageId, page pagepool.Page) error {
+	// Recover either from primary or overflow buckets
+	if pageId.IsOverFlowPage() {
+		return c.overflowFile.Load(pageId.Overflow()-1, page)
+	} else {
+		return c.primaryFile.Load(pageId.Bucket(), page)
+	}
+}
+
+// Store persists the input page under input key.
+func (c *TwoFilesPageStorage) Store(pageId PageId, page pagepool.Page) (err error) {
+	// Recover either from primary or overflow buckets
+	if pageId.IsOverFlowPage() {
+		return c.overflowFile.Store(pageId.Overflow()-1, page)
+	} else {
+		return c.primaryFile.Store(pageId.Bucket(), page)
+	}
+}
+
+// Remove deletes the key from the map and returns whether an element was removed.
+func (c *TwoFilesPageStorage) Remove(pageId PageId) error {
+	if pageId.IsOverFlowPage() {
+		return c.overflowFile.Remove(pageId.Overflow() - 1)
+	} else {
+		return c.primaryFile.Remove(pageId.Bucket())
+	}
+}
+
+func (c *TwoFilesPageStorage) NextId() PageId {
+	return NewPageId(0, c.overflowFile.NextId()+1)
+}
+
+// Flush all changes to the disk
+func (c *TwoFilesPageStorage) Flush() (err error) {
+	// flush data file changes to disk
+	primFileErr := c.primaryFile.Flush()
+	overflowFileErr := c.overflowFile.Flush()
+
+	if primFileErr != nil || overflowFileErr != nil {
+		err = fmt.Errorf("flush error: Primary file: %s, Overflow file: %s", primFileErr, overflowFileErr)
+	}
+
+	return
+}
+
+// Close the store
+func (c *TwoFilesPageStorage) Close() (err error) {
+	flushErr := c.Flush()
+	primFileErr := c.primaryFile.Close()
+	overflowFileErr := c.overflowFile.Close()
+
+	if flushErr != nil || primFileErr != nil || overflowFileErr != nil {
+		err = fmt.Errorf("close error: Flush: %s,  Primary file: %s, Overflow file: %s", flushErr, primFileErr, overflowFileErr)
+	}
+
+	return
+}
+
+func (c *TwoFilesPageStorage) GetMemoryFootprint() *common.MemoryFootprint {
+	selfSize := unsafe.Sizeof(*c)
+	memoryFootprint := common.NewMemoryFootprint(selfSize)
+	memoryFootprint.AddChild("primaryFile", c.primaryFile.GetMemoryFootprint())
+	memoryFootprint.AddChild("overflowFile", c.overflowFile.GetMemoryFootprint())
+	return memoryFootprint
+}

--- a/go/backend/index/file/pagestorage_test.go
+++ b/go/backend/index/file/pagestorage_test.go
@@ -1,0 +1,231 @@
+package file
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/pagepool"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"testing"
+)
+
+func TestPageStorageTwoFilesImplements(t *testing.T) {
+	var inst TwoFilesPageStorage
+	var _ pagepool.PageStorage[PageId] = &inst
+	var _ common.FlushAndCloser = &inst
+}
+
+func TestPageStorageTwoFilesStoreLoad(t *testing.T) {
+	tempDir := t.TempDir()
+	s, err := NewTwoFilesPageStorage(tempDir, common.PageSize)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	loadPageA := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	idA := NewPageId(5, 0)
+	if err := s.Load(idA, loadPageA); loadPageA.sizeKeys() != 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+
+	_ = s.Store(idA, initPageA())
+
+	loadPageA = NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(idA, loadPageA); loadPageA.sizeKeys() == 0 || err != nil {
+		t.Errorf("Page should exist")
+	}
+
+	testPageContent(t, 1, 3, loadPageA)
+
+	if hasNext := loadPageA.hasNext; hasNext {
+		t.Errorf("Has getNextPage is wrong")
+	}
+	if next := loadPageA.next; next != 0 {
+		t.Errorf("Wront link to getNextPage: %v != %v", next, 0)
+	}
+
+	idB := NewPageId(0, 1)
+	_ = s.Store(idB, initPageB())
+
+	loadPageB := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(idB, loadPageB); loadPageB.sizeKeys() == 0 || err != nil {
+		t.Errorf("Page should exist")
+	}
+
+	testPageContent(t, 4, 1, loadPageB)
+
+	if hasNext := loadPageB.hasNext; !hasNext {
+		t.Errorf("Has getNextPage is wrong")
+	}
+	if next := loadPageB.next; next != 4 {
+		t.Errorf("Wront link to getNextPage: %v != %v", next, 4)
+	}
+
+	idC := NewPageId(5, 7)
+	_ = s.Store(idC, initPageC())
+
+	loadPageC := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(idC, loadPageC); loadPageC.sizeKeys() == 0 || err != nil {
+		t.Errorf("Page should exist")
+	}
+
+	testPageContent(t, 5, 2, loadPageC)
+
+	if lastId := s.NextId(); lastId.Overflow() != 8 {
+		t.Errorf("Last ID does not match: %d != %d", lastId, 8)
+	}
+}
+
+func TestPageStorageTwoFilesRemovePage(t *testing.T) {
+	tempDir := t.TempDir()
+	s, err := NewTwoFilesPageStorage(tempDir, common.PageSize)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	err = s.Store(NewPageId(2, 0), initPageA())
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	err = s.Store(NewPageId(2, 4), initPageA())
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	if lastId := s.NextId(); lastId.Overflow() != 5 {
+		t.Errorf("Last ID does not match: %d != %d", lastId.Overflow(), 5)
+	}
+
+	// remove both pages
+	err = s.Remove(NewPageId(2, 0))
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	err = s.Remove(NewPageId(2, 3))
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	// Last ID is the last removed one (three minus one)
+	if lastId := s.NextId(); lastId.Overflow() != 3 {
+		t.Errorf("Last ID does not match: %d != %d", lastId.Overflow(), 3)
+	}
+
+	// try to load removed pages
+	loadPageA := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(NewPageId(1, 0), loadPageA); loadPageA.sizeKeys() > 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+	if err := s.Load(NewPageId(2, 3), loadPageA); loadPageA.sizeKeys() > 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+}
+
+func TestPageStorageTwoFilesDataPersisted(t *testing.T) {
+	tempDir := t.TempDir()
+	s, err := NewTwoFilesPageStorage(tempDir, common.PageSize)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	loadPageA := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	idA := NewPageId(5, 0)
+	if err := s.Load(idA, loadPageA); loadPageA.sizeKeys() != 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+
+	_ = s.Store(idA, initPageA())
+
+	idB := NewPageId(5, 3)
+	_ = s.Store(idB, initPageA())
+
+	// create and remove a few items
+	_ = s.Store(NewPageId(4, 0), initPageA())
+	_ = s.Store(NewPageId(5, 0), initPageA())
+	_ = s.Store(NewPageId(5, 1), initPageA())
+	_ = s.Store(NewPageId(5, 2), initPageA())
+
+	_ = s.Remove(NewPageId(4, 0))
+	_ = s.Remove(NewPageId(5, 1))
+	_ = s.Remove(NewPageId(5, 2))
+
+	// reopen
+	err = s.Close()
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	s, err = NewTwoFilesPageStorage(tempDir, common.PageSize)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+
+	loadPageA = NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(idA, loadPageA); loadPageA.sizeKeys() == 0 || err != nil {
+		t.Errorf("Page should exist")
+	}
+
+	testPageContent(t, 1, 3, loadPageA)
+
+	loadPageB := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(idB, loadPageB); loadPageB.sizeKeys() == 0 || err != nil {
+		t.Errorf("Page should exist")
+	}
+
+	testPageContent(t, 1, 3, loadPageB)
+
+	// removed pages cannot exist
+	page := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(NewPageId(4, 0), page); page.sizeKeys() > 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+
+	page = NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(NewPageId(5, 1), page); page.sizeKeys() > 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+
+	page = NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	if err := s.Load(NewPageId(5, 2), page); page.sizeKeys() > 0 || err != nil {
+		t.Errorf("Page should not exist")
+	}
+
+}
+
+func testPageContent(t *testing.T, start, expectedSize int, page *IndexPage[common.Address, uint32]) {
+	size := page.sizeKeys()
+	if size != expectedSize {
+		t.Errorf("Page size does not match: %d != %d", size, expectedSize)
+	}
+
+	for i := start; i < start+size; i++ {
+		key := common.Address{byte(i)}
+		if item, exists := page.get(key); !exists || item != uint32(i) {
+			t.Errorf("Missing value: key %v -> %d != %d ", key, item, uint32(i))
+		}
+	}
+}
+
+func initPageA() *IndexPage[common.Address, uint32] {
+	page := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	page.put(common.Address{1}, 1)
+	page.put(common.Address{2}, 2)
+	page.put(common.Address{3}, 3)
+
+	return page
+}
+
+func initPageB() *IndexPage[common.Address, uint32] {
+	page := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	page.put(common.Address{4}, 4)
+
+	page.setNext(4)
+	return page
+}
+
+func initPageC() *IndexPage[common.Address, uint32] {
+	page := NewIndexPage[common.Address, uint32](common.PageSize, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
+	page.put(common.Address{5}, 5)
+	page.put(common.Address{6}, 6)
+
+	return page
+}

--- a/go/backend/pagepool/pagepool_test.go
+++ b/go/backend/pagepool/pagepool_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	pageA = PageId{0, 0}
-	pageB = PageId{1, 0}
-	pageC = PageId{2, 0}
-	pageD = PageId{3, 0}
+	pageA = 0
+	pageB = 1
+	pageC = 2
+	pageD = 3
 
 	data = []byte{0xAA}
 )
@@ -134,8 +134,16 @@ func TestPageClose(t *testing.T) {
 	}
 }
 
-func initPagePool() *PagePool[*RawPage] {
+func initPagePool() *PagePool[int, *RawPage] {
 	poolSize := 3
 	pageFactory := func() *RawPage { return NewRawPage(common.PageSize) }
-	return NewPagePool[*RawPage](poolSize, nil, NewMemoryPageStore(), pageFactory)
+	return NewPagePool[int, *RawPage](poolSize, NewMemoryPageStore[int](nextIdGenerator()), pageFactory)
+}
+
+func nextIdGenerator() func() int {
+	var id int
+	return func() int {
+		id += 1
+		return id
+	}
 }

--- a/go/backend/pagepool/pagestoragemem.go
+++ b/go/backend/pagepool/pagestoragemem.go
@@ -1,0 +1,56 @@
+package pagepool
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
+)
+
+// MemoryPageStore stores pages in-memory only, its use is mainly for testing.
+type MemoryPageStore[T comparable] struct {
+	table  map[T][]byte
+	nextId func() T
+}
+
+func NewMemoryPageStore[T comparable](nextId func() T) *MemoryPageStore[T] {
+	return &MemoryPageStore[T]{
+		table:  make(map[T][]byte),
+		nextId: nextId,
+	}
+}
+
+func (c *MemoryPageStore[T]) Remove(pageId T) error {
+	delete(c.table, pageId)
+	return nil
+}
+
+func (c *MemoryPageStore[T]) Store(pageId T, page Page) (err error) {
+	data := make([]byte, page.Size())
+	page.ToBytes(data)
+	c.table[pageId] = data
+	return nil
+}
+
+func (c *MemoryPageStore[T]) Load(pageId T, page Page) error {
+	storedPage, exists := c.table[pageId]
+	if exists {
+		page.FromBytes(storedPage)
+	} else {
+		page.Clear()
+	}
+	return nil
+}
+
+func (c *MemoryPageStore[T]) NextId() T {
+	return c.nextId()
+}
+
+func (c *MemoryPageStore[T]) GetMemoryFootprint() *common.MemoryFootprint {
+	selfSize := unsafe.Sizeof(*c)
+	memfootprint := common.NewMemoryFootprint(selfSize)
+	var size uintptr
+	for k, v := range c.table {
+		size += unsafe.Sizeof(k) + unsafe.Sizeof(v)
+	}
+	memfootprint.AddChild("pageStore", common.NewMemoryFootprint(size))
+	return memfootprint
+}


### PR DESCRIPTION
This PR yet more improves the design of PagePool. It generalises PageStorage so it can store any type of Page under any type of ID.

Two implementations are created:  
* `FilePageStorage` - which stores pages under consecutive `int` ID in one file
* `TwoFilesPageStorage` - which stores pages under `index/file/PageId` which maintains two `int` sequences and stores Pages either in a primary or overflow page. 

Furthermore the Storage maintains its own metadata - i.e. list of FreeIDs of deleted pages, the last ID

After this PR we should have fully re-usable PagePool and PageStorage
