### PR TITLE
Strengthen trivial type requirements

### DIFF
--- a/cpp/backend/index/file/index.h
+++ b/cpp/backend/index/file/index.h
@@ -220,7 +220,7 @@ class FileIndex {
 
   mutable std::queue<K> unhashed_keys_;
   mutable Sha256Hasher hasher_;
-  mutable Hash hash_;
+  mutable Hash hash_{};
 };
 
 template <Trivial K, std::integral I, template <std::size_t> class F,

--- a/cpp/backend/index/memory/index.h
+++ b/cpp/backend/index/memory/index.h
@@ -146,7 +146,7 @@ class InMemoryIndex {
 
   mutable std::size_t next_to_hash_ = 0;
   mutable Sha256Hasher hasher_;
-  mutable Hash hash_;
+  mutable Hash hash_{};
 };
 
 template <Trivial K, std::integral I>

--- a/cpp/backend/index/test_util.h
+++ b/cpp/backend/index/test_util.h
@@ -95,7 +95,7 @@ TYPED_TEST_P(IndexTest, EmptyIndexHasHashEqualsZero) {
 }
 
 TYPED_TEST_P(IndexTest, IndexHashIsEqualToInsertionOrder) {
-  Hash hash;
+  Hash hash{};
   ASSERT_OK_AND_ASSIGN(auto wrapper, IndexHandler<TypeParam>::Create());
   auto& index = wrapper.GetIndex();
   EXPECT_THAT(index.GetHash(), IsOkAndHolds(hash));

--- a/cpp/common/hash.h
+++ b/cpp/common/hash.h
@@ -74,21 +74,21 @@ class Sha256Hasher {
   std::unique_ptr<internal::Sha256Impl> _impl;
 };
 
-// A utility function to hash a list of trivial elements using the given hasher
+// A utility function to hash a list of elements using the given hasher
 // instance. The state of the handed in hasher is reset before ingesting the
 // provided list of elements.
-template <Trivial... Elements>
+template <typename... Elements>
 Hash GetHash(Sha256Hasher& hasher, const Elements&... elements) {
   hasher.Reset();
   hasher.Ingest(elements...);
   return hasher.GetHash();
 }
 
-// A utility function to compute the SHA256 hash of a list of trivial elements.
+// A utility function to compute the SHA256 hash of a list of elements.
 // It internally creates a Sha256Hasher instance for computing the hash. If
 // multiple hashes are to be computed, consider creating such an instance in the
 // caller scope and reusing the instance for all invocations.
-template <Trivial... Elements>
+template <typename... Elements>
 Hash GetSha256Hash(const Elements&... elements) {
   Sha256Hasher hasher;
   return GetHash(hasher, elements...);

--- a/cpp/common/hex_util.cc
+++ b/cpp/common/hex_util.cc
@@ -7,16 +7,16 @@
 namespace carmen::hex_util {
 
 namespace {
-const std::array<char, 16> HEX_MAP = {'0', '1', '2', '3', '4', '5', '6', '7',
+const std::array<char, 16> kHexMap = {'0', '1', '2', '3', '4', '5', '6', '7',
                                       '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 }  // namespace
 
 // Write hex representation of given sequence prefixed with "0x" into ostream.
-void WriteTo(std::ostream& out, std::span<std::uint8_t> data) {
+void WriteTo(std::ostream& out, std::span<const std::uint8_t> data) {
   out << "0x";
   for (const auto& i : data) {
-    out << HEX_MAP[i >> 4];
-    out << HEX_MAP[i & 0xF];
+    out << kHexMap[i >> 4];
+    out << kHexMap[i & 0xF];
   }
 }
 

--- a/cpp/common/hex_util.h
+++ b/cpp/common/hex_util.h
@@ -7,6 +7,6 @@
 namespace carmen::hex_util {
 
 // Write hex representation of given sequence prefixed with "0x" into ostream.
-void WriteTo(std::ostream& out, std::span<std::uint8_t> data);
+void WriteTo(std::ostream& out, std::span<const std::uint8_t> data);
 
 }  // namespace carmen::hex_util

--- a/cpp/common/type.h
+++ b/cpp/common/type.h
@@ -5,6 +5,7 @@
 #include <compare>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <iostream>
 #include <span>
 #include <vector>
@@ -14,7 +15,8 @@
 namespace carmen {
 
 template <typename T>
-concept Trivial = std::is_trivially_copyable_v<T>;
+concept Trivial = std::is_trivially_default_constructible_v<T> &&
+    std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>;
 
 constexpr int kHashLength = 32;
 constexpr int kAddressLength = 20;
@@ -23,7 +25,27 @@ constexpr int kValueLength = 32;
 constexpr int kBalanceLength = 16;
 constexpr int kNonceLength = 8;
 
-// Class template for all types based on byte array value.
+// Class template for all types based on byte array value. Byte values are
+// trivial objects containing a fixed length sequence of bytes. All byte
+// sequences are valid.
+//
+// When creating a byte value, there are multiple options:
+//
+//   // Creates a byte value with uninitialized (random) data:
+//   ByteValue<2> value;
+//
+//   // Create and initialize a value with some values:
+//   ByteValue<2> value{1,2};
+//
+//   // Create a value with a partial list, rest is zero:
+//   ByteValue<2> value{1};  // == {1,0}
+//
+// Thus, to initialize a byte value with all zeros, one can write
+//   ByteValue value{};
+//
+// Note the difference: without {} the byte value remains uninitialized, with {}
+// the value is initialized to zero. This is the same semantic as it is
+// exhibited by the underlying std::array<..>.
 template <std::size_t N>
 class ByteValue {
  public:
@@ -31,8 +53,7 @@ class ByteValue {
 
   // Class constructor populating data with given list of values.
   ByteValue(std::initializer_list<std::uint8_t> il) {
-    std::copy(il.begin(), il.begin() + std::min(il.size(), data_.size()),
-              std::begin(data_));
+    SetBytes(std::as_bytes(std::span<const std::uint8_t>(il)));
   }
 
   // Provide mutable access to the individual bytes.
@@ -60,17 +81,16 @@ class ByteValue {
   // exceeding the size of this ByteValue are ignored. If the input is too
   // short, the rest of the bytes are filled with zero.
   void SetBytes(std::span<const std::byte> data) {
-    std::memcpy(&data_[0], data.data(), std::min(data.size(), data_.size()));
-    if (data.size() < data_.size()) {
-      std::memset(&data_[0] + data.size(), 0, data_.size() - data.size());
+    std::memcpy(&data_[0], data.data(), std::min(data.size(), N));
+    if (data.size() < N) {
+      std::memset(&data_[0] + data.size(), 0, N - data.size());
     }
   }
 
   // Overload of << operator to make class printable.
   friend std::ostream& operator<<(std::ostream& out,
                                   const ByteValue<N>& hexContainer) {
-    hex_util::WriteTo(
-        out, *const_cast<std::array<std::uint8_t, N>*>(&hexContainer.data_));
+    hex_util::WriteTo(out, hexContainer.data_);
     return out;
   }
 
@@ -99,7 +119,7 @@ class ByteValue {
   }
 
  private:
-  std::array<std::uint8_t, N> data_{};
+  std::array<std::uint8_t, N> data_;
 };
 
 // Hash represents the 32 byte hash of data

--- a/cpp/common/type_test.cc
+++ b/cpp/common/type_test.cc
@@ -12,6 +12,13 @@ using ::testing::ElementsAre;
 using ::testing::StrEq;
 using ::testing::StrNe;
 
+TEST(ByteValueTest, TypePorperties) {
+  EXPECT_TRUE(std::is_trivially_default_constructible_v<ByteValue<10>>);
+  EXPECT_TRUE(std::is_trivially_copyable_v<ByteValue<10>>);
+  EXPECT_TRUE(std::is_trivially_destructible_v<ByteValue<10>>);
+  EXPECT_TRUE(Trivial<ByteValue<10>>);
+}
+
 TEST(ByteValueTest, CanBePrinted) {
   ByteValue<2> container{0x12, 0xab};
   EXPECT_THAT(Print(container), StrEq("0x12ab"));
@@ -23,7 +30,7 @@ TEST(ByteValueTest, CanBeEmpty) {
 }
 
 TEST(ByteValueTest, CanBeInitializedEmpty) {
-  ByteValue<1> container;
+  ByteValue<1> container{};
   EXPECT_THAT(Print(container), StrEq("0x00"));
 }
 

--- a/cpp/state/archive.cc
+++ b/cpp/state/archive.cc
@@ -184,7 +184,7 @@ class Archive {
 
     // The query produces 0 or 1 results. If there is no result, returning the
     // zero value is what is expected since this is the default balance.
-    Balance result;
+    Balance result{};
     RETURN_IF_ERROR(get_balance_stmt_->Run(
         [&](const SqlRow& row) { result.SetBytes(row.GetBytes(0)); }));
     return result;
@@ -201,7 +201,7 @@ class Archive {
 
     // The query produces 0 or 1 results. If there is no result, returning the
     // zero value is what is expected since this is the default code.
-    Code result;
+    Code result{};
     RETURN_IF_ERROR(get_code_stmt_->Run(
         [&](const SqlRow& row) { result = Code(row.GetBytes(0)); }));
     return result;
@@ -218,7 +218,7 @@ class Archive {
 
     // The query produces 0 or 1 results. If there is no result, returning the
     // zero value is what is expected since this is the default balance.
-    Nonce result;
+    Nonce result{};
     RETURN_IF_ERROR(get_nonce_stmt_->Run(
         [&](const SqlRow& row) { result.SetBytes(row.GetBytes(0)); }));
     return result;
@@ -243,7 +243,7 @@ class Archive {
     // The query produces 0 or 1 results. If there is no result, returning the
     // zero value is what is expected since this is the default value of storage
     // slots.
-    Value result;
+    Value result{};
     RETURN_IF_ERROR(get_value_stmt_->Run(
         [&](const SqlRow& row) { result.SetBytes(row.GetBytes(0)); }));
     return result;

--- a/cpp/state/archive_test.cc
+++ b/cpp/state/archive_test.cc
@@ -50,9 +50,9 @@ TEST(Archive, MultipleBalancesOfTheSameAccountCanBeRetained) {
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
 
-  Address addr;
+  Address addr{};
 
-  Balance zero;
+  Balance zero{};
   Balance one{0x01};
   Balance two{0x02};
 
@@ -76,9 +76,9 @@ TEST(Archive, MultipleCodesOfTheSameAccountCanBeRetained) {
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
 
-  Address addr;
+  Address addr{};
 
-  Code zero;
+  Code zero{};
   Code one{0x01};
   Code two{0x02, 0x03};
 
@@ -102,9 +102,9 @@ TEST(Archive, MultipleNoncesOfTheSameAccountCanBeRetained) {
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
 
-  Address addr;
+  Address addr{};
 
-  Nonce zero;
+  Nonce zero{};
   Nonce one{0x01};
   Nonce two{0x02};
 
@@ -128,10 +128,10 @@ TEST(Archive, MultipleValuesOfTheSameSlotCanBeRetained) {
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto archive, Archive::Open(dir));
 
-  Address addr;
-  Key key;
+  Address addr{};
+  Key key{};
 
-  Value zero;
+  Value zero{};
   Value one{0x01};
   Value two{0x02};
 
@@ -158,7 +158,7 @@ TEST(Archive, BalancesOfDifferentAccountsAreDifferentiated) {
   Address addr1{0x01};
   Address addr2{0x02};
 
-  Balance zero;
+  Balance zero{};
   Balance one{0x01};
   Balance two{0x02};
 
@@ -183,7 +183,7 @@ TEST(Archive, CodesOfDifferentAccountsAreDifferentiated) {
   Address addr1{0x01};
   Address addr2{0x02};
 
-  Code zero;
+  Code zero{};
   Code one{0x01};
   Code two{0x02, 0x03};
 
@@ -208,7 +208,7 @@ TEST(Archive, NoncesOfDifferentAccountsAreDifferentiated) {
   Address addr1{0x01};
   Address addr2{0x02};
 
-  Nonce zero;
+  Nonce zero{};
   Nonce one{0x01};
   Nonce two{0x02, 0x03};
 
@@ -235,7 +235,7 @@ TEST(Archive, ValuesOfDifferentAccountsAreDifferentiated) {
   Key key1{0x01};
   Key key2{0x02};
 
-  Value zero;
+  Value zero{};
   Value one{0x01};
   Value two{0x02};
 

--- a/cpp/state/state.h
+++ b/cpp/state/state.h
@@ -299,7 +299,7 @@ template <template <typename K, typename V> class IndexType,
 StatusOrRef<const Balance>
 State<IndexType, StoreType, DepotType, MultiMapType>::GetBalance(
     const Address& address) const {
-  constexpr static const Balance kZero;
+  constexpr static const Balance kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return kZero;
@@ -325,7 +325,7 @@ template <template <typename K, typename V> class IndexType,
 StatusOrRef<const Nonce>
 State<IndexType, StoreType, DepotType, MultiMapType>::GetNonce(
     const Address& address) const {
-  constexpr static const Nonce kZero;
+  constexpr static const Nonce kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return kZero;
@@ -351,7 +351,7 @@ template <template <typename K, typename V> class IndexType,
 StatusOrRef<const Value>
 State<IndexType, StoreType, DepotType, MultiMapType>::GetStorageValue(
     const Address& address, const Key& key) const {
-  constexpr static const Value kZero;
+  constexpr static const Value kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return kZero;

--- a/cpp/state/state_test.cc
+++ b/cpp/state/state_test.cc
@@ -174,7 +174,7 @@ TYPED_TEST_P(StateTest, BalancesAreCoveredByGlobalStateHash) {
 TYPED_TEST_P(StateTest, DefaultNonceIsZero) {
   Address a{0x01};
   Address b{0x02};
-  Nonce zero;
+  Nonce zero{};
 
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto state, TypeParam::Open(dir));
@@ -185,7 +185,7 @@ TYPED_TEST_P(StateTest, DefaultNonceIsZero) {
 TYPED_TEST_P(StateTest, NoncesCanBeUpdated) {
   Address a{0x01};
   Address b{0x02};
-  Nonce zero;
+  Nonce zero{};
 
   TempDir dir;
   ASSERT_OK_AND_ASSIGN(auto state, TypeParam::Open(dir));


### PR DESCRIPTION
This PR strengthens the requirements of trivial types. After this, trivial types have to be trivially default constructible, trivially copyable, and trivially destructible. When using trivial types in file pages, those properties have already been assumed, and now they are enforced.

As part of this, the initialization of `ByteValues` was updated to allow users to decide whether a zero-initialization should be conducted or not. For instance:
 - `Key key;` .. no initialization, key has a uninitialized (=random) value;
 - `Key key{};` .. all-zero-initialized key
 - `Key key{0x01};` .. initialized key with a leading `0x01` as its first byte and zeros for the rest

This change is required since the property of being trivially default constructed is exploited by the B-tree implementation.