### PR TITLE
Initial prototype for C++ Archive

### DIFF
--- a/cpp/backend/common/sqlite/BUILD
+++ b/cpp/backend/common/sqlite/BUILD
@@ -2,7 +2,7 @@ cc_library(
     name = "sqlite",
     srcs = ["sqlite.cc"],
     hdrs = ["sqlite.h"],
-    visibility = ["//backend:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//common:status_util",
         "@com_github_rockwotj_sqlite_bazel//:sqlite3",

--- a/cpp/common/type.h
+++ b/cpp/common/type.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <compare>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -75,13 +76,17 @@ class ByteValue {
                          const ByteValue<N>& containerB) = default;
 
   // Add comparison support for all ByteValues.
-  friend int operator<=>(const ByteValue<N>& containerA,
-                         const ByteValue<N>& containerB) {
+  friend std::strong_ordering operator<=>(const ByteValue<N>& containerA,
+                                          const ByteValue<N>& containerB) {
     // Ideally we would just let this generate using =default, but this fails on
     // MacOS since no <=> operator for arrays can be found. This seems to be a
     // missing feature, since according to the cppreference such an operator
     // should be defined.
-    return std::memcmp(containerA.data_.begin(), containerB.data_.begin(), N);
+    int res =
+        std::memcmp(containerA.data_.begin(), containerB.data_.begin(), N);
+    return res < 0    ? std::strong_ordering::less
+           : res == 0 ? std::strong_ordering::equal
+                      : std::strong_ordering::greater;
   }
 
   // Support the usage of ByteValues in hash based absl containers.

--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -95,3 +95,28 @@ cc_binary(
         ":c_state",
     ],
 )
+
+cc_library(
+    name = "archive",
+    srcs = ["archive.cc"],
+    hdrs = ["archive.h"],
+    deps = [
+        "//backend/common/sqlite",
+        "//common:type",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "archive_test",
+    srcs = ["archive_test.cc"],
+    deps = [
+        ":archive",
+        "//common:file_util",
+        "//common:status_test_util",
+        "//common:type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/cpp/state/archive.cc
+++ b/cpp/state/archive.cc
@@ -1,0 +1,185 @@
+#include "state/archive.h"
+
+#include "absl/container/btree_map.h"
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "backend/common/sqlite/sqlite.h"
+#include "common/status_util.h"
+#include "common/type.h"
+
+namespace carmen {
+
+using ::carmen::backend::Sqlite;
+using ::carmen::backend::SqlRow;
+using ::carmen::backend::SqlStatement;
+
+namespace internal {
+
+class Archive {
+ public:
+  // Opens an archive database stored in the given file.
+  static absl::StatusOr<std::unique_ptr<Archive>> Open(
+      std::filesystem::path file) {
+    ASSIGN_OR_RETURN(auto db, Sqlite::Open(file));
+
+    // TODO: check whether there is already some data in the proper format.
+
+    // Create tables.
+    RETURN_IF_ERROR(db.Run(kCreateValueTable));
+
+    // Prepare query statements.
+    ASSIGN_OR_RETURN(auto add_value, db.Prepare(kAddValueStmt));
+    ASSIGN_OR_RETURN(auto get_value, db.Prepare(kGetValueStmt));
+
+    return std::unique_ptr<Archive>(new Archive(
+        std::move(db), std::make_unique<SqlStatement>(std::move(add_value)),
+        std::make_unique<SqlStatement>(std::move(get_value))));
+  }
+
+  // Adds the block update for the given block.
+  absl::Status Add(BlockId block, const BlockUpdate& update) {
+    auto guard = absl::MutexLock(&add_value_lock_);
+    if (!add_value_stmt_) return absl::FailedPreconditionError("DB Closed");
+    RETURN_IF_ERROR(db_.Run("BEGIN TRANSACTION"));
+    for (auto& [key, value] : update.GetStorage()) {
+      RETURN_IF_ERROR(add_value_stmt_->Reset());
+      RETURN_IF_ERROR(add_value_stmt_->Bind(0, key.account));
+      RETURN_IF_ERROR(add_value_stmt_->Bind(1, key.slot));
+      RETURN_IF_ERROR(add_value_stmt_->Bind(2, static_cast<int>(block)));
+      RETURN_IF_ERROR(add_value_stmt_->Bind(3, value));
+      RETURN_IF_ERROR(add_value_stmt_->Run());
+    }
+    return db_.Run("END TRANSACTION");
+  }
+
+  // Fetches the value of a storage slot at the given block height. If the value
+  // was not defined at this block (or any time before) a zero value is
+  // returned.
+  absl::StatusOr<Value> GetStorage(BlockId block, const Address& account,
+                                   const Key& key) {
+    // TODO: once account states are tracked, make sure the account exists at
+    // that block.
+    auto guard = absl::MutexLock(&get_value_lock_);
+    if (!get_value_stmt_) return absl::FailedPreconditionError("DB Closed");
+    RETURN_IF_ERROR(get_value_stmt_->Reset());
+    RETURN_IF_ERROR(get_value_stmt_->Bind(0, account));
+    RETURN_IF_ERROR(get_value_stmt_->Bind(1, key));
+    RETURN_IF_ERROR(get_value_stmt_->Bind(2, static_cast<int>(block)));
+
+    // Here the first result is fetched. If there is no result, returning the
+    // zero value is what is expected since this is the default value of storage
+    // slots.
+    Value result;
+    RETURN_IF_ERROR(get_value_stmt_->Run(
+        [&](const SqlRow& row) { result.SetBytes(row.GetBytes(0)); }));
+    return result;
+  }
+
+  absl::Status Flush() {
+    // Nothing to do.
+    return absl::OkStatus();
+  }
+
+  // Closes this archive. After this, no more operations are allowed on it (not
+  // checked).
+  absl::Status Close() {
+    // Before closing the DB all prepared statements need to be finalized.
+    {
+      auto guard = absl::MutexLock(&add_value_lock_);
+      add_value_stmt_.reset();
+    }
+    {
+      auto guard = absl::MutexLock(&get_value_lock_);
+      get_value_stmt_.reset();
+    }
+    return db_.Close();
+  }
+
+ private:
+  // See reference: https://www.sqlite.org/lang.html
+
+  static constexpr const std::string_view kCreateValueTable =
+      "CREATE TABLE storage (account BLOB, slot BLOB, block INT, value BLOB, "
+      "PRIMARY KEY (account,slot,block))";
+
+  static constexpr const std::string_view kAddValueStmt =
+      "INSERT INTO storage(account,slot,block,value) VALUES (?,?,?,?)";
+
+  static constexpr const std::string_view kGetValueStmt =
+      "SELECT value FROM storage WHERE account = ? AND slot = ? AND block <= ? "
+      "ORDER BY block DESC LIMIT 1";
+
+  Archive(Sqlite db, std::unique_ptr<SqlStatement> add_value,
+          std::unique_ptr<SqlStatement> get_value)
+      : db_(std::move(db)),
+        add_value_stmt_(std::move(add_value)),
+        get_value_stmt_(std::move(get_value)) {}
+
+  // The DB connection.
+  Sqlite db_;
+
+  // TODO: introduce pool of statements to support concurrent reads and writes.
+
+  // The prepared statement for adding new values to the storage history.
+  std::unique_ptr<SqlStatement> add_value_stmt_ GUARDED_BY(add_value_lock_);
+  absl::Mutex add_value_lock_;
+
+  // The prepared statement for fetching values from the storage history.
+  std::unique_ptr<SqlStatement> get_value_stmt_ GUARDED_BY(get_value_lock_);
+  absl::Mutex get_value_lock_;
+};
+
+}  // namespace internal
+
+Archive::Archive(std::unique_ptr<internal::Archive> impl)
+    : impl_(std::move(impl)) {}
+
+Archive::Archive(Archive&&) = default;
+
+Archive::~Archive() { Close().IgnoreError(); }
+
+Archive& Archive::operator=(Archive&&) = default;
+
+absl::StatusOr<Archive> Archive::Open(std::filesystem::path directory) {
+  // TODO: create directory if it does not exist.
+  ASSIGN_OR_RETURN(auto impl,
+                   internal::Archive::Open(directory / "archive.sqlite"));
+  return Archive(std::move(impl));
+}
+
+absl::Status Archive::Add(BlockId block, const BlockUpdate& update) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->Add(block, update);
+}
+
+absl::StatusOr<Value> Archive::GetStorage(BlockId block, const Address& account,
+                                          const Key& key) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetStorage(block, account, key);
+}
+
+absl::Status Archive::Flush() {
+  if (!impl_) return absl::OkStatus();
+  return impl_->Flush();
+}
+
+absl::Status Archive::Close() {
+  if (!impl_) return absl::OkStatus();
+  auto result = impl_->Close();
+  impl_ = nullptr;
+  return result;
+}
+
+absl::Status Archive::CheckState() const {
+  if (impl_) return absl::OkStatus();
+  return absl::FailedPreconditionError("Archive not connected to DB.");
+}
+
+void BlockUpdate::Set(const Address& account, const Key& key,
+                      const Value& value) {
+  storage_[{account, key}] = value;
+}
+
+}  // namespace carmen

--- a/cpp/state/archive.h
+++ b/cpp/state/archive.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+
+#include "absl/container/btree_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "common/type.h"
+
+namespace carmen {
+
+// A type alias for block numbers.
+using BlockId = std::uint32_t;
+
+class BlockUpdate;
+
+namespace internal {
+class Archive;
+}
+
+// An archive retains a history of state mutations in a block chain on a
+// block-level granularity. The history is recorded by adding per-block updates.
+// All updates are append-only. History written once can no longer be altered.
+//
+// Archive Add(..) and GetXXX(..) operations are thread safe and may thus be run
+// in parallel.
+class Archive {
+ public:
+  // Opens the archive located in the given directory. May fail if the directory
+  // can not be accessed or the data format in the contained database does not
+  // match requirements.
+  static absl::StatusOr<Archive> Open(std::filesystem::path directory);
+
+  Archive(Archive&&);
+  ~Archive();
+  Archive& operator=(Archive&&);
+
+  // Adds the changes of the given block to this archive.
+  absl::Status Add(BlockId block, const BlockUpdate& update);
+
+  // Allows to fetch a historic value for a given slot.
+  absl::StatusOr<Value> GetStorage(BlockId block, const Address& account,
+                                   const Key& key);
+
+  // Flushes all temporary changes to disk.
+  absl::Status Flush();
+
+  // Closes the archive. This disconnects the archive from the underlying DB and
+  // no further member function calls will be successful.
+  absl::Status Close();
+
+ private:
+  Archive(std::unique_ptr<internal::Archive> archive);
+
+  absl::Status CheckState() const;
+
+  // The actual archive implementation is hidden using an opaque internal type.
+  std::unique_ptr<internal::Archive> impl_;
+};
+
+// A BlockUpdate summarizes all the updates produced by processing a block in
+// the chain. It is the unit of data used to update archives and to synchronize
+// data between archive instances.
+// TODO:
+//  - implement balance update support
+//  - implement nonce update support
+//  - implement account state update support
+//  - implement cryptographic hashing of updates
+//  - implement serialization and de-serialization of updates
+class BlockUpdate {
+ public:
+  // The identifier used for slots.
+  struct SlotKey {
+    Address account;
+    Key slot;
+    auto operator<=>(const SlotKey&) const = default;
+  };
+
+  // Adds the update of a storage slot to the changes to be covered by this
+  // update.
+  void Set(const Address& account, const Key& key, const Value& value);
+
+  // Provides read access to the sorted map of storage updates maintained.
+  const absl::btree_map<SlotKey, Value>& GetStorage() const {
+    return storage_;
+  };
+
+ private:
+  // Retains storage updates in sorted order. By sorting them, a normal form for
+  // updates is defined, aiding the verification of updates.
+  absl::btree_map<SlotKey, Value> storage_;
+};
+
+}  // namespace carmen

--- a/cpp/state/archive_test.cc
+++ b/cpp/state/archive_test.cc
@@ -1,0 +1,137 @@
+#include "state/archive.h"
+
+#include <type_traits>
+
+#include "common/file_util.h"
+#include "common/status_test_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace carmen {
+namespace {
+
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::StatusIs;
+
+TEST(Archive, TypeProperties) {
+  EXPECT_FALSE(std::is_default_constructible_v<Archive>);
+  EXPECT_FALSE(std::is_copy_constructible_v<Archive>);
+  EXPECT_TRUE(std::is_move_constructible_v<Archive>);
+  EXPECT_FALSE(std::is_copy_assignable_v<Archive>);
+  EXPECT_TRUE(std::is_move_assignable_v<Archive>);
+  EXPECT_TRUE(std::is_destructible_v<Archive>);
+}
+
+TEST(Archive, OpenAndClosingEmptyDbWorks) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
+  EXPECT_OK(archive.Close());
+}
+
+TEST(Archive, InAnEmptyArchiveStorageIsZero) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
+
+  const Value zero{};
+  for (BlockId block = 0; block < 5; block++) {
+    for (Address addr; addr[0] < 5; addr[0]++) {
+      for (Key key; key[0] < 5; key[0]++) {
+        EXPECT_THAT(archive.GetStorage(block, addr, key), zero);
+      }
+    }
+  }
+}
+
+TEST(Archive, MultipleVersionsOfTheSameValueCanBeRetained) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
+
+  Address addr;
+  Key key;
+
+  Value zero;
+  Value one{0x01};
+  Value two{0x02};
+
+  BlockUpdate update1;
+  update1.Set(addr, key, one);
+  EXPECT_OK(archive.Add(BlockId(2), update1));
+
+  BlockUpdate update2;
+  update2.Set(addr, key, two);
+  EXPECT_OK(archive.Add(BlockId(4), update2));
+
+  EXPECT_THAT(archive.GetStorage(0, addr, key), zero);
+  EXPECT_THAT(archive.GetStorage(1, addr, key), zero);
+  EXPECT_THAT(archive.GetStorage(2, addr, key), one);
+  EXPECT_THAT(archive.GetStorage(3, addr, key), one);
+  EXPECT_THAT(archive.GetStorage(4, addr, key), two);
+  EXPECT_THAT(archive.GetStorage(5, addr, key), two);
+}
+
+TEST(Archive, DifferentAccountsAreDifferentiated) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
+
+  Address addr1{0x01};
+  Address addr2{0x02};
+  Key key1{0x01};
+  Key key2{0x02};
+
+  Value zero;
+  Value one{0x01};
+  Value two{0x02};
+
+  BlockUpdate update1;
+  update1.Set(addr1, key1, one);
+  update1.Set(addr1, key2, two);
+  update1.Set(addr2, key1, two);
+  update1.Set(addr2, key2, one);
+  EXPECT_OK(archive.Add(BlockId(1), update1));
+
+  EXPECT_THAT(archive.GetStorage(0, addr1, key1), zero);
+  EXPECT_THAT(archive.GetStorage(1, addr1, key1), one);
+  EXPECT_THAT(archive.GetStorage(2, addr1, key1), one);
+
+  EXPECT_THAT(archive.GetStorage(0, addr1, key2), zero);
+  EXPECT_THAT(archive.GetStorage(1, addr1, key2), two);
+  EXPECT_THAT(archive.GetStorage(2, addr1, key2), two);
+
+  EXPECT_THAT(archive.GetStorage(0, addr2, key1), zero);
+  EXPECT_THAT(archive.GetStorage(1, addr2, key1), two);
+  EXPECT_THAT(archive.GetStorage(2, addr2, key1), two);
+
+  EXPECT_THAT(archive.GetStorage(0, addr2, key2), zero);
+  EXPECT_THAT(archive.GetStorage(1, addr2, key2), one);
+  EXPECT_THAT(archive.GetStorage(2, addr2, key2), one);
+}
+
+TEST(Archive, ConflictingHistoryCanNotBeAdded) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
+
+  BlockId block = 2;
+  Address addr;
+  Key key;
+
+  Value one{0x01};
+  Value two{0x02};
+
+  BlockUpdate update1;
+  update1.Set(addr, key, one);
+  EXPECT_OK(archive.Add(block, update1));
+  EXPECT_THAT(archive.GetStorage(block, addr, key), one);
+
+  // Attempting to update the same block again fails.
+  BlockUpdate update2;
+  update2.Set(addr, key, two);
+  EXPECT_THAT(archive.Add(block, update2),
+              StatusIs(_, HasSubstr("UNIQUE constraint failed")));
+
+  // The storage remains as it was.
+  EXPECT_THAT(archive.GetStorage(block, addr, key), one);
+}
+
+}  // namespace
+}  // namespace carmen


### PR DESCRIPTION
This PR adds an initial prototype for some archive features. In particular, it uses an SQLite DB to store the history of storage values and to fetch values of various historic moments.

This is the first of a series of PRs integrating Archive support into Carmen.