### PR TITLE
Add support for bulk-loading data with active archive

### DIFF
--- a/cpp/state/c_state.cc
+++ b/cpp/state/c_state.cc
@@ -36,6 +36,7 @@ class WorldState {
   virtual absl::StatusOr<Hash> GetCodeHash(const Address&) = 0;
 
   virtual absl::Status Apply(std::uint64_t block, const Update&) = 0;
+  virtual absl::Status ApplyToState(const Update&) = 0;
 
   virtual absl::StatusOr<Hash> GetHash() = 0;
 
@@ -86,6 +87,10 @@ class WorldStateWrapper : public WorldState {
 
   absl::Status Apply(std::uint64_t block, const Update& update) override {
     return state_.Apply(block, update);
+  }
+
+  absl::Status ApplyToState(const Update& update) override {
+    return state_.ApplyToState(update);
   }
 
   absl::StatusOr<Hash> GetHash() override { return state_.GetHash(); }
@@ -257,7 +262,23 @@ void Carmen_Apply(C_State state, uint64_t block, C_Update update,
               << "\n";
     return;
   }
-  auto res = s.Apply(block, *change);
+  auto res = s.Apply(block, *std::move(change));
+  if (!res.ok()) {
+    std::cout << "WARNING: Failed to apply update: " << res << "\n";
+  }
+}
+
+void Carmen_ApplyToState(C_State state, C_Update update, uint32_t length) {
+  auto& s = *reinterpret_cast<carmen::WorldState*>(state);
+  std::span<const std::byte> data(reinterpret_cast<const std::byte*>(update),
+                                  length);
+  auto change = carmen::Update::FromBytes(data);
+  if (!change.ok()) {
+    std::cout << "WARNING: Failed to decode update: " << change.status()
+              << "\n";
+    return;
+  }
+  auto res = s.ApplyToState(*std::move(change));
   if (!res.ok()) {
     std::cout << "WARNING: Failed to apply update: " << res << "\n";
   }

--- a/cpp/state/c_state.h
+++ b/cpp/state/c_state.h
@@ -101,6 +101,10 @@ void Carmen_GetCodeSize(C_State state, C_Address addr, uint32_t* out_length);
 void Carmen_Apply(C_State state, uint64_t block, C_Update update,
                   uint32_t length);
 
+// Applies the provided update to the current state only. This is intended for
+// the bulk load interface support.
+void Carmen_ApplyToState(C_State state, C_Update update, uint32_t length);
+
 // ------------------------------ Global Hash ---------------------------------
 
 // Retrieves a global state hash of the given state.


### PR DESCRIPTION
Before this change, priming the DB kept reporting errors since no block numbers have been provided during DB priming and the default block number of 0 was not unique.

This PR does not resolve the priming problem of Archives but fixes the broken priming support for current states.