### PR TITLE
file multimap btree

### DIFF
--- a/go/backend/btree/btree.go
+++ b/go/backend/btree/btree.go
@@ -3,6 +3,7 @@ package btree
 import (
 	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
 )
 
 // BTree implements a classic B-tree.
@@ -64,4 +65,10 @@ func (m BTree[K]) String() string {
 func (m *BTree[K]) checkProperties() error {
 	height := -1
 	return m.root.checkProperties(&height, 0)
+}
+
+func (m *BTree[K]) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*m))
+	mf.AddChild("nodes", m.root.GetMemoryFootprint())
+	return mf
 }

--- a/go/backend/btree/innernode.go
+++ b/go/backend/btree/innernode.go
@@ -3,6 +3,7 @@ package btree
 import (
 	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
 )
 
 // InnerNode contains keys as the LeafNode, in addition, it contains array of children elements.
@@ -417,4 +418,15 @@ func (m InnerNode[K]) checkProperties(treeDepth *int, currentLevel int) error {
 	}
 
 	return nil
+}
+
+func (m *InnerNode[K]) GetMemoryFootprint() *common.MemoryFootprint {
+	selfSize := unsafe.Sizeof(*m)
+	var k K
+	keysSize := uintptr(len(m.keys)) * unsafe.Sizeof(k)
+	var childrenSize uintptr
+	for _, child := range m.children {
+		childrenSize += child.GetMemoryFootprint().Value()
+	}
+	return common.NewMemoryFootprint(selfSize + keysSize + childrenSize)
 }

--- a/go/backend/btree/leafnode.go
+++ b/go/backend/btree/leafnode.go
@@ -3,6 +3,7 @@ package btree
 import (
 	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
 )
 
 // LeafNode contains a list of keys. The node has a maximal capacity, i.e. the number of keys it can hold.
@@ -186,4 +187,11 @@ func (m LeafNode[K]) checkProperties(treeDepth *int, currentLevel int) error {
 	}
 
 	return nil
+}
+
+func (m *LeafNode[K]) GetMemoryFootprint() *common.MemoryFootprint {
+	selfSize := unsafe.Sizeof(*m)
+	var k K
+	keysSize := uintptr(len(m.keys)) * unsafe.Sizeof(k)
+	return common.NewMemoryFootprint(selfSize + keysSize)
 }

--- a/go/backend/btree/node.go
+++ b/go/backend/btree/node.go
@@ -1,8 +1,11 @@
 package btree
 
+import "github.com/Fantom-foundation/Carmen/go/common"
+
 type node[K any] interface {
 	ForEacher[K]
 	nodeChecker[K]
+	common.MemoryFootprintProvider
 
 	// insert finds an in-order position of the key and inserts it in this node.
 	// When the key already exits, nothing happens.

--- a/go/backend/multimap/btreemem/dbkey.go
+++ b/go/backend/multimap/btreemem/dbkey.go
@@ -1,0 +1,58 @@
+package btreemem
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// dbKey is used as a key to the BTree backed Multimap.
+// It concatenates Key-Value pairs into one database (BTree) key.
+type dbKey[K any, V any] struct {
+	k              K
+	v              V
+	maxVal, minVal bool // shortcuts for comparator of [K,V] with max value [K,0xF...F] or min [K,0x0...0]
+}
+
+// newDbKey creates a new key concatenating input key-value pair.
+func newDbKey[K any, V any](k K, v V) dbKey[K, V] {
+	return dbKey[K, V]{k, v, false, false}
+}
+
+// newDbKeyMaxVal creates a new key where the input key is used
+// and the value is assumed as a maximal value from the address space
+// i.e. dbKey := [key][0xFF..FF]
+func newDbKeyMaxVal[K any, V any](k K) dbKey[K, V] {
+	return dbKey[K, V]{k: k, maxVal: true, minVal: false}
+}
+
+// newDbKeyMinVal creates a new key where the input key is used
+// and the value is assumed as a minimal value from the address space
+// i.e. dbKey := [key][0x00..00]
+func newDbKeyMinVal[K any, V any](k K) dbKey[K, V] {
+	return dbKey[K, V]{k: k, maxVal: false, minVal: true}
+}
+
+func (c dbKey[K, V]) String() string {
+	return fmt.Sprintf("dbKey: %v -> %v", c.k, c.v)
+}
+
+// dbKeyComparator comparator of DB key, which is composed of a Key-Value pair
+type dbKeyComparator[K any, V any] struct {
+	keyComparator   common.Comparator[K]
+	valueComparator common.Comparator[V]
+}
+
+func (c dbKeyComparator[K, V]) Compare(a, b *dbKey[K, V]) int {
+	res := c.keyComparator.Compare(&a.k, &b.k)
+	if res == 0 {
+		if b.minVal || a.maxVal {
+			return +1
+		}
+		if a.minVal || b.maxVal {
+			return -1
+		}
+		res = c.valueComparator.Compare(&a.v, &b.v)
+	}
+
+	return res
+}

--- a/go/backend/multimap/btreemem/file.go
+++ b/go/backend/multimap/btreemem/file.go
@@ -1,0 +1,82 @@
+package btreemem
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/btree"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"unsafe"
+)
+
+// MultiMap implemented via BTree, and persisted via pagepool.PagePool and pagepool.FilePageStorage
+type MultiMap[K any, V any] struct {
+	btree *btree.BTree[dbKey[K, V]]
+
+	keyComparator   common.Comparator[K]
+	valueComparator common.Comparator[V]
+}
+
+// NewMultiMap creates new instance
+func NewMultiMap[K any, V any](
+	keySerializer common.Serializer[K],
+	valueSerializer common.Serializer[V],
+	keyComparator common.Comparator[K],
+	valueComparator common.Comparator[V],
+) *MultiMap[K, V] {
+
+	// TODO calculate page size including links to children
+	dbKeySize := keySerializer.Size() + valueSerializer.Size()
+	pageItems := common.PageSize / dbKeySize
+	return &MultiMap[K, V]{
+		btree:           btree.NewBTree[dbKey[K, V]](pageItems, dbKeyComparator[K, V]{keyComparator, valueComparator}),
+		keyComparator:   keyComparator,
+		valueComparator: valueComparator,
+	}
+}
+
+func (m *MultiMap[K, V]) Add(key K, value V) error {
+	m.btree.Insert(newDbKey[K, V](key, value))
+	return nil
+}
+
+func (m *MultiMap[K, V]) Remove(key K, value V) error {
+	m.btree.Remove(newDbKey[K, V](key, value))
+	return nil
+}
+
+func (m *MultiMap[K, V]) RemoveAll(key K) error {
+	// TODO - implement btree.RemoveAll(key)
+	it := m.btree.NewIterator(newDbKeyMinVal[K, V](key), newDbKeyMaxVal[K, V](key))
+	keys := make([]dbKey[K, V], 0, 100)
+	for it.HasNext() {
+		keys = append(keys, it.Next())
+	}
+	for _, key := range keys {
+		m.btree.Remove(key)
+	}
+	return nil
+}
+
+func (m *MultiMap[K, V]) GetAll(key K) ([]V, error) {
+	it := m.btree.NewIterator(newDbKeyMinVal[K, V](key), newDbKeyMaxVal[K, V](key))
+	values := make([]V, 0, 100)
+	for it.HasNext() {
+		values = append(values, it.Next().v)
+	}
+	return values, nil
+}
+
+// Flush the store
+func (m *MultiMap[K, V]) Flush() error {
+	return nil
+}
+
+// Close the store
+func (m *MultiMap[K, V]) Close() error {
+	return nil
+}
+
+// GetMemoryFootprint provides the size of the store in memory in bytes
+func (m *MultiMap[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*m))
+	mf.AddChild("btree", m.btree.GetMemoryFootprint())
+	return mf
+}

--- a/go/backend/multimap/multimap_test.go
+++ b/go/backend/multimap/multimap_test.go
@@ -2,6 +2,7 @@ package multimap
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/multimap/btreemem"
 	"github.com/Fantom-foundation/Carmen/go/backend/multimap/ldb"
 	"github.com/Fantom-foundation/Carmen/go/backend/multimap/memory"
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -35,6 +36,12 @@ func getMultiMapFactories(tb testing.TB) (stores []multimapFactory) {
 					tb.Fatalf("failed to init leveldb store; %s", err)
 				}
 				return &multiMapClosingWrapper{mm, []func() error{db.Close}}
+			},
+		},
+		{
+			label: "BTree",
+			getMultiMap: func(tempDir string) MultiMap[uint32, uint64] {
+				return btreemem.NewMultiMap[uint32, uint64](common.Identifier32Serializer{}, common.Identifier64Serializer{}, common.Uint32Comparator{}, common.Uint64Comparator{})
 			},
 		},
 	}

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -162,6 +162,19 @@ func (c Uint32Comparator) Compare(a, b *uint32) int {
 	return 0
 }
 
+type Uint64Comparator struct{}
+
+func (c Uint64Comparator) Compare(a, b *uint64) int {
+	if *a > *b {
+		return 1
+	}
+	if *a < *b {
+		return -1
+	}
+
+	return 0
+}
+
 var (
 	one        = big.NewInt(1)
 	maxBalance = getMaxBalance()

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -22,6 +22,7 @@ import (
 	cachedIndex "github.com/Fantom-foundation/Carmen/go/backend/index/cache"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
 	indexmem "github.com/Fantom-foundation/Carmen/go/backend/index/memory"
+	mapbtree "github.com/Fantom-foundation/Carmen/go/backend/multimap/btreemem"
 	mapldb "github.com/Fantom-foundation/Carmen/go/backend/multimap/ldb"
 	mapmem "github.com/Fantom-foundation/Carmen/go/backend/multimap/memory"
 	cachedStore "github.com/Fantom-foundation/Carmen/go/backend/store/cache"
@@ -184,7 +185,7 @@ func NewGoFileState(params Parameters) (State, error) {
 	if err != nil {
 		return nil, err
 	}
-	addressToSlots := mapmem.NewMultiMap[uint32, uint32]()
+	addressToSlots := mapbtree.NewMultiMap[uint32, uint32](common.Identifier32Serializer{}, common.Identifier32Serializer{}, common.Uint32Comparator{}, common.Uint32Comparator{})
 
 	var arch archive.Archive
 	if params.WithArchive {
@@ -291,7 +292,7 @@ func NewGoCachedFileState(params Parameters) (State, error) {
 	if err != nil {
 		return nil, err
 	}
-	addressToSlots := mapmem.NewMultiMap[uint32, uint32]()
+	addressToSlots := mapbtree.NewMultiMap[uint32, uint32](common.Identifier32Serializer{}, common.Identifier32Serializer{}, common.Uint32Comparator{}, common.Uint32Comparator{})
 
 	var arch archive.Archive
 	if params.WithArchive {


### PR DESCRIPTION
This PR implements MultiMap via BTree. It is stored in the package `file` whereas BTree is at the moment implemented for in-memory only.  The BTree will be updated to persist on disk as a future work, which will cause this Multimap to be file persisted. 

This chart shows performance of this in-memory BTree vs. original in-memory
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/7114574/220374064-db32fad8-cec4-4107-8e82-4d2626ad5643.png">
