### PR TITLE
Add convenience functions to ByteValue

### DIFF
--- a/cpp/common/type.h
+++ b/cpp/common/type.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #include "hex_util.h"
@@ -28,6 +29,37 @@ class ByteValue {
   ByteValue(std::initializer_list<std::uint8_t> il) {
     std::copy(il.begin(), il.begin() + std::min(il.size(), data_.size()),
               std::begin(data_));
+  }
+
+  // Provide mutable access to the individual bytes.
+  std::uint8_t& operator[](std::size_t index) { return data_[index]; }
+
+  // Provide read-only access to the individual bytes.
+  std::uint8_t operator[](std::size_t index) const { return data_[index]; }
+
+  // Enables the implicit conversion into fixed-length spans of bytes.
+  operator std::span<const std::byte, N>() const {
+    return std::as_bytes(std::span(data_));
+  }
+
+  // Enables the implicit conversion into spans of bytes with dynamic extend.
+  operator std::span<const std::byte>() const {
+    return std::as_bytes(std::span(data_));
+  }
+
+  // Sets the bytes of this value to the provided data.
+  void SetBytes(std::span<const std::byte, N> data) {
+    std::memcpy(&data_[0], data.data(), data.size());
+  }
+
+  // Sets the bytes of this value to the data provided. Elements in the input
+  // exceeding the size of this ByteValue are ignored. If the input is too
+  // short, the rest of the bytes are filled with zero.
+  void SetBytes(std::span<const std::byte> data) {
+    std::memcpy(&data_[0], data.data(), std::min(data.size(), data_.size()));
+    if (data.size() < data_.size()) {
+      std::memset(&data_[0] + data.size(), 0, data_.size() - data.size());
+    }
   }
 
   // Overload of << operator to make class printable.

--- a/cpp/common/type_test.cc
+++ b/cpp/common/type_test.cc
@@ -42,6 +42,56 @@ TEST(ByteValueTest, CanBeUsedInFlatHashSet) {
   EXPECT_FALSE(set.contains(b));
 }
 
+TEST(ByteValueTest, ValuesCanBeAccessedUsingSubscripts) {
+  ByteValue<3> a{};
+  a[0] = 1;
+  a[1] = 2;
+  a[2] = 3;
+  const ByteValue<3> b = a;
+  EXPECT_EQ(b[0], 1);
+  EXPECT_EQ(b[1], 2);
+  EXPECT_EQ(b[2], 3);
+}
+
+TEST(ByteValueTest, CanBeConvertedToByteSpans) {
+  ByteValue<23> a{};
+  std::span<const std::byte> span_a = a;
+  std::span<const std::byte, 23> span_b = a;
+  EXPECT_EQ(span_a.size(), span_b.size());
+  EXPECT_EQ(span_a.data(), span_b.data());
+  EXPECT_EQ(span_a.data(), reinterpret_cast<const std::byte*>(&a[0]));
+}
+
+TEST(ByteValueTest, ValuesCanBeUpdatedUsingSetByte) {
+  ByteValue<3> a{};
+  std::span<const std::byte, 3> span_fixed = a;
+  std::span<const std::byte> span_variable = a;
+
+  a[0] = 1;
+  a[1] = 2;
+  a[2] = 3;
+  ByteValue<3> b;
+  b.SetBytes(span_fixed);
+  EXPECT_EQ(a, b);
+
+  a[1] = 4;
+  EXPECT_NE(a, b);
+  b.SetBytes(span_variable);
+  EXPECT_EQ(a, b);
+}
+
+TEST(ByteValueTest, ValuesCanBeUpdatedUsingDifferentLengthSpan) {
+  ByteValue<3> a{};
+
+  ByteValue<4> b{0x01, 0x02, 0x03, 0x04};
+  a.SetBytes(b);
+  EXPECT_EQ(a, (ByteValue<3>{0x01, 0x02, 0x03}));
+
+  ByteValue<2> c{0x04, 0x05};
+  a.SetBytes(c);
+  EXPECT_EQ(a, (ByteValue<3>{0x04, 0x05, 0x00}));
+}
+
 TEST(HashTest, SizeIsCompact) { EXPECT_EQ(kHashLength, sizeof(Hash)); }
 
 TEST(HashTest, TypeProperties) {


### PR DESCRIPTION
These additional functions simplify the handling of ByteValues and the interaction between ByteValues and byte spans.