### PR TITLE
Add support to enable archive through exported state factory interface

### DIFF
--- a/cpp/state/archive.cc
+++ b/cpp/state/archive.cc
@@ -307,7 +307,7 @@ class Archive {
   // -- Blocks --
 
   static constexpr const std::string_view kCreateBlockTable =
-      "CREATE TABLE block (number INT PRIMARY KEY, hash BLOB)";
+      "CREATE TABLE IF NOT EXISTS block (number INT PRIMARY KEY, hash BLOB)";
 
   static constexpr const std::string_view kAddBlockStmt =
       "INSERT INTO block(number, hash) VALUES (?,?)";
@@ -318,8 +318,8 @@ class Archive {
   // -- Account Status --
 
   static constexpr const std::string_view kCreateStatusTable =
-      "CREATE TABLE status (account BLOB, block INT, exist, reincarnation INT "
-      "INT, PRIMARY KEY (account,block))";
+      "CREATE TABLE IF NOT EXISTS status (account BLOB, block INT, exist INT, "
+      "reincarnation INT, PRIMARY KEY (account,block))";
 
   static constexpr const std::string_view kCreateAccountStmt =
       "INSERT INTO status(account,block,exist,reincarnation) VALUES "
@@ -338,8 +338,8 @@ class Archive {
   // -- Balance --
 
   static constexpr const std::string_view kCreateBalanceTable =
-      "CREATE TABLE balance (account BLOB, block INT, value BLOB, "
-      "PRIMARY KEY (account,block))";
+      "CREATE TABLE IF NOT EXISTS balance (account BLOB, block INT, value "
+      "BLOB, PRIMARY KEY (account,block))";
 
   static constexpr const std::string_view kAddBalanceStmt =
       "INSERT INTO balance(account,block,value) VALUES (?,?,?)";
@@ -351,7 +351,7 @@ class Archive {
   // -- Code --
 
   static constexpr const std::string_view kCreateCodeTable =
-      "CREATE TABLE code (account BLOB, block INT, code BLOB, "
+      "CREATE TABLE IF NOT EXISTS code (account BLOB, block INT, code BLOB, "
       "PRIMARY KEY (account,block))";
 
   static constexpr const std::string_view kAddCodeStmt =
@@ -364,7 +364,7 @@ class Archive {
   // -- Nonces --
 
   static constexpr const std::string_view kCreateNonceTable =
-      "CREATE TABLE nonce (account BLOB, block INT, value BLOB, "
+      "CREATE TABLE IF NOT EXISTS nonce (account BLOB, block INT, value BLOB, "
       "PRIMARY KEY (account,block))";
 
   static constexpr const std::string_view kAddNonceStmt =
@@ -377,9 +377,9 @@ class Archive {
   // -- Storage --
 
   static constexpr const std::string_view kCreateValueTable =
-      "CREATE TABLE storage (account BLOB, reincarnation INT, slot BLOB, block "
-      "INT, value BLOB, "
-      "PRIMARY KEY (account,reincarnation,slot,block))";
+      "CREATE TABLE IF NOT EXISTS storage (account BLOB, reincarnation INT, "
+      "slot BLOB, block INT, value BLOB, PRIMARY KEY "
+      "(account,reincarnation,slot,block))";
 
   static constexpr const std::string_view kAddValueStmt =
       "INSERT INTO storage(account,reincarnation,slot,block,value) VALUES "

--- a/cpp/state/c_state.cc
+++ b/cpp/state/c_state.cc
@@ -103,8 +103,8 @@ class WorldStateWrapper : public WorldState {
 };
 
 template <typename State>
-WorldState* Open(const std::filesystem::path& directory) {
-  auto state = State::Open(directory);
+WorldState* Open(const std::filesystem::path& directory, C_bool with_archive) {
+  auto state = State::Open(directory, with_archive);
   if (!state.ok()) {
     std::cout << "WARNING: Failed to open state: " << state.status() << "\n";
     return nullptr;
@@ -117,18 +117,20 @@ WorldState* Open(const std::filesystem::path& directory) {
 
 extern "C" {
 
-C_State Carmen_CreateInMemoryState() {
-  return carmen::Open<carmen::InMemoryState>("");
+C_State Carmen_CreateInMemoryState(C_bool with_archive) {
+  return carmen::Open<carmen::InMemoryState>("", with_archive);
 }
 
-C_State Carmen_CreateFileBasedState(const char* directory, int length) {
+C_State Carmen_CreateFileBasedState(const char* directory, int length,
+                                    C_bool with_archive) {
   return carmen::Open<carmen::FileBasedState>(
-      std::string_view(directory, length));
+      std::string_view(directory, length), with_archive);
 }
 
-C_State Carmen_CreateLevelDbBasedState(const char* directory, int length) {
+C_State Carmen_CreateLevelDbBasedState(const char* directory, int length,
+                                       C_bool with_archive) {
   return carmen::Open<carmen::LevelDbBasedState>(
-      std::string_view(directory, length));
+      std::string_view(directory, length), with_archive);
 }
 
 void Carmen_Flush(C_State state) {

--- a/cpp/state/c_state.h
+++ b/cpp/state/c_state.h
@@ -19,6 +19,7 @@ extern "C" {
 
 #define C_State void*
 
+#define C_bool uint8_t
 #define C_Address void*
 #define C_Key void*
 #define C_Value void*
@@ -34,18 +35,20 @@ extern "C" {
 // Creates a new state retaining all data in memory and returns an opaque
 // pointer to it. Ownership of the state is transfered to the caller, which is
 // required to release it eventually.
-C_State Carmen_CreateInMemoryState();
+C_State Carmen_CreateInMemoryState(C_bool with_archive);
 
 // Creates a new state object maintaining data in files of the given directory
 // and returns an opaque pointer to it. Ownership of the state is transfered to
 // the caller, which is required to release it eventually.
-C_State Carmen_CreateFileBasedState(const char* directory, int length);
+C_State Carmen_CreateFileBasedState(const char* directory, int length,
+                                    C_bool with_archive);
 
 // Creates a new state object maintaining data in a LevelDB instance located in
 // the given directory and returns an opaque pointer to it. Ownership of the
 // state is transferred to the caller, which is required to release it
 // eventually.
-C_State Carmen_CreateLevelDbBasedState(const char* directory, int length);
+C_State Carmen_CreateLevelDbBasedState(const char* directory, int length,
+                                       C_bool with_archive);
 
 // Flushes all committed state information to disk to guarantee permanent
 // storage. All internally cached modifications is synced to disk.

--- a/cpp/state/c_state_test.cc
+++ b/cpp/state/c_state_test.cc
@@ -13,23 +13,29 @@ namespace {
 
 using ::testing::ElementsAre;
 
-enum class Config {
+enum class Variant {
   kInMemory,
   kFileBased,
   kLevelDbBased,
 };
 
-std::string ToString(Config c) {
+std::string ToString(Variant c) {
   switch (c) {
-    case Config::kInMemory:
+    case Variant::kInMemory:
       return "InMemory";
-    case Config::kFileBased:
+    case Variant::kFileBased:
       return "FileBased";
-    case Config::kLevelDbBased:
+    case Variant::kLevelDbBased:
       return "LevelDbBased";
   }
   return "Unknown";
 }
+
+// A configuration struct for the parameterized test below.
+struct Config {
+  Variant variant;
+  bool with_archive;
+};
 
 // Wrapper functions for updateing individual elements.
 
@@ -85,28 +91,31 @@ void Carmen_SetStorageValue(C_State state, C_Address addr, C_Key key,
 class CStateTest : public testing::TestWithParam<Config> {
  public:
   void SetUp() override {
-    switch (GetParam()) {
-      case Config::kInMemory: {
-        state_ = Carmen_CreateInMemoryState();
+    const Config& config = GetParam();
+    switch (config.variant) {
+      case Variant::kInMemory: {
+        state_ = Carmen_CreateInMemoryState(config.with_archive);
         ASSERT_NE(state_, nullptr);
         return;
       }
-      case Config::kFileBased: {
+      case Variant::kFileBased: {
         dir_ = std::make_unique<TempDir>();
         auto path = dir_->GetPath().string();
-        state_ = Carmen_CreateFileBasedState(path.c_str(), path.size());
+        state_ = Carmen_CreateFileBasedState(path.c_str(), path.size(),
+                                             config.with_archive);
         ASSERT_NE(state_, nullptr);
         return;
       }
-      case Config::kLevelDbBased: {
+      case Variant::kLevelDbBased: {
         dir_ = std::make_unique<TempDir>();
         auto path = dir_->GetPath().string();
-        state_ = Carmen_CreateLevelDbBasedState(path.c_str(), path.size());
+        state_ = Carmen_CreateLevelDbBasedState(path.c_str(), path.size(),
+                                                config.with_archive);
         ASSERT_NE(state_, nullptr);
         return;
       }
     }
-    FAIL() << "Unknown configuration: " << ToString(GetParam());
+    FAIL() << "Unknown variant: " << ToString(config.variant);
   }
 
   void TearDown() override {
@@ -417,18 +426,24 @@ TEST_P(CStateTest, MemoryFootprintCanBeObtained) {
 
 INSTANTIATE_TEST_SUITE_P(
     All, CStateTest,
-    testing::Values(Config::kInMemory, Config::kFileBased,
-                    Config::kLevelDbBased),
+    testing::Values(Config{Variant::kInMemory, false},
+                    Config{Variant::kFileBased, false},
+                    Config{Variant::kLevelDbBased, false},
+                    Config{Variant::kInMemory, true},
+                    Config{Variant::kFileBased, true},
+                    Config{Variant::kLevelDbBased, true}),
     [](const testing::TestParamInfo<CStateTest::ParamType>& info) {
-      return ToString(info.param);
+      const char* archive = info.param.with_archive ? "with" : "without";
+      return ToString(info.param.variant) + "_" + archive + "_archive";
     });
 
-TEST(FileBasedStateTest, CanBeStoredAndReloaded) {
+void StoreAndReloadFileBasedStore(bool with_archive) {
   TempDir dir;
   auto path = dir.GetPath().string();
   Hash hash;
   {
-    auto state = Carmen_CreateFileBasedState(path.c_str(), path.length());
+    auto state =
+        Carmen_CreateFileBasedState(path.c_str(), path.length(), with_archive);
     ASSERT_NE(state, nullptr);
 
     Address addr{0x01};
@@ -439,7 +454,8 @@ TEST(FileBasedStateTest, CanBeStoredAndReloaded) {
     Carmen_ReleaseState(state);
   }
   {
-    auto state = Carmen_CreateFileBasedState(path.c_str(), path.length());
+    auto state =
+        Carmen_CreateFileBasedState(path.c_str(), path.length(), with_archive);
     ASSERT_NE(state, nullptr);
 
     Address addr{0x01};
@@ -454,12 +470,21 @@ TEST(FileBasedStateTest, CanBeStoredAndReloaded) {
   }
 }
 
-TEST(LevelDbBasedStateTest, CanBeStoredAndReloaded) {
+TEST(FileBasedStateTest, CanBeStoredAndReloadedWithoutArchive) {
+  StoreAndReloadFileBasedStore(/*with_archive=*/false);
+}
+
+TEST(FileBasedStateTest, CanBeStoredAndReloadedWithArchive) {
+  StoreAndReloadFileBasedStore(/*with_archive=*/true);
+}
+
+void StoreAndReloadLevelDbBasedStore(bool with_archive) {
   TempDir dir;
   auto path = dir.GetPath().string();
   Hash hash;
   {
-    auto state = Carmen_CreateLevelDbBasedState(path.c_str(), path.length());
+    auto state = Carmen_CreateLevelDbBasedState(path.c_str(), path.length(),
+                                                with_archive);
     ASSERT_NE(state, nullptr);
 
     Address addr{0x01};
@@ -470,7 +495,8 @@ TEST(LevelDbBasedStateTest, CanBeStoredAndReloaded) {
     Carmen_ReleaseState(state);
   }
   {
-    auto state = Carmen_CreateLevelDbBasedState(path.c_str(), path.length());
+    auto state = Carmen_CreateLevelDbBasedState(path.c_str(), path.length(),
+                                                with_archive);
     ASSERT_NE(state, nullptr);
 
     Address addr{0x01};
@@ -483,6 +509,14 @@ TEST(LevelDbBasedStateTest, CanBeStoredAndReloaded) {
     EXPECT_EQ(hash, recovered);
     Carmen_ReleaseState(state);
   }
+}
+
+TEST(LevelDbBasedStateTest, CanBeStoredAndReloadedWithoutArchive) {
+  StoreAndReloadLevelDbBasedStore(/*with_archive=*/false);
+}
+
+TEST(LevelDbBasedStateTest, CanBeStoredAndReloadedWithArchive) {
+  StoreAndReloadLevelDbBasedStore(/*with_archive=*/true);
 }
 
 }  // namespace

--- a/go/simulation/state_simulation.go
+++ b/go/simulation/state_simulation.go
@@ -3,18 +3,19 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/common"
-	"github.com/Fantom-foundation/Carmen/go/state"
 	"math"
 	"math/big"
 	"math/rand"
 	"time"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
 const KeysCacheSize = 256
 
 func main() {
-	memState, err := state.NewGoMemoryState()
+	memState, err := state.NewGoMemoryState(state.Parameters{})
 	if err != nil {
 		panic(err)
 	}

--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -29,29 +29,36 @@ type CppState struct {
 	codeCache *common.Cache[common.Address, []byte]
 }
 
-func NewCppInMemoryState(directory string) (State, error) {
+func NewCppInMemoryState(params Parameters) (State, error) {
 	return &CppState{
-		state:     C.Carmen_CreateInMemoryState(),
+		state:     C.Carmen_CreateInMemoryState(toCBool(params.WithArchive)),
 		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
 	}, nil
 }
 
-func NewCppFileBasedState(directory string) (State, error) {
-	dir := C.CString(directory)
+func NewCppFileBasedState(params Parameters) (State, error) {
+	dir := C.CString(params.Directory)
 	defer C.free(unsafe.Pointer(dir))
 	return &CppState{
-		state:     C.Carmen_CreateFileBasedState(dir, C.int(len(directory))),
+		state:     C.Carmen_CreateFileBasedState(dir, C.int(len(params.Directory)), toCBool(params.WithArchive)),
 		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
 	}, nil
 }
 
-func NewCppLevelDbBasedState(directory string) (State, error) {
-	dir := C.CString(directory)
+func NewCppLevelDbBasedState(params Parameters) (State, error) {
+	dir := C.CString(params.Directory)
 	defer C.free(unsafe.Pointer(dir))
 	return &CppState{
-		state:     C.Carmen_CreateLevelDbBasedState(dir, C.int(len(directory))),
+		state:     C.Carmen_CreateLevelDbBasedState(dir, C.int(len(params.Directory)), toCBool(params.WithArchive)),
 		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
 	}, nil
+}
+
+func toCBool(flag bool) C.C_bool {
+	if flag {
+		return C.C_bool(1)
+	}
+	return C.C_bool(0)
 }
 
 func (cs *CppState) createAccount(address common.Address) error {

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -36,7 +36,7 @@ var (
 
 func initGoStates() []namedStateConfig {
 	return []namedStateConfig{
-		{"Memory", castToDirectUpdateState(newTestingMemory)},
+		{"Memory", castToDirectUpdateState(NewGoMemoryState)},
 		{"File Index and Store", castToDirectUpdateState(NewGoFileState)},
 		{"Cached File Index and Store", castToDirectUpdateState(NewGoCachedFileState)},
 		{"LevelDB Index, File Store", castToDirectUpdateState(NewGoLeveLIndexFileStoreState)},
@@ -46,10 +46,6 @@ func initGoStates() []namedStateConfig {
 		{"Cached LevelDB Index and Store", castToDirectUpdateState(NewGoCachedLeveLIndexAndStoreState)},
 		{"Cached Transact LevelDB Index and Store", castToDirectUpdateState(NewGoTransactCachedLeveLIndexAndStoreState)}, // cannot combine transact and non-transact access
 	}
-}
-
-func newTestingMemory(_ string) (State, error) {
-	return NewGoMemoryState()
 }
 
 func TestMissingKeys(t *testing.T) {
@@ -269,7 +265,7 @@ func (m failingIndex[K, I]) Get(key K) (id I, err error) {
 }
 
 func TestFailingStore(t *testing.T) {
-	state, err := NewGoMemoryState()
+	state, err := NewGoMemoryState(Parameters{})
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}
@@ -299,7 +295,7 @@ func TestFailingStore(t *testing.T) {
 }
 
 func TestFailingIndex(t *testing.T) {
-	state, err := NewGoMemoryState()
+	state, err := NewGoMemoryState(Parameters{})
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -1,10 +1,12 @@
 package state
 
 import (
-	"github.com/Fantom-foundation/Carmen/go/backend/index/file"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/index/file"
 
 	cachedDepot "github.com/Fantom-foundation/Carmen/go/backend/depot/cache"
 	fileDepot "github.com/Fantom-foundation/Carmen/go/backend/depot/file"
@@ -39,9 +41,18 @@ const PoolSize = 100000
 // The number of codes grouped together in depots to form one leaf node of the hash tree.
 const CodeHashGroupSize = 4
 
+// Parameters struct defining configuration parameters for state instances.
+type Parameters struct {
+	Directory   string
+	WithArchive bool
+}
+
 // NewGoMemoryState creates in memory implementation
 // (path parameter for compatibility with other state factories, can be left empty)
-func NewGoMemoryState() (State, error) {
+func NewGoMemoryState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
 	addressIndex := indexmem.NewIndex[common.Address, uint32](common.AddressSerializer{})
 	slotIndex := indexmem.NewIndex[common.SlotIdx[uint32], uint32](common.SlotIdxSerializer32{})
 	keyIndex := indexmem.NewIndex[common.Key, uint32](common.KeySerializer{})
@@ -79,8 +90,11 @@ func NewGoMemoryState() (State, error) {
 }
 
 // NewGoFileState creates File based Index and Store implementations
-func NewGoFileState(path string) (State, error) {
-	indexPath, storePath, err := createSubDirs(path)
+func NewGoFileState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	indexPath, storePath, err := createSubDirs(params.Directory)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +191,11 @@ func NewGoFileState(path string) (State, error) {
 }
 
 // NewGoCachedFileState creates File based Index and Store implementations
-func NewGoCachedFileState(path string) (State, error) {
-	indexPath, storePath, err := createSubDirs(path)
+func NewGoCachedFileState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	indexPath, storePath, err := createSubDirs(params.Directory)
 	if err != nil {
 		return nil, err
 	}
@@ -275,8 +292,11 @@ func NewGoCachedFileState(path string) (State, error) {
 }
 
 // NewGoLeveLIndexFileStoreState creates LevelDB Index and File Store implementations
-func NewGoLeveLIndexFileStoreState(path string) (State, error) {
-	indexPath, storePath, err := createSubDirs(path)
+func NewGoLeveLIndexFileStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	indexPath, storePath, err := createSubDirs(params.Directory)
 	if err != nil {
 		return nil, err
 	}
@@ -356,8 +376,11 @@ func NewGoLeveLIndexFileStoreState(path string) (State, error) {
 }
 
 // NewGoCachedLeveLIndexFileStoreState creates Cached LevelDB Index and File Store implementations
-func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
-	indexPath, storePath, err := createSubDirs(path)
+func NewGoCachedLeveLIndexFileStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	indexPath, storePath, err := createSubDirs(params.Directory)
 	if err != nil {
 		return nil, err
 	}
@@ -449,8 +472,11 @@ func NewGoCachedLeveLIndexFileStoreState(path string) (State, error) {
 }
 
 // NewGoCachedTransactLeveLIndexFileStoreState creates Cached and Transactional LevelDB Index and File Store implementations
-func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
-	indexPath, storePath, err := createSubDirs(path)
+func NewGoCachedTransactLeveLIndexFileStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	indexPath, storePath, err := createSubDirs(params.Directory)
 	if err != nil {
 		return nil, err
 	}
@@ -555,8 +581,11 @@ func NewGoCachedTransactLeveLIndexFileStoreState(path string) (State, error) {
 }
 
 // NewGoLeveLIndexAndStoreState creates Index and Store both backed up by the leveldb
-func NewGoLeveLIndexAndStoreState(path string) (State, error) {
-	db, err := common.OpenLevelDb(path, nil)
+func NewGoLeveLIndexAndStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	db, err := common.OpenLevelDb(params.Directory, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -611,8 +640,11 @@ func NewGoLeveLIndexAndStoreState(path string) (State, error) {
 }
 
 // NewGoCachedLeveLIndexAndStoreState creates Index and Store both backed up by the leveldb
-func NewGoCachedLeveLIndexAndStoreState(path string) (State, error) {
-	db, err := common.OpenLevelDb(path, nil)
+func NewGoCachedLeveLIndexAndStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
+	db, err := common.OpenLevelDb(params.Directory, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -678,9 +710,12 @@ func NewGoCachedLeveLIndexAndStoreState(path string) (State, error) {
 }
 
 // NewGoTransactCachedLeveLIndexAndStoreState creates Index and Store both backed up by the leveldb
-func NewGoTransactCachedLeveLIndexAndStoreState(path string) (State, error) {
+func NewGoTransactCachedLeveLIndexAndStoreState(params Parameters) (State, error) {
+	if params.WithArchive {
+		return nil, fmt.Errorf("archive mode not supported yet in go-* variant")
+	}
 	opts := opt.Options{WriteBuffer: TransactBufferMB}
-	db, err := common.OpenLevelDb(path, &opts)
+	db, err := common.OpenLevelDb(params.Directory, &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -2542,7 +2542,7 @@ func TestCarmenStateGetMemoryFootprintIsReturnedAndNotZero(t *testing.T) {
 }
 
 func testCarmenStateDbHashAfterModification(t *testing.T, mod func(s StateDB)) {
-	ref_state, err := NewGoMemoryState()
+	ref_state, err := NewGoMemoryState(Parameters{})
 	if err != nil {
 		t.Fatalf("failed to create reference state: %v", err)
 	}


### PR DESCRIPTION
This PR is ..
 - adding a `withArchive` option for creating State instances
 - adding test coverage for opening and closing States with Archives (where supported)
 