### PR TITLE
Make B-tree set flushable, closeable, and re-openable

### DIFF
--- a/cpp/backend/common/btree/BUILD
+++ b/cpp/backend/common/btree/BUILD
@@ -23,6 +23,20 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "btree_set_benchmark",
+    testonly = True,
+    srcs = ["btree_set_benchmark.cc"],
+    deps = [
+        ":btree_set",
+        "//backend/common:access_pattern",
+        "//common:file_util",
+        "//common:status_test_util",
+        "//third_party/gperftools:profiler",
+        "@com_github_google_benchmark//:benchmark_main",
+    ],
+)
+
 cc_library(
     name = "insert_result",
     hdrs = ["insert_result.h"],

--- a/cpp/backend/common/btree/btree_set_benchmark.cc
+++ b/cpp/backend/common/btree/btree_set_benchmark.cc
@@ -1,0 +1,55 @@
+#include "backend/common/btree/btree_set.h"
+#include "backend/common/file.h"
+#include "benchmark/benchmark.h"
+#include "common/file_util.h"
+#include "common/status_test_util.h"
+#include "common/type.h"
+
+namespace carmen::backend {
+namespace {
+
+// To run benchmarks, use the following command:
+//    bazel run -c opt //backend/common/btree:btree_set_benchmark
+
+using TestPagePool = PagePool<SingleFile<kFileSystemPageSize>>;
+
+template <Trivial Value>
+using TestBTreeSet = BTreeSet<Value, TestPagePool>;
+
+template <typename Distribution>
+void BM_IntInsertion(benchmark::State& state) {
+  TempFile file;
+  ASSERT_OK_AND_ASSIGN(auto set, TestBTreeSet<int>::Open(file));
+  Distribution distribution(1'000'000'000);
+  for (auto _ : state) {
+    int next = distribution.Next();
+    ASSERT_OK(set.Insert(next));
+  }
+}
+
+BENCHMARK(BM_IntInsertion<Sequential>);
+BENCHMARK(BM_IntInsertion<Uniform>);
+BENCHMARK(BM_IntInsertion<Exponential>);
+
+template <typename Distribution>
+void BM_ValueInsertion(benchmark::State& state) {
+  TempFile file;
+  ASSERT_OK_AND_ASSIGN(auto set, TestBTreeSet<Value>::Open(file));
+  Distribution distribution(1'000'000'000);
+  for (auto _ : state) {
+    int next = distribution.Next();
+    Value value;
+    value[7] = next;
+    value[15] = next >> 8;
+    value[23] = next >> 16;
+    value[31] = next >> 24;
+    ASSERT_OK(set.Insert(value));
+  }
+}
+
+BENCHMARK(BM_ValueInsertion<Sequential>);
+BENCHMARK(BM_ValueInsertion<Uniform>);
+BENCHMARK(BM_ValueInsertion<Exponential>);
+
+}  // namespace
+}  // namespace carmen::backend

--- a/cpp/backend/common/page_manager_test.cc
+++ b/cpp/backend/common/page_manager_test.cc
@@ -4,10 +4,16 @@
 #include "backend/common/page.h"
 #include "backend/common/page_id.h"
 #include "common/status_test_util.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace carmen::backend {
 namespace {
+
+using ::testing::FieldsAre;
+using ::testing::IsOkAndHolds;
+using ::testing::Return;
+using ::testing::StatusIs;
 
 using Page = RawPage<>;
 using TestPagePool = PagePool<InMemoryFile<kFileSystemPageSize>>;
@@ -46,6 +52,119 @@ TEST(PageManager, PageIdsAreResolvedToCorrespondingPages) {
 
   EXPECT_EQ(&page1, &reload1);
   EXPECT_EQ(&page2, &reload2);
+}
+
+// A mock version of a page pool to test PageManager internals.
+class MockPagePool {
+ public:
+  template <typename Page>
+  StatusOrRef<Page> Get(PageId id) {
+    return mock_->Get(id);
+  }
+
+  auto MarkAsDirty(PageId id) { return mock_->MarkAsDirty(id); }
+  auto Flush() { return mock_->Flush(); }
+  auto Close() { return mock_->Close(); }
+
+  auto& GetMock() { return *mock_; }
+
+ private:
+  class Mock {
+   public:
+    MOCK_METHOD(StatusOrRef<Page>, Get, (PageId id));
+    MOCK_METHOD(void, MarkAsDirty, (PageId id));
+    MOCK_METHOD(absl::Status, Flush, ());
+    MOCK_METHOD(absl::Status, Close, ());
+  };
+
+  // Mock is wrapped in unique_ptr to allow move semantics.
+  std::unique_ptr<Mock> mock_{std::make_unique<Mock>()};
+};
+
+TEST(PageManager, NewPageProducesFreshIdAndLoadsMatchingPage) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool));
+
+  Page page0;
+  Page page1;
+  EXPECT_CALL(mock, Get(0)).WillOnce(Return(StatusOrRef<Page>(page0)));
+  EXPECT_CALL(mock, Get(1)).WillOnce(Return(StatusOrRef<Page>(page1)));
+
+  EXPECT_THAT(manager.New<Page>(),
+              IsOkAndHolds(FieldsAre(0, testing::Address(&page0))));
+  EXPECT_THAT(manager.New<Page>(),
+              IsOkAndHolds(FieldsAre(1, testing::Address(&page1))));
+}
+
+TEST(PageManager, StartingOffsetOfPageManagerIsUsed) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool), /*next=*/42);
+
+  Page page42;
+  Page page43;
+  EXPECT_CALL(mock, Get(42)).WillOnce(Return(StatusOrRef<Page>(page42)));
+  EXPECT_CALL(mock, Get(43)).WillOnce(Return(StatusOrRef<Page>(page43)));
+
+  EXPECT_THAT(manager.New<Page>(),
+              IsOkAndHolds(FieldsAre(42, testing::Address(&page42))));
+  EXPECT_THAT(manager.New<Page>(),
+              IsOkAndHolds(FieldsAre(43, testing::Address(&page43))));
+}
+
+TEST(PageManager, PageLookupFailureIsForwardedInNew) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool), 12);
+
+  EXPECT_CALL(mock, Get(12)).WillOnce(Return(absl::InternalError("test")));
+  EXPECT_THAT(manager.New<Page>(),
+              StatusIs(absl::StatusCode::kInternal, "test"));
+}
+
+TEST(PageManager, GetIsForwarded) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool));
+
+  Page page;
+  EXPECT_CALL(mock, Get(2)).WillOnce(Return(StatusOrRef<Page>(page)));
+  ASSERT_OK_AND_ASSIGN(Page * ptr, manager.Get<Page>(2));
+  EXPECT_EQ(ptr, &page);
+
+  auto error = absl::InternalError("test");
+  EXPECT_CALL(mock, Get(5)).WillOnce(Return(error));
+  EXPECT_THAT(manager.Get<Page>(5), error);
+}
+
+TEST(PageManager, MarkAsDirtyIsForwarded) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool));
+
+  EXPECT_CALL(mock, MarkAsDirty(2));
+  manager.MarkAsDirty(2);
+}
+
+TEST(PageManager, FlushIsForwarded) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool));
+
+  auto error = absl::InternalError("test");
+  EXPECT_CALL(mock, Flush()).WillOnce(Return(error));
+  EXPECT_THAT(manager.Flush(), error);
+}
+
+TEST(PageManager, CloseIsForwarded) {
+  MockPagePool pool;
+  auto& mock = pool.GetMock();
+  PageManager<MockPagePool> manager(std::move(pool));
+
+  auto error = absl::InternalError("test");
+  EXPECT_CALL(mock, Close()).WillOnce(Return(error));
+  EXPECT_THAT(manager.Close(), error);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds support for closing and re-opening B-tree sets, fixes the marking of dirty pages, and adds a benchmark for the insertion performance of B-tree sets.