### PR TITLE
save the number of records of linear hash in metadata file

### DIFF
--- a/go/backend/index/file/linearhashmap_test.go
+++ b/go/backend/index/file/linearhashmap_test.go
@@ -62,11 +62,11 @@ func TestLinearHashOverflow(t *testing.T) {
 	if h.GetBits() != common.IntLog2(NumBuckets) {
 		t.Errorf("Property is not correct %d", h.GetBits())
 	}
-	if h.records != BucketSize*NumBuckets {
-		t.Errorf("Property is not correct %d", h.records)
+	if h.size != BucketSize*NumBuckets {
+		t.Errorf("Property is not correct %d", h.size)
 	}
-	if len(h.list) != NumBuckets {
-		t.Errorf("Property is not correct %d", len(h.list))
+	if int(h.GetNumBuckets()) != NumBuckets {
+		t.Errorf("Property is not correct %d", h.GetNumBuckets())
 	}
 
 	// check values properly set
@@ -77,6 +77,8 @@ func TestLinearHashOverflow(t *testing.T) {
 		}
 	}
 
+	//h.PrintDump()
+
 	// this will overflow!
 	_ = h.Put(A, 9999)
 
@@ -84,20 +86,20 @@ func TestLinearHashOverflow(t *testing.T) {
 	if h.GetBits() != common.IntLog2(NumBuckets+1) {
 		t.Errorf("Property is not correct %d", h.GetBits())
 	}
-	if h.records != BucketSize*NumBuckets+1 {
-		t.Errorf("Property is not correct %d", h.records)
+	if h.size != BucketSize*NumBuckets+1 {
+		t.Errorf("Property is not correct %d", h.size)
 	}
-	if len(h.list) != NumBuckets+1 {
-		t.Errorf("Property is not correct %d", len(h.list))
+	if int(h.GetNumBuckets()) != NumBuckets+1 {
+		t.Errorf("Property is not correct %d", int(h.GetNumBuckets()))
 	}
 
-	//h.printDump()
+	//h.PrintDump()
 
 	// check values properly set
 	for i := 0; i < BucketSize*NumBuckets; i++ {
 		address := common.AddressFromNumber(i + 1)
 		if val, exists, _ := h.Get(address); !exists || val != uint32(i+1) {
-			t.Errorf("Value incorrect: %v -> %d  (hash: %x)", address, val, common.AddressHasher{}.Hash(&address))
+			t.Errorf("Value incorrect: %v -> %d != %d  (hash: %x)", address, val, uint32(i+1), common.AddressHasher{}.Hash(&address))
 		}
 	}
 
@@ -119,11 +121,11 @@ func TestLinearHashGetOrAddOverflow(t *testing.T) {
 	if h.GetBits() != common.IntLog2(NumBuckets) {
 		t.Errorf("Property is not correct %d", h.GetBits())
 	}
-	if h.records != BucketSize*NumBuckets {
-		t.Errorf("Property is not correct %d", h.records)
+	if h.size != BucketSize*NumBuckets {
+		t.Errorf("Property is not correct %d", h.size)
 	}
-	if len(h.list) != NumBuckets {
-		t.Errorf("Property is not correct %d", len(h.list))
+	if int(h.GetNumBuckets()) != NumBuckets {
+		t.Errorf("Property is not correct %d", h.GetNumBuckets())
 	}
 
 	if size := h.Size(); size != BucketSize*NumBuckets {
@@ -144,11 +146,11 @@ func TestLinearHashGetOrAddOverflow(t *testing.T) {
 	if h.GetBits() != common.IntLog2(NumBuckets+1) {
 		t.Errorf("Property is not correct %d", h.GetBits())
 	}
-	if h.records != BucketSize*NumBuckets+1 {
-		t.Errorf("Property is not correct %d", h.records)
+	if h.size != BucketSize*NumBuckets+1 {
+		t.Errorf("Property is not correct %d", h.size)
 	}
-	if len(h.list) != NumBuckets+1 {
-		t.Errorf("Property is not correct %d", len(h.list))
+	if int(h.GetNumBuckets()) != NumBuckets+1 {
+		t.Errorf("Property is not correct %d", h.GetNumBuckets())
 	}
 	if size := h.Size(); size != BucketSize*NumBuckets+1 {
 		t.Errorf("Invalid size: %d", size)
@@ -188,5 +190,5 @@ func TestLinearHashRemove(t *testing.T) {
 func initLinearHashMap() *LinearHashMap[common.Address, uint32] {
 	// two pages in the pool, two items each
 	pagePool := pagepool.NewPagePool[common.Address, uint32](pagePoolSize, maxItems, nil, pagepool.NewMemoryPageStore[common.Address, uint32](), common.AddressComparator{})
-	return NewLinearHashMap[common.Address, uint32](maxItems, NumBuckets, pagePool, common.AddressHasher{}, common.AddressComparator{})
+	return NewLinearHashMap[common.Address, uint32](maxItems, NumBuckets, 0, pagePool, common.AddressHasher{}, common.AddressComparator{})
 }

--- a/go/backend/index/file/pagelist_test.go
+++ b/go/backend/index/file/pagelist_test.go
@@ -15,16 +15,12 @@ func TestPageListIsMap(t *testing.T) {
 	var _ common.ErrMap[common.Address, uint32] = &instance
 }
 
-func TestPageListBulkInsertNonEmptyList(t *testing.T) {
+func TestPageListBulkInsert(t *testing.T) {
 	p := initPageList()
 
 	if _, exists, _ := p.Get(A); exists {
 		t.Errorf("Value is not correct")
 	}
-
-	// input some initial items
-	_ = p.Put(A, 3000)
-	_ = p.Put(B, 4000)
 
 	max := uint32(2 * maxItems) // two pages + 2 already existing items will make three pages
 	data := make([]common.MapEntry[common.Address, uint32], max)
@@ -35,59 +31,19 @@ func TestPageListBulkInsertNonEmptyList(t *testing.T) {
 
 	_ = p.bulkInsert(data)
 
-	expectedData := append(make([]common.MapEntry[common.Address, uint32], 0, 3*max), common.MapEntry[common.Address, uint32]{A, 3000})
-	expectedData = append(expectedData, common.MapEntry[common.Address, uint32]{B, 4000})
-	expectedData = append(expectedData, data...)
-
-	if size := p.Size(); size != len(expectedData) {
-		t.Errorf("Size does not match: %d != %d", size, len(expectedData))
-	}
-
-	if size := len(p.pageList); size != 3 {
-		t.Errorf("Number of pages does not match: %d != %d", size, max)
+	if size := p.Size(); size != len(data) {
+		t.Errorf("Size does not match: %d != %d", size, len(data))
 	}
 
 	// inserted data must much returned data
 	entries, _ := p.GetEntries()
 	for i, entry := range entries {
-		if entry.Key != expectedData[i].Key || entry.Val != expectedData[i].Val {
-			t.Errorf("Entries do not match: %v, %d != %v, %d", entry.Key, entry.Val, expectedData[i].Key, expectedData[i].Val)
+		if entry.Key != data[i].Key || entry.Val != data[i].Val {
+			t.Errorf("Entries do not match: %v, %d != %v, %d", entry.Key, entry.Val, data[i].Key, data[i].Val)
 		}
 	}
 
-	if size := len(entries); size != len(expectedData) {
-		t.Errorf("Size does not match: %d != %d", size, max)
-	}
-
-	// insert one more dataset to the tail with values after already inserted ones
-	nextMax := uint32(2 * maxItems) // two more pages will make five pages
-	data = make([]common.MapEntry[common.Address, uint32], nextMax)
-	for i := uint32(0); i < nextMax; i++ {
-		address := common.Address{byte(max + i + 1)}
-		data[i] = common.MapEntry[common.Address, uint32]{address, max + i + 1}
-	}
-
-	_ = p.bulkInsert(data)
-
-	expectedData = append(expectedData, data...)
-
-	if size := p.Size(); size != len(expectedData) {
-		t.Errorf("Size does not match: %d != %d", size, max)
-	}
-
-	if size := len(p.pageList); size != 5 {
-		t.Errorf("Number of pages does not match: %d != %d", size, max)
-	}
-
-	// inserted data must much returned data
-	entries, _ = p.GetEntries()
-	for i, entry := range entries {
-		if entry.Key != expectedData[i].Key || entry.Val != expectedData[i].Val {
-			t.Errorf("Entries do not match: %v, %d != %v, %d", entry.Key, entry.Val, expectedData[i].Key, expectedData[i].Val)
-		}
-	}
-
-	if size := len(entries); size != len(expectedData) {
+	if size := len(entries); size != len(data) {
 		t.Errorf("Size does not match: %d != %d", size, max)
 	}
 }
@@ -102,23 +58,21 @@ func TestPageListOverflow(t *testing.T) {
 		_ = p.Put(address, i+1)
 	}
 
-	if len(p.pageList) != 1 {
-		t.Errorf("PageList should have one page")
-	}
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, p.pageList[0])); page.Size() != maxItems {
+	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.Size() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.Size(), maxItems)
 	}
 
 	// add overflow page
 	_ = p.Put(B, 199)
 
-	if len(p.pageList) != 2 {
-		t.Errorf("PageList should have two pages")
-	}
 	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.Size() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.Size(), maxItems)
 	}
-	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, p.pageList[1])); page.Size() != 1 {
+	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); !page.HasNext() || page.NextPage().Overflow() == 0 {
+		t.Errorf("Wrong has next link: %d ", page.NextPage().Overflow())
+	}
+	// since we have a fresh page pool, next page ID will be one
+	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 1)); page.Size() != 1 {
 		t.Errorf("Wrong page size: %d != %d", page.Size(), 1)
 	}
 
@@ -127,12 +81,12 @@ func TestPageListOverflow(t *testing.T) {
 		t.Errorf("Item not removed")
 	}
 
-	// we should have back one full page
-	if len(p.pageList) != 1 {
-		t.Errorf("PageList should have one page")
-	}
 	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.Size() != maxItems {
 		t.Errorf("Wrong page size: %d != %d", page.Size(), maxItems)
+	}
+	// link to next page must be removed
+	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.HasNext() || page.NextPage().Overflow() != 0 {
+		t.Errorf("Wrong has next link: %d ", page.NextPage().Overflow())
 	}
 
 	// remove yet one item
@@ -141,16 +95,12 @@ func TestPageListOverflow(t *testing.T) {
 		t.Errorf("Item not removed")
 	}
 
-	// we should have back one full page
-	if len(p.pageList) != 1 {
-		t.Errorf("PageList should have one page")
-	}
 	if page, _ := p.pagePool.Get(pagepool.NewPageId(randomBucket, 0)); page.Size() != maxItems-1 {
 		t.Errorf("Wrong page size: %d != %d", page.Size(), maxItems-1)
 	}
 }
 
-func initPageList() *PageList[common.Address, uint32] {
+func initPageList() PageList[common.Address, uint32] {
 	// two pages in the pool, two items each
 	pagePool := pagepool.NewPagePool[common.Address, uint32](pagePoolSize, maxItems, nil, pagepool.NewMemoryPageStore[common.Address, uint32](), common.AddressComparator{})
 	return NewPageList[common.Address, uint32](33, maxItems, pagePool)

--- a/go/common/linearhashbase.go
+++ b/go/common/linearhashbase.go
@@ -75,6 +75,10 @@ func (h *LinearHashBase[K, V]) GetBits() uint {
 	return h.bits
 }
 
+func (h *LinearHashBase[K, V]) GetNumBuckets() uint {
+	return h.numBuckets
+}
+
 func IntLog2(x int) (y uint) {
 	return uint(math.Ceil(math.Log2(float64(x))))
 }

--- a/go/common/map_test.go
+++ b/go/common/map_test.go
@@ -170,19 +170,20 @@ func initMapFactories(t *testing.T) map[string]func() common.Map[common.Address,
 	singlePageListFactory := func() common.Map[common.Address, uint32] {
 		eachPageStore := pagepool.NewMemoryPageStore[common.Address, uint32]()
 		eachPagePool := pagepool.NewPagePool[common.Address, uint32](pagePoolSize, pageItems, nil, eachPageStore, common.AddressComparator{})
-		return &noErrMapWrapper[common.Address, uint32]{file.NewPageList[common.Address, uint32](123, pageItems, eachPagePool)}
+		pageList := file.NewPageList[common.Address, uint32](123, pageItems, eachPagePool)
+		return &noErrMapWrapper[common.Address, uint32]{&pageList}
 	}
 
 	sharedPageStore := pagepool.NewMemoryPageStore[common.Address, uint32]()
 	sharedPagePool := pagepool.NewPagePool[common.Address, uint32](pagePoolSize, pageItems, nil, sharedPageStore, common.AddressComparator{})
 	linearHashPagePoolFactory := func() common.Map[common.Address, uint32] {
-		return &noErrMapWrapper[common.Address, uint32]{file.NewLinearHashMap[common.Address, uint32](pageItems, numBuckets, sharedPagePool, common.AddressHasher{}, common.AddressComparator{})}
+		return &noErrMapWrapper[common.Address, uint32]{file.NewLinearHashMap[common.Address, uint32](pageItems, numBuckets, 0, sharedPagePool, common.AddressHasher{}, common.AddressComparator{})}
 	}
 
 	persistedLinearHashPagePoolFactory := func() common.Map[common.Address, uint32] {
 		persistedSharedPageStore, _ := pagepool.NewFilePageStorage[common.Address, uint32](t.TempDir(), pageSize, pageItems, 0, 0, common.AddressSerializer{}, common.Identifier32Serializer{}, common.AddressComparator{})
 		persistedSharedPagePool := pagepool.NewPagePool[common.Address, uint32](pagePoolSize, pageItems, nil, persistedSharedPageStore, common.AddressComparator{})
-		return &noErrMapWrapper[common.Address, uint32]{file.NewLinearHashMap[common.Address, uint32](pageItems, numBuckets, persistedSharedPagePool, common.AddressHasher{}, common.AddressComparator{})}
+		return &noErrMapWrapper[common.Address, uint32]{file.NewLinearHashMap[common.Address, uint32](pageItems, numBuckets, 0, persistedSharedPagePool, common.AddressHasher{}, common.AddressComparator{})}
 	}
 
 	factories := map[string]func() common.Map[common.Address, uint32]{


### PR DESCRIPTION
This PR 
* persists number of items, i.e. the size, of LinearHash for file/index
* removes the list of PageList from LinearHash and creates the instance on-demand