### PR TITLE
Switch to single update call on block commit in C++ implementation

### DIFF
--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "state",
     hdrs = ["state.h"],
     deps = [
+        ":update",
         "//backend:structure",
         "//common:account_state",
         "//common:type",

--- a/cpp/state/c_state.h
+++ b/cpp/state/c_state.h
@@ -25,7 +25,7 @@ extern "C" {
 #define C_Balance void*
 #define C_Nonce void*
 #define C_Code void*
-
+#define C_Update void*
 #define C_Hash void*
 #define C_AccountState void*
 
@@ -60,31 +60,19 @@ void Carmen_ReleaseState(C_State state);
 
 // ------------------------------- Accounts -----------------------------------
 
-// Creates a new account or resurrects a deleted account.
-void Carmen_CreateAccount(C_State state, C_Address addr);
-
 // Gets the current state of the given account.
 void Carmen_GetAccountState(C_State state, C_Address addr,
                             C_AccountState out_state);
-
-// Deletes the given account.
-void Carmen_DeleteAccount(C_State state, C_Address addr);
 
 // -------------------------------- Balance -----------------------------------
 
 // Retrieves the balance of the given account.
 void Carmen_GetBalance(C_State state, C_Address addr, C_Balance out_balance);
 
-// Updates the balance of the given account.
-void Carmen_SetBalance(C_State state, C_Address addr, C_Balance balance);
-
 // --------------------------------- Nonce ------------------------------------
 
 // Retrieves the nonce of the given account.
 void Carmen_GetNonce(C_State state, C_Address addr, C_Nonce out_nonce);
-
-// Updates the nonce of the given account.
-void Carmen_SetNonce(C_State state, C_Address addr, C_Nonce nonce);
 
 // -------------------------------- Storage -----------------------------------
 
@@ -92,25 +80,23 @@ void Carmen_SetNonce(C_State state, C_Address addr, C_Nonce nonce);
 void Carmen_GetStorageValue(C_State state, C_Address addr, C_Key key,
                             C_Value out_value);
 
-// Updates the value of storage location (addr,key) in the given state.
-void Carmen_SetStorageValue(C_State state, C_Address addr, C_Key key,
-                            C_Value value);
-
 // --------------------------------- Code -------------------------------------
 
 // Retrieves the code stored under the given address.
 void Carmen_GetCode(C_State state, C_Address addr, C_Code out_code,
                     uint32_t* out_length);
 
-// Updates the code stored under the given address.
-void Carmen_SetCode(C_State state, C_Address addr, C_Code code,
-                    uint32_t length);
-
 // Retrieves the hash of the code stored under the given address.
 void Carmen_GetCodeHash(C_State state, C_Address addr, C_Hash out_hash);
 
 // Retrieves the code length stored under the given address.
 void Carmen_GetCodeSize(C_State state, C_Address addr, uint32_t* out_length);
+
+// -------------------------------- Update ------------------------------------
+
+// Applies the provided block update to the maintained state.
+void Carmen_Apply(C_State state, uint64_t block, C_Update update,
+                  uint32_t length);
 
 // ------------------------------ Global Hash ---------------------------------
 

--- a/cpp/state/c_state_test.cc
+++ b/cpp/state/c_state_test.cc
@@ -6,6 +6,7 @@
 #include "common/type.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "state/update.h"
 
 namespace carmen {
 namespace {
@@ -28,6 +29,57 @@ std::string ToString(Config c) {
       return "LevelDbBased";
   }
   return "Unknown";
+}
+
+// Wrapper functions for updateing individual elements.
+
+void Carmen_CreateAccount(C_State state, C_Address addr) {
+  Update update;
+  update.Create(*reinterpret_cast<const Address*>(addr));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
+}
+
+void Carmen_DeleteAccount(C_State state, C_Address addr) {
+  Update update;
+  update.Delete(*reinterpret_cast<const Address*>(addr));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
+}
+
+void Carmen_SetBalance(C_State state, C_Address addr, C_Balance balance) {
+  Update update;
+  update.Set(*reinterpret_cast<const Address*>(addr),
+             *reinterpret_cast<const Balance*>(balance));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
+}
+
+void Carmen_SetCode(C_State state, C_Address addr, C_Code code,
+                    uint32_t length) {
+  Update update;
+  update.Set(*reinterpret_cast<const Address*>(addr),
+             Code(std::span(reinterpret_cast<const std::byte*>(code), length)));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
+}
+
+void Carmen_SetNonce(C_State state, C_Address addr, C_Nonce nonce) {
+  Update update;
+  update.Set(*reinterpret_cast<const Address*>(addr),
+             *reinterpret_cast<const Nonce*>(nonce));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
+}
+
+void Carmen_SetStorageValue(C_State state, C_Address addr, C_Key key,
+                            C_Value value) {
+  Update update;
+  update.Set(*reinterpret_cast<const Address*>(addr),
+             *reinterpret_cast<const Key*>(key),
+             *reinterpret_cast<const Value*>(value));
+  auto data = update.ToBytes();
+  Carmen_Apply(state, 0, data->data(), data->size());
 }
 
 class CStateTest : public testing::TestWithParam<Config> {

--- a/cpp/state/update.cc
+++ b/cpp/state/update.cc
@@ -37,7 +37,8 @@ class Reader {
 
   absl::StatusOr<std::vector<std::byte>> ReadBytes(int length) {
     RETURN_IF_ERROR(CheckEnd(length));
-    std::vector<std::byte> result(length);
+    std::vector<std::byte> result;
+    result.resize(length);
     std::memcpy(result.data(), data_.data() + pos_, length);
     pos_ += length;
     return result;


### PR DESCRIPTION
This simplifies the interface between Go and C++ and groups updates of a single block together implicitly.

However, it will slow down the C++ implementation due to the additional serialization / deserialization overhead for each Apply call. This impact will have to be assessed and, if needed, mitigated.