### PR TITLE
Add tests verifying that byte values are comparable

### DIFF
--- a/cpp/common/type.h
+++ b/cpp/common/type.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #include "hex_util.h"
@@ -38,9 +39,19 @@ class ByteValue {
     return out;
   }
 
-  // Ensure default three-way comparison.
-  friend auto operator<=>(const ByteValue<N>& containerA,
-                          const ByteValue<N>& containerB) = default;
+  // Add equality and inequality comparison support for all ByteValues.
+  friend bool operator==(const ByteValue<N>& containerA,
+                         const ByteValue<N>& containerB) = default;
+
+  // Add comparison support for all ByteValues.
+  friend int operator<=>(const ByteValue<N>& containerA,
+                         const ByteValue<N>& containerB) {
+    // Ideally we would just let this generate using =default, but this fails on
+    // MacOS since no <=> operator for arrays can be found. This seems to be a
+    // missing feature, since according to the cppreference such an operator
+    // should be defined.
+    return std::memcmp(containerA.data_.begin(), containerB.data_.begin(), N);
+  }
 
   // Support the usage of ByteValues in hash based absl containers.
   template <typename H>

--- a/cpp/common/type_test.cc
+++ b/cpp/common/type_test.cc
@@ -31,6 +31,30 @@ TEST(ByteValueTest, CannotHoldMoreValues) {
   EXPECT_THAT(Print(container), StrNe("0x12abef"));
 }
 
+TEST(ByteValueTest, DefaultValueIsZero) {
+  EXPECT_EQ(ByteValue<0>{}, (ByteValue<0>{}));
+  EXPECT_EQ(ByteValue<1>{}, (ByteValue<1>{0x00}));
+  EXPECT_EQ(ByteValue<2>{}, (ByteValue<2>{0x00, 0x00}));
+  EXPECT_EQ(ByteValue<3>{}, (ByteValue<3>{0x00, 0x00, 0x00}));
+}
+
+TEST(ByteValueTest, AreComarable) {
+  using Value = ByteValue<2>;
+  EXPECT_EQ(Value{0x01}, Value{0x01});
+  EXPECT_NE(Value{0x01}, Value{0x02});
+  EXPECT_LT(Value{0x01}, Value{0x02});
+  EXPECT_LE(Value{0x01}, Value{0x02});
+  EXPECT_GT(Value{0x02}, Value{0x01});
+  EXPECT_GE(Value{0x02}, Value{0x01});
+}
+
+TEST(ByteValueTest, AreLexicographicallySorted) {
+  EXPECT_LT((ByteValue<3>{0x01, 0x02}), (ByteValue<3>{0x01, 0x03}));
+  EXPECT_LT((ByteValue<3>{0x01, 0x02}), (ByteValue<3>{0x02, 0x01}));
+  EXPECT_LT((ByteValue<3>{0x01}), (ByteValue<3>{0x01, 0x02}));
+  EXPECT_EQ((ByteValue<3>{0x01}), (ByteValue<3>{0x01, 0x00}));
+}
+
 TEST(ByteValueTest, CanBeUsedInFlatHashSet) {
   ByteValue<2> a{0x12, 0x14};
   ByteValue<2> b{0x16, 0xf5};


### PR DESCRIPTION
Support for <=> comparison of bye values was broken on OSX builds. This change fixes this and adds a test for it.