### PR TITLE
Generalizes BTree-Set to BTree-Map

### DIFF
--- a/cpp/backend/common/btree/BUILD
+++ b/cpp/backend/common/btree/BUILD
@@ -1,7 +1,49 @@
 cc_library(
+    name = "btree",
+    hdrs = ["btree.h"],
+    deps = [
+        ":nodes",
+        "//backend/common:page_manager",
+        "//common:status_util",
+        "//common:type",
+        "//common:variant_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "btree_map",
+    hdrs = ["btree_map.h"],
+    deps = [
+        ":btree",
+        ":nodes",
+        "//backend/common:page_manager",
+        "//common:status_util",
+        "//common:type",
+        "//common:variant_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "btree_map_test",
+    srcs = ["btree_map_test.cc"],
+    deps = [
+        ":btree_map",
+        ":test_util",
+        "//common:file_util",
+        "//common:status_test_util",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "btree_set",
     hdrs = ["btree_set.h"],
     deps = [
+        ":btree",
         ":nodes",
         "//backend/common:page_manager",
         "//common:status_util",
@@ -17,6 +59,7 @@ cc_test(
     srcs = ["btree_set_test.cc"],
     deps = [
         ":btree_set",
+        ":test_util",
         "//common:file_util",
         "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
@@ -38,6 +81,25 @@ cc_binary(
 )
 
 cc_library(
+    name = "entry",
+    hdrs = ["entry.h"],
+    deps = [
+        "//common:type",
+        "@com_google_absl//absl/base",
+    ],
+)
+
+cc_test(
+    name = "entry_test",
+    srcs = ["entry_test.cc"],
+    deps = [
+        ":entry",
+        "//common:type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "insert_result",
     hdrs = ["insert_result.h"],
     deps = [
@@ -49,6 +111,7 @@ cc_library(
     name = "nodes",
     hdrs = ["nodes.h"],
     deps = [
+        ":entry",
         ":insert_result",
         "//backend/common:page",
         "//backend/common:page_id",
@@ -65,9 +128,17 @@ cc_test(
     name = "nodes_test",
     srcs = ["nodes_test.cc"],
     deps = [
+        ":entry",
         ":nodes",
         "//backend/common:page_manager",
         "//common:status_test_util",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "test_util",
+    testonly = True,
+    srcs = ["test_util.cc"],
+    hdrs = ["test_util.h"],
 )

--- a/cpp/backend/common/btree/btree.h
+++ b/cpp/backend/common/btree/btree.h
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include "absl/status/statusor.h"
+#include "backend/common/btree/entry.h"
+#include "backend/common/btree/nodes.h"
+#include "backend/common/page_manager.h"
+#include "common/type.h"
+#include "common/variant_util.h"
+
+namespace carmen::backend::btree {
+
+// ----------------------------------------------------------------------------
+//                            BTree Declaration
+// ----------------------------------------------------------------------------
+
+// A BTree is an ordered set of entries stored on secondary storage. Each node
+// of the tree is a page of a file. Inner nodes contain list of keys and
+// child-page pointers, while leaf nodes contain sorted list of entries. Entries
+// comprise a key and a value, although the value is ignored if its the Unit
+// type.
+//
+// This BTree implementation is intended to be the common base for the BTreeSet
+// and BTreeMap implementation customizing its parameters for the respective use
+// case. It is not intended to be used directly.
+//
+// This implementation can be customized by the types of Keys and Values to be
+// stored, the page pool implementation to be used for accessing data, and the
+// order in which keys are stored. Also, to ease the testing of deeper trees,
+// the default width of inner nodes and leafs can be overridden.
+template <Trivial Key, Trivial Value, typename PagePool,
+          typename Comparator = std::less<Key>,
+          std::size_t max_keys = 0,      // 0 means as many as fit in a page
+          std::size_t max_elements = 0>  // 0 means as many as fit in a page
+class BTree {
+ public:
+  // Opens the tree stored in the given directory. If no data is found, an empty
+  // tree linked to this directory is created.
+  template <typename Derived>
+  static absl::StatusOr<Derived> Open(std::filesystem::path directory);
+
+  // Get the number of entries in this tree.
+  std::size_t Size() const;
+
+  // Tests whether the given key is contained in this tree.
+  absl::StatusOr<bool> Contains(const Key& key) const;
+
+  // Flushes all pending changes to disk.
+  absl::Status Flush();
+
+  // Closes this tree by flushing its content and closing the underlying file.
+  // After this, no more operations on the tree will be successful.
+  absl::Status Close();
+
+  // For testing: checks internal invariants of this data structure.
+  absl::Status Check() const;
+
+  // For debugging: Prints the content of this tree to std::cout.
+  void Print() const;
+
+ protected:
+  // Returns the value associated to the given key or std::nullopt if there is
+  // no such key. To mearly check whether an element is present it is more
+  // efficient to use the Contains(..) function, since contains may stop in the
+  // unlikely case of the key being present in an inner node, while find needs
+  // to go all the way to the leaf node to get the value.
+  absl::StatusOr<std::optional<Value>> Find(const Key& key) const;
+
+  // Inserts the given entry. This function is intended to be used by derived
+  // implementations, customized for their use case.
+  absl::StatusOr<bool> Insert(const Entry<Key, Value>& entry);
+
+ private:
+  using LeafNode = btree::LeafNode<Key, Value, Comparator, max_keys>;
+  using InnerNode = btree::InnerNode<LeafNode, max_elements>;
+
+  // A special page type used to store tree meta data. This node type is always
+  // at page 0 of a file.
+  struct MetaData : public btree::internal::Node<MetaData> {
+    PageId root;
+    std::uint64_t num_entries;
+    std::uint32_t height;
+    // TODO: include page manager state!
+  };
+
+  BTree(const MetaData& data, PageManager<PagePool> page_manager);
+
+  // The page ID of the root node.
+  PageId root_id_;
+
+  // The total number of entries stored in this tree.
+  std::uint64_t num_entries_;
+
+  // The node height of this tree. This is the maximum number of nodes that need
+  // to be accessed when navigating from the root to the leaf nodes.
+  std::uint32_t height_;
+
+  // The page manager handling the allocation of nodes (=pages).
+  PageManager<PagePool> page_manager_;
+};
+
+// ----------------------------------------------------------------------------
+//                             BTree Definitions
+// ----------------------------------------------------------------------------
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+template <typename Derived>
+absl::StatusOr<Derived> BTree<Key, Value, PagePool, Comparator, max_keys,
+                              max_elements>::Open(std::filesystem::path path) {
+  ASSIGN_OR_RETURN(auto file, PagePool::File::Open(path));
+  MetaData meta;
+  auto num_pages = file.GetNumPages();
+  if (num_pages == 0) {
+    meta.root = 1;
+    meta.num_entries = 0;
+    meta.height = 0;
+    num_pages++;  // Page 0 is implicitly used for meta data.
+  } else {
+    RETURN_IF_ERROR(file.LoadPage(0, meta));
+  }
+  PagePool pool(std::make_unique<typename PagePool::File>(std::move(file)));
+  return Derived(meta, PageManager(std::move(pool), num_pages + 1));
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::BTree(
+    const MetaData& meta, PageManager<PagePool> page_manager)
+    : root_id_(meta.root),
+      num_entries_(meta.num_entries),
+      height_(meta.height),
+      page_manager_(std::move(page_manager)) {}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+std::size_t
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Size() const {
+  return num_entries_;
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::StatusOr<bool> BTree<Key, Value, PagePool, Comparator, max_keys,
+                           max_elements>::Contains(const Key& key) const {
+  if (height_ > 0) {
+    ASSIGN_OR_RETURN(InnerNode & inner,
+                     page_manager_.template Get<InnerNode>(root_id_));
+    return inner.Contains(height_, key, page_manager_);
+  }
+  ASSIGN_OR_RETURN(LeafNode & leaf,
+                   page_manager_.template Get<LeafNode>(root_id_));
+  return leaf.Contains(key);
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::StatusOr<std::optional<Value>>
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Find(
+    const Key& key) const {
+  if (height_ > 0) {
+    ASSIGN_OR_RETURN(InnerNode & inner,
+                     page_manager_.template Get<InnerNode>(root_id_));
+    return inner.Find(height_, key, page_manager_);
+  }
+  ASSIGN_OR_RETURN(LeafNode & leaf,
+                   page_manager_.template Get<LeafNode>(root_id_));
+  return leaf.Find(key);
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::StatusOr<bool>
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Insert(
+    const Entry<Key, Value>& entry) {
+  btree::InsertResult<Key> result;
+  if (height_ > 0) {
+    ASSIGN_OR_RETURN(InnerNode & inner,
+                     page_manager_.template Get<InnerNode>(root_id_));
+    ASSIGN_OR_RETURN(result,
+                     inner.Insert(root_id_, height_, entry, page_manager_));
+  } else {
+    ASSIGN_OR_RETURN(LeafNode & leaf,
+                     page_manager_.template Get<LeafNode>(root_id_));
+    ASSIGN_OR_RETURN(result, leaf.Insert(root_id_, entry, page_manager_));
+  }
+  return std::visit(
+      match{
+          [&](btree::EntryPresent) -> absl::StatusOr<bool> { return false; },
+          [&](btree::EntryAdded) -> absl::StatusOr<bool> {
+            num_entries_++;
+            return true;
+          },
+          [&](const btree::Split<Key>& split) -> absl::StatusOr<bool> {
+            ASSIGN_OR_RETURN((auto [id, inner]),
+                             page_manager_.template New<InnerNode>());
+            page_manager_.MarkAsDirty(id);
+            inner.Init(root_id_, split.key, split.new_tree);
+            root_id_ = id;
+            height_++;
+            num_entries_++;
+            return true;
+          },
+      },
+      result);
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::Status
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Flush() {
+  ASSIGN_OR_RETURN(MetaData & meta, page_manager_.template Get<MetaData>(0));
+  meta.root = root_id_;
+  meta.num_entries = num_entries_;
+  meta.height = height_;
+  page_manager_.MarkAsDirty(0);
+  return page_manager_.Flush();
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::Status
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Close() {
+  RETURN_IF_ERROR(Flush());
+  return page_manager_.Close();
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+absl::Status
+BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Check() const {
+  if (height_ > 0) {
+    ASSIGN_OR_RETURN(InnerNode & inner,
+                     page_manager_.template Get<InnerNode>(root_id_));
+    return inner.Check(height_, nullptr, nullptr, page_manager_);
+  }
+  ASSIGN_OR_RETURN(LeafNode & leaf,
+                   page_manager_.template Get<LeafNode>(root_id_));
+  return leaf.Check(nullptr, nullptr);
+}
+
+template <Trivial Key, Trivial Value, typename PagePool, typename Comparator,
+          std::size_t max_keys, std::size_t max_elements>
+void BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>::Print()
+    const {
+  if (height_ > 0) {
+    auto inner = page_manager_.template Get<InnerNode>(root_id_);
+    if (!inner.ok()) {
+      std::cout << "Unable to load root node: " << inner.status();
+    }
+    inner->get().Print(height_, 0, page_manager_);
+    return;
+  }
+  auto leaf = page_manager_.template Get<LeafNode>(root_id_);
+  if (!leaf.ok()) {
+    std::cout << "Unable to load root node: " << leaf.status();
+  }
+  leaf->get().Print();
+}
+
+}  // namespace carmen::backend::btree

--- a/cpp/backend/common/btree/btree_map.h
+++ b/cpp/backend/common/btree/btree_map.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <filesystem>
+
+#include "absl/status/statusor.h"
+#include "backend/common/btree/btree.h"
+#include "backend/common/btree/nodes.h"
+#include "backend/common/page_manager.h"
+#include "common/type.h"
+#include "common/variant_util.h"
+
+namespace carmen::backend {
+
+// ----------------------------------------------------------------------------
+//                         BTreeMap Declaration
+// ----------------------------------------------------------------------------
+
+// A BTreeMap is an ordered map of key/value pairs stored on secondary storage.
+// Each node of the tree is a page of a file. Inner nodes contain list of keys
+// and child-page pointers, while leaf nodes contain key/value pairs.
+//
+// This implementation can be customized by the type of key/values to be stored,
+// the page pool implementation to be used for accessing data, and the order in
+// which keys are stored. Also, to ease the testing of deeper trees, the default
+// width of inner nodes and leafs can be overridden.
+template <Trivial Key, Trivial Value, typename PagePool,
+          typename Comparator = std::less<Key>,
+          std::size_t max_keys = 0,      // 0 means as many as fit in a page
+          std::size_t max_elements = 0>  // 0 means as many as fit in a page
+class BTreeMap : public btree::BTree<Key, Value, PagePool, Comparator, max_keys,
+                                     max_elements> {
+  using super =
+      btree::BTree<Key, Value, PagePool, Comparator, max_keys, max_elements>;
+  using entry_t = btree::Entry<Key, Value>;
+
+ public:
+  // Opens the map stored in the given directory. If no data is found, an empty
+  // map is created.
+  static absl::StatusOr<BTreeMap> Open(std::filesystem::path directory) {
+    return super::template Open<BTreeMap>(directory);
+  }
+
+  // Inserts the given key/value pair into this map. If the given key is not yet
+  // present, it will be added, mapped to the given value. If the given key is
+  // present, the content of the map is not changed. Returns true if an element
+  // was inserted, false otherwise.
+  absl::StatusOr<bool> Insert(const Key& key, const Value& value) {
+    return super::Insert(entry_t{key, value});
+  }
+
+  // Attempts to locate the given key in the map and returns the associated
+  // value, or std::nullopt if there is no such key in the map.
+  absl::StatusOr<std::optional<Value>> Find(const Key& key) {
+    return super::Find(key);
+  }
+
+ private:
+  // Inherit the constructors of the generic BTree implementation.
+  using super::BTree;
+};
+
+}  // namespace carmen::backend

--- a/cpp/backend/common/btree/btree_map_test.cc
+++ b/cpp/backend/common/btree/btree_map_test.cc
@@ -1,0 +1,176 @@
+#include "backend/common/btree/btree_map.h"
+
+#include "backend/common/btree/test_util.h"
+#include "backend/common/file.h"
+#include "backend/common/page_pool.h"
+#include "common/file_util.h"
+#include "common/status_test_util.h"
+
+namespace carmen::backend {
+namespace {
+
+using ::testing::IsOkAndHolds;
+using ::testing::Optional;
+
+using TestPagePool = PagePool<InMemoryFile<kFileSystemPageSize>>;
+
+template <Trivial Key, Trivial Value, std::size_t max_keys = 0,
+          std::size_t max_elements = 0>
+using TestBTreeMap = BTreeMap<Key, Value, TestPagePool, std::less<Value>,
+                              max_keys, max_elements>;
+
+TEST(BTreeMap, EmptySetContainsNothing) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto map, (TestBTreeMap<int, int>::Open(dir)));
+
+  EXPECT_THAT(map.Contains(0), false);
+  EXPECT_THAT(map.Contains(1), false);
+  EXPECT_THAT(map.Contains(7), false);
+  EXPECT_THAT(map.Contains(92), false);
+}
+
+TEST(BTreeMap, InsertedElementsCanBeFound) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto map, (TestBTreeMap<int, int>::Open(dir)));
+  EXPECT_THAT(map.Contains(12), false);
+  EXPECT_THAT(map.Contains(14), false);
+  EXPECT_THAT(map.Insert(12, 14), true);
+  EXPECT_THAT(map.Contains(12), true);
+  EXPECT_THAT(map.Contains(14), false);
+}
+
+TEST(BTreeMap, ValuesAssociatedToKeysCanBetFound) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto map, (TestBTreeMap<int, int>::Open(dir)));
+  EXPECT_THAT(map.Insert(1, 2), true);
+  EXPECT_THAT(map.Insert(2, 3), true);
+
+  EXPECT_THAT(map.Find(1), 2);
+  EXPECT_THAT(map.Find(2), 3);
+}
+
+template <typename Tree>
+void RunInsertionAndLookupTest(const std::vector<int>& data) {
+  TempDir dir;
+  ASSERT_OK_AND_ASSIGN(auto set, Tree::Open(dir));
+  for (int i : data) {
+    EXPECT_THAT(set.Insert(i, 2 * i), true);
+    if (auto check = set.Check(); !check.ok()) {
+      std::cout << "After inserting " << i << " ...\n";
+      set.Print();
+      ASSERT_OK(check);
+    }
+  }
+  for (int i : data) {
+    EXPECT_THAT(set.Find(i), IsOkAndHolds(Optional(2 * i))) << "i=" << i;
+  }
+}
+
+TEST(BTreeMap, OrderedInsertsRetainInvariants) {
+  RunInsertionAndLookupTest<TestBTreeMap<int, int>>(GetSequence(10000));
+}
+
+TEST(BTreeMap, OrderedInsertsRetainInvariantsInNarrowTreeWithEvenBranching) {
+  // This is the same as above, but with a tree with a reduced branch width to
+  // stress-test edge cases and splitting.
+  RunInsertionAndLookupTest<TestBTreeMap<int, int, 6, 6>>(GetSequence(10000));
+}
+
+TEST(BTreeMap, OrderedInsertsRetainInvariantsInNarrowTreeWithOddBranching) {
+  // Same as above, but with an odd number of keys / elements.
+  RunInsertionAndLookupTest<TestBTreeMap<int, int, 7, 7>>(GetSequence(10000));
+}
+
+TEST(BTreeMap, RandomInsertsRetainInvariants) {
+  RunInsertionAndLookupTest<TestBTreeMap<int, int>>(
+      Shuffle(GetSequence(10000)));
+}
+
+TEST(BTreeMap, RandomInsertsRetainInvariantsInNarrowTreeWithEvenBranching) {
+  RunInsertionAndLookupTest<TestBTreeMap<int, int, 6, 6>>(
+      Shuffle(GetSequence(10000)));
+}
+
+TEST(BTreeMap, RandomInsertsRetainInvariantsInNarrowTreeWithOddBranching) {
+  RunInsertionAndLookupTest<TestBTreeMap<int, int, 7, 7>>(
+      Shuffle(GetSequence(10000)));
+}
+
+template <typename Map>
+void RunClosingAndReopeningTest() {
+  const int N = 10000;
+  const int S = 3;
+  const int K = 5;
+  TempFile file;
+  std::size_t size;
+
+  // Create a map containing some elements.
+  {
+    ASSERT_OK_AND_ASSIGN(auto map, Map::Open(file));
+    EXPECT_OK(map.Check());
+    for (int i = 0; i < N; i += S) {
+      ASSERT_OK(map.Insert(i, 2 * i));
+    }
+    EXPECT_OK(map.Check());
+    size = map.Size();
+    EXPECT_OK(map.Close());
+  }
+
+  // Reopen the map, check content, and add additional elements.
+  {
+    ASSERT_OK_AND_ASSIGN(auto map, Map::Open(file));
+    EXPECT_OK(map.Check());
+    EXPECT_EQ(map.Size(), size);
+    for (int i = 0; i < N; i++) {
+      bool should_exist = (i % S == 0);
+      EXPECT_THAT(map.Contains(i), should_exist) << "i=" << i;
+      if (should_exist) {
+        EXPECT_THAT(map.Find(i), 2 * i) << "i=" << i;
+        ;
+      } else {
+        EXPECT_THAT(map.Find(i), std::nullopt);
+      }
+    }
+    for (int i = 0; i < N; i += K) {
+      EXPECT_THAT(map.Insert(i, 2 * i), !(i % S == 0));
+    }
+    EXPECT_OK(map.Check());
+    size = map.Size();
+    EXPECT_OK(map.Close());
+  }
+
+  // Reopen a second time to see whether insert on the reopened map was
+  // successful.
+  {
+    ASSERT_OK_AND_ASSIGN(auto map, Map::Open(file));
+    EXPECT_OK(map.Check());
+    EXPECT_EQ(map.Size(), size);
+    for (int i = 0; i < N; i++) {
+      bool should_exist = (i % S == 0 || i % K == 0);
+      EXPECT_THAT(map.Contains(i), should_exist) << "i=" << i;
+      if (should_exist) {
+        EXPECT_THAT(map.Find(i), 2 * i) << "i=" << i;
+        ;
+      } else {
+        EXPECT_THAT(map.Find(i), std::nullopt);
+      }
+    }
+    EXPECT_OK(map.Close());
+  }
+}
+
+TEST(BTreeMap, ClosingAndReopeningProducesSameMap) {
+  using Pool = PagePool<SingleFile<kFileSystemPageSize>>;
+  // Run the test with the maximum number of keys per node.
+  RunClosingAndReopeningTest<BTreeMap<int, int, Pool>>();
+  // Run the tests with small even/odd numbers of keys to test deeper trees.
+  RunClosingAndReopeningTest<BTreeMap<int, int, Pool, std::less<int>, 2, 2>>();
+  RunClosingAndReopeningTest<BTreeMap<int, int, Pool, std::less<int>, 3, 3>>();
+  RunClosingAndReopeningTest<
+      BTreeMap<int, int, Pool, std::less<int>, 11, 10>>();
+  RunClosingAndReopeningTest<
+      BTreeMap<int, int, Pool, std::less<int>, 10, 11>>();
+}
+
+}  // namespace
+}  // namespace carmen::backend

--- a/cpp/backend/common/btree/btree_set.h
+++ b/cpp/backend/common/btree/btree_set.h
@@ -3,6 +3,8 @@
 #include <filesystem>
 
 #include "absl/status/statusor.h"
+#include "backend/common/btree/btree.h"
+#include "backend/common/btree/entry.h"
 #include "backend/common/btree/nodes.h"
 #include "backend/common/page_manager.h"
 #include "common/type.h"
@@ -11,12 +13,13 @@
 namespace carmen::backend {
 
 // ----------------------------------------------------------------------------
-//                         BTreeSet Definitions
+//                         BTreeSet Declaration
 // ----------------------------------------------------------------------------
 
 // A BTreeSet is an ordered set of values stored on secondary storage. Each node
-// of the tree is a page of a file. Inner nodes contain list of keys and
-// child-page pointers, while leaf nodes contain only sorted list of values.
+// of the tree is a page of a file. Inner nodes contain list of values used as
+// keys and child-page pointers, while leaf nodes contain only sorted list of
+// values. Keys stored in inner nodes are not repeated in leave nodes.
 //
 // This implementation can be customized by the type of value to be stored, the
 // page pool implementation to be used for accessing data, and the order in
@@ -26,205 +29,27 @@ template <Trivial Value, typename PagePool,
           typename Comparator = std::less<Value>,
           std::size_t max_keys = 0,      // 0 means as many as fit in a page
           std::size_t max_elements = 0>  // 0 means as many as fit in a page
-class BTreeSet {
+class BTreeSet : public btree::BTree<Value, btree::Unit, PagePool, Comparator,
+                                     max_keys, max_elements> {
+  using super = btree::BTree<Value, btree::Unit, PagePool, Comparator, max_keys,
+                             max_elements>;
+
  public:
   // Opens the set stored in the given directory. If no data is found, an empty
   // set is created.
-  static absl::StatusOr<BTreeSet> Open(std::filesystem::path directory);
-
-  // Get the number of elements in this set.
-  std::size_t Size() const;
-
-  // Tests whether the given element is contained in this set.
-  absl::StatusOr<bool> Contains(const Value& value) const;
+  static absl::StatusOr<BTreeSet> Open(std::filesystem::path directory) {
+    return super::template Open<BTreeSet>(directory);
+  }
 
   // Inserts the given element.
-  absl::StatusOr<bool> Insert(const Value& value);
-
-  // Flushes all pending changes to disk.
-  absl::Status Flush();
-
-  // Closes this set by flushing its content and closing the file. After this,
-  // no more operations on the set will be successful.
-  absl::Status Close();
-
-  // For testing: checks internal invariants of this data structure.
-  absl::Status Check() const;
-
-  // For debugging: Prints the content of this tree to std::cout.
-  void Print() const;
+  absl::StatusOr<bool> Insert(const Value& value) {
+    return super::Insert(value);
+  }
 
  private:
-  using LeafNode = btree::LeafNode<Value, Comparator, max_keys>;
-  using InnerNode = btree::InnerNode<LeafNode, max_elements>;
-
-  // A special page type used to store set meta data. This node type is always
-  // at page 0 of a file.
-  struct MetaData : public btree::internal::Node<MetaData> {
-    PageId root;
-    std::uint64_t num_elements;
-    std::uint32_t height;
-    // TODO: include page manager state!
-  };
-
-  BTreeSet(const MetaData& data, PageManager<PagePool> page_manager);
-
-  // The page ID of the root node.
-  PageId root_id_;
-
-  // The total number of elements stored in this tree.
-  std::uint64_t num_elements_;
-
-  // The node height of this tree. This is the maximum number of nodes that need
-  // to be accessed when navigating from the root to the leaf nodes.
-  std::uint32_t height_;
-
-  // The page manager handling the allocation of nodes (=pages).
-  PageManager<PagePool> page_manager_;
+  // Inherit the constructors of the generic BTree implementation.
+  using btree::BTree<Value, btree::Unit, PagePool, Comparator, max_keys,
+                     max_elements>::BTree;
 };
-
-// ----------------------------------------------------------------------------
-//                           BTreeSet Definitions
-// ----------------------------------------------------------------------------
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::StatusOr<BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>>
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Open(
-    std::filesystem::path path) {
-  ASSIGN_OR_RETURN(auto file, PagePool::File::Open(path));
-  MetaData meta;
-  auto num_pages = file.GetNumPages();
-  if (num_pages == 0) {
-    meta.root = 1;
-    meta.num_elements = 0;
-    meta.height = 0;
-    num_pages++;  // Page 0 is implicitly used for meta data.
-  } else {
-    RETURN_IF_ERROR(file.LoadPage(0, meta));
-  }
-  PagePool pool(std::make_unique<typename PagePool::File>(std::move(file)));
-  return BTreeSet(meta, PageManager(std::move(pool), num_pages + 1));
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::BTreeSet(
-    const MetaData& meta, PageManager<PagePool> page_manager)
-    : root_id_(meta.root),
-      num_elements_(meta.num_elements),
-      height_(meta.height),
-      page_manager_(std::move(page_manager)) {}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-std::size_t
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Size() const {
-  return num_elements_;
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::StatusOr<bool>
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Contains(
-    const Value& value) const {
-  if (height_ > 0) {
-    ASSIGN_OR_RETURN(InnerNode & inner,
-                     page_manager_.template Get<InnerNode>(root_id_));
-    return inner.Contains(height_, value, page_manager_);
-  }
-  ASSIGN_OR_RETURN(LeafNode & leaf,
-                   page_manager_.template Get<LeafNode>(root_id_));
-  return leaf.Contains(value);
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::StatusOr<bool> BTreeSet<Value, PagePool, Comparator, max_keys,
-                              max_elements>::Insert(const Value& value) {
-  btree::InsertResult<Value> result;
-  if (height_ > 0) {
-    ASSIGN_OR_RETURN(InnerNode & inner,
-                     page_manager_.template Get<InnerNode>(root_id_));
-    ASSIGN_OR_RETURN(result,
-                     inner.Insert(root_id_, height_, value, page_manager_));
-  } else {
-    ASSIGN_OR_RETURN(LeafNode & leaf,
-                     page_manager_.template Get<LeafNode>(root_id_));
-    ASSIGN_OR_RETURN(result, leaf.Insert(root_id_, value, page_manager_));
-  }
-  return std::visit(
-      match{
-          [&](btree::ElementPresent) -> absl::StatusOr<bool> { return false; },
-          [&](btree::ElementAdded) -> absl::StatusOr<bool> {
-            num_elements_++;
-            return true;
-          },
-          [&](const btree::Split<Value>& split) -> absl::StatusOr<bool> {
-            ASSIGN_OR_RETURN((auto [id, inner]),
-                             page_manager_.template New<InnerNode>());
-            page_manager_.MarkAsDirty(id);
-            inner.Init(root_id_, split.key, split.new_tree);
-            root_id_ = id;
-            height_++;
-            num_elements_++;
-            return true;
-          },
-      },
-      result);
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::Status
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Flush() {
-  ASSIGN_OR_RETURN(MetaData & meta, page_manager_.template Get<MetaData>(0));
-  meta.root = root_id_;
-  meta.num_elements = num_elements_;
-  meta.height = height_;
-  page_manager_.MarkAsDirty(0);
-  return page_manager_.Flush();
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::Status
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Close() {
-  RETURN_IF_ERROR(Flush());
-  return page_manager_.Close();
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-absl::Status
-BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Check() const {
-  if (height_ > 0) {
-    ASSIGN_OR_RETURN(InnerNode & inner,
-                     page_manager_.template Get<InnerNode>(root_id_));
-    return inner.Check(height_, nullptr, nullptr, page_manager_);
-  }
-  ASSIGN_OR_RETURN(LeafNode & leaf,
-                   page_manager_.template Get<LeafNode>(root_id_));
-  return leaf.Check(nullptr, nullptr);
-}
-
-template <Trivial Value, typename PagePool, typename Comparator,
-          std::size_t max_keys, std::size_t max_elements>
-void BTreeSet<Value, PagePool, Comparator, max_keys, max_elements>::Print()
-    const {
-  if (height_ > 0) {
-    auto inner = page_manager_.template Get<InnerNode>(root_id_);
-    if (!inner.ok()) {
-      std::cout << "Unable to load root node: " << inner.status();
-    }
-    inner->get().Print(height_, 0, page_manager_);
-    return;
-  }
-  auto leaf = page_manager_.template Get<LeafNode>(root_id_);
-  if (!leaf.ok()) {
-    std::cout << "Unable to load root node: " << leaf.status();
-  }
-  leaf->get().Print();
-}
 
 }  // namespace carmen::backend

--- a/cpp/backend/common/btree/btree_set_test.cc
+++ b/cpp/backend/common/btree/btree_set_test.cc
@@ -1,10 +1,8 @@
 #include "backend/common/btree/btree_set.h"
 
-#include <algorithm>
-#include <initializer_list>
-#include <ostream>
 #include <vector>
 
+#include "backend/common/btree/test_util.h"
 #include "backend/common/file.h"
 #include "backend/common/page_pool.h"
 #include "common/file_util.h"
@@ -44,21 +42,6 @@ TEST(BTreeSet, InsertingZeroWorks) {
   EXPECT_THAT(set.Contains(0), false);
   EXPECT_THAT(set.Insert(0), true);
   EXPECT_THAT(set.Contains(0), true);
-}
-
-std::vector<int> GetSequence(int size) {
-  std::vector<int> data;
-  for (int i = 0; i < size; i++) {
-    data.push_back(i);
-  }
-  return data;
-}
-
-std::vector<int> Shuffle(std::vector<int> data) {
-  std::random_device rd;
-  std::mt19937 g(rd());
-  std::shuffle(data.begin(), data.end(), g);
-  return data;
 }
 
 template <typename Tree>
@@ -131,7 +114,7 @@ void RunClosingAndReopeningTest() {
       EXPECT_THAT(set.Contains(i), i % S == 0) << "i=" << i;
     }
     for (int i = 0; i < N; i += K) {
-      ASSERT_OK(set.Insert(i));
+      EXPECT_THAT(set.Insert(i), !(i % S == 0));
     }
     EXPECT_OK(set.Check());
     size = set.Size();

--- a/cpp/backend/common/btree/entry.h
+++ b/cpp/backend/common/btree/entry.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <ostream>
+
+#include "absl/base/attributes.h"
+#include "common/type.h"
+
+namespace carmen::backend::btree {
+
+// A struct with the distinct feature of being empty. It is called unit because
+// there is exactly one value of this type. It is used to mark the absense of a
+// value in the entry type below.
+struct Unit {};
+
+// An entry of a B-tree comprised of a key and an optional value. The key and
+// value are packed tightly to avoid increasing memory and storage consumption
+// due to padding.
+template <Trivial Key, Trivial Value = Unit>
+struct ABSL_ATTRIBUTE_PACKED Entry {
+  Entry() = default;
+  Entry(Key key) : key(key){};
+  Entry(Key key, Value value) : key(key), value(value){};
+
+  bool operator==(const Entry&) const = default;
+
+  friend std::ostream& operator<<(std::ostream& out, const Entry& entry) {
+    return out << entry.key << "->" << entry.value;
+  }
+
+  Key key;
+  Value value;
+};
+
+// A specialization of an entry without a value. Removing the extra value field
+// removes 1 byte of storage requirement for the empty value.
+template <typename Key>
+struct ABSL_ATTRIBUTE_PACKED Entry<Key, Unit> {
+  Entry() = default;
+  Entry(Key key) : key(key) {}
+
+  bool operator==(const Entry&) const = default;
+
+  friend std::ostream& operator<<(std::ostream& out, const Entry& entry) {
+    return out << entry.key;
+  }
+
+  Key key;
+};
+
+}  // namespace carmen::backend::btree

--- a/cpp/backend/common/btree/entry_test.cc
+++ b/cpp/backend/common/btree/entry_test.cc
@@ -1,0 +1,36 @@
+#include "backend/common/btree/entry.h"
+
+#include <cstdint>
+
+#include "common/type.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace carmen::backend::btree {
+namespace {
+
+TEST(Entry, SizeOfKeyOnly) {
+  EXPECT_EQ(sizeof(Entry<std::uint8_t>), sizeof(std::uint8_t));
+  EXPECT_EQ(sizeof(Entry<std::uint16_t>), sizeof(std::uint16_t));
+  EXPECT_EQ(sizeof(Entry<std::uint32_t>), sizeof(std::uint32_t));
+  EXPECT_EQ(sizeof(Entry<std::uint64_t>), sizeof(std::uint64_t));
+}
+
+TEST(Entry, SizeOfKeyValuePair) {
+  EXPECT_EQ((sizeof(Entry<std::uint8_t, std::uint8_t>)), 2);
+  EXPECT_EQ((sizeof(Entry<std::uint16_t, std::uint8_t>)), 3);
+  EXPECT_EQ((sizeof(Entry<std::uint16_t, std::uint16_t>)), 4);
+  EXPECT_EQ((sizeof(Entry<std::uint32_t, std::uint8_t>)), 5);
+  EXPECT_EQ((sizeof(Entry<std::uint8_t, std::uint32_t>)), 5);
+
+  EXPECT_EQ((sizeof(Entry<Address, Value>)), 20 + 32);
+}
+
+TEST(Entry, EntriesAreTrivial) {
+  EXPECT_TRUE((Trivial<Entry<int>>));
+  EXPECT_TRUE((Trivial<Entry<int, int>>));
+  EXPECT_TRUE((Trivial<Entry<Address, Value>>));
+}
+
+}  // namespace
+}  // namespace carmen::backend::btree

--- a/cpp/backend/common/btree/insert_result.h
+++ b/cpp/backend/common/btree/insert_result.h
@@ -14,42 +14,42 @@ namespace carmen::backend::btree {
 // This file defines the type returned by recursive internal BTree insert
 // operations indicating the effect of the insertion to the parent. This could
 // be one of the following cases:
-//   - the element was present, no insert occured
-//   - the element was added, no split necessary
-//   - the element was added, but this triggered a split that needs to be
+//   - the entry was present, no insert occured
+//   - the entry was added, no split necessary
+//   - the entry was added, but this triggered a split that needs to be
 //     handled by the parent
 
-// This is the type of result returned if an inserted element was present.
-struct ElementPresent {
-  auto operator<=>(const ElementPresent&) const = default;
+// The result returned if an entry with the same key was already present.
+struct EntryPresent {
+  auto operator<=>(const EntryPresent&) const = default;
 };
 
-// This is the type of result returned if an element was added without a split.
-struct ElementAdded {
-  auto operator<=>(const ElementAdded&) const = default;
+// The result returned if an entry was added without a split.
+struct EntryAdded {
+  auto operator<=>(const EntryAdded&) const = default;
 };
 
-// This is the type of result returned when an insertion triggered a split.
-template <typename V>
+// The result returned when an insertion triggered a split.
+template <typename Key>
 struct Split {
-  auto operator<=>(const Split<V>&) const = default;
+  auto operator<=>(const Split<Key>&) const = default;
   // The key to be used to in the parent node to distinguish between the node
   // the element was inserted and the new tree returned. Both, the key and the
   // new tree should be inserted in one of the anchester nodes.
-  V key;
+  Key key;
   // The PageId of the root of the tree created by the split, to be inserted in
   // some parent node.
   PageId new_tree;
 
   // Make splits human readable in test assertions.
   friend std::ostream& operator<<(std::ostream& out,
-                                  const btree::Split<V>& split) {
+                                  const btree::Split<Key>& split) {
     return out << "Split{" << split.key << "," << split.new_tree << "}";
   }
 };
 
 // The type combining the possible insert results.
-template <typename V>
-using InsertResult = std::variant<ElementPresent, ElementAdded, Split<V>>;
+template <typename Key>
+using InsertResult = std::variant<EntryPresent, EntryAdded, Split<Key>>;
 
 }  // namespace carmen::backend::btree

--- a/cpp/backend/common/btree/nodes_test.cc
+++ b/cpp/backend/common/btree/nodes_test.cc
@@ -69,10 +69,10 @@ StatusOrRef<Inner> Create(TestPageManager& manager,
   ASSIGN_OR_RETURN((auto [left_id, left_leaf]), manager.New<Leaf>());
   ASSIGN_OR_RETURN((auto [right_id, right_leaf]), manager.New<Leaf>());
   for (int cur : left) {
-    EXPECT_THAT(left_leaf.Insert(left_id, cur, manager), ElementAdded{});
+    EXPECT_THAT(left_leaf.Insert(left_id, cur, manager), EntryAdded{});
   }
   for (int cur : right) {
-    EXPECT_THAT(right_leaf.Insert(right_id, cur, manager), ElementAdded{});
+    EXPECT_THAT(right_leaf.Insert(right_id, cur, manager), EntryAdded{});
   }
   inner.Init(left_id, key, right_id);
   return inner;
@@ -88,7 +88,7 @@ StatusOrRef<Inner> Create(TestPageManager& manager,
   ASSIGN_OR_RETURN(Inner & result, Create<Inner>(manager, a, k1, b));
   ASSIGN_OR_RETURN((auto [id, leaf]), manager.New<typename Inner::leaf_t>());
   for (int cur : c) {
-    EXPECT_THAT(leaf.Insert(id, cur, manager), ElementAdded{});
+    EXPECT_THAT(leaf.Insert(id, cur, manager), EntryAdded{});
   }
   result.Append(k2, id);
   return result;
@@ -105,7 +105,7 @@ StatusOrRef<Inner> Create(TestPageManager& manager,
   ASSIGN_OR_RETURN(Inner & result, Create<Inner>(manager, a, k1, b, k2, c));
   ASSIGN_OR_RETURN((auto [id, leaf]), manager.New<typename Inner::leaf_t>());
   for (int cur : d) {
-    EXPECT_THAT(leaf.Insert(id, cur, manager), ElementAdded{});
+    EXPECT_THAT(leaf.Insert(id, cur, manager), EntryAdded{});
   }
   result.Append(k3, id);
   return result;
@@ -172,7 +172,16 @@ struct Tree<0> {
   template <Page Inner, typename PageManager>
   PageId Build(PageManager& manager) const {
     auto [id, node] = *manager.template New<typename Inner::leaf_t>();
-    node.SetTestElements(values);
+    using entry_t = typename Inner::leaf_t::entry_t;
+    std::vector<entry_t> entries;
+    for (auto cur : values) {
+      if constexpr (std::is_same_v<entry_t, Entry<int, int>>) {
+        entries.push_back(entry_t(cur, cur));
+      } else {
+        entries.push_back(entry_t(cur));
+      }
+    }
+    node.SetTestEntries(entries);
     return id;
   }
 
@@ -265,8 +274,8 @@ template <std::size_t level, typename Node, typename PageManager>
 Tree<level> ToTree(const Node& node, PageManager& manager) {
   if constexpr (level == 0) {
     Tree<0> result;
-    for (int cur : node.GetElements()) {
-      result.values.push_back(cur);
+    for (auto cur : node.GetEntries()) {
+      result.values.push_back(cur.key);
     }
     return result;
   } else {
@@ -294,240 +303,294 @@ Tree<level> ToTree(const Node& node, PageManager& manager) {
 // ----------------------------------------------------------------------------
 
 TEST(LeafNode, IsPage) {
-  EXPECT_TRUE(Page<LeafNode<int>>);
-  EXPECT_EQ(sizeof(LeafNode<int>), kFileSystemPageSize);
+  EXPECT_TRUE((Page<LeafNode<int, Unit>>));
+  EXPECT_EQ(sizeof(LeafNode<int, Unit>), kFileSystemPageSize);
 
-  EXPECT_TRUE((Page<LeafNode<int, std::less<int>, 4>>));
-  EXPECT_EQ(sizeof(LeafNode<int, std::less<int>, 4>), kFileSystemPageSize);
+  EXPECT_TRUE((Page<LeafNode<int, int>>));
+  EXPECT_EQ(sizeof(LeafNode<int, int>), kFileSystemPageSize);
 
-  EXPECT_TRUE(Page<LeafNode<Value>>);
-  EXPECT_EQ(sizeof(LeafNode<Value>), kFileSystemPageSize);
+  EXPECT_TRUE((Page<LeafNode<int, Unit, std::less<int>, 4>>));
+  EXPECT_EQ(sizeof(LeafNode<int, Unit, std::less<int>, 4>),
+            kFileSystemPageSize);
 
-  EXPECT_TRUE((Page<LeafNode<Value, std::less<Value>, 4>>));
-  EXPECT_EQ(sizeof(LeafNode<Value, std::less<Value>, 4>), kFileSystemPageSize);
+  EXPECT_TRUE((Page<LeafNode<int, double, std::less<int>, 4>>));
+  EXPECT_EQ(sizeof(LeafNode<int, double, std::less<int>, 4>),
+            kFileSystemPageSize);
+
+  EXPECT_TRUE((Page<LeafNode<Value, Unit>>));
+  EXPECT_EQ(sizeof(LeafNode<Value, Unit>), kFileSystemPageSize);
+
+  EXPECT_TRUE((Page<LeafNode<Value, Unit, std::less<Value>, 4>>));
+  EXPECT_EQ(sizeof(LeafNode<Value, Unit, std::less<Value>, 4>),
+            kFileSystemPageSize);
 }
 
 TEST(LeafNode, DefaultMaxElementsUsesFullNodeSize) {
   EXPECT_EQ(
-      LeafNode<std::uint8_t>::kMaxElements,
+      (LeafNode<std::uint8_t, Unit>::kMaxEntries),
       (kFileSystemPageSize - sizeof(std::uint16_t)) / sizeof(std::uint8_t));
   EXPECT_EQ(
-      LeafNode<std::uint64_t>::kMaxElements,
+      (LeafNode<std::uint64_t, Unit>::kMaxEntries),
       (kFileSystemPageSize - sizeof(std::uint16_t)) / sizeof(std::uint64_t));
+
+  EXPECT_EQ((LeafNode<std::uint8_t, std::uint16_t>::kMaxEntries),
+            (kFileSystemPageSize - sizeof(std::uint16_t)) /
+                (sizeof(std::uint8_t) + sizeof(std::uint16_t)));
 }
 
 TEST(LeafNode, ZeroInitializedNodeIsEmpty) {
   TestPageManager manager;
   auto& leaf = manager.Create<LeafNode<int>>();
-  EXPECT_THAT(leaf.GetElements(), IsEmpty());
+  EXPECT_THAT(leaf.GetEntries(), IsEmpty());
 }
 
 TEST(LeafNode, InsertedElementsAreOrdered) {
   using Leaf = LeafNode<int>;
   TestPageManager manager;
-  ASSERT_GT(Leaf::kMaxElements, 5);
+  ASSERT_GT(Leaf::kMaxEntries, 5);
 
   auto& leaf = manager.Create<Leaf>();
-  EXPECT_THAT(leaf.GetElements(), IsEmpty());
+  EXPECT_THAT(leaf.GetEntries(), IsEmpty());
 
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(2));
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(2));
 
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
 
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 4));
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 4));
 
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 3, 4));
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 3, 4));
 }
 
 TEST(LeafNode, InsertionOrderCanBeCustomized) {
-  using Leaf = LeafNode<int, std::greater<int>>;
+  using Leaf = LeafNode<int, Unit, std::greater<int>>;
   TestPageManager manager;
-  ASSERT_GT(Leaf::kMaxElements, 5);
+  ASSERT_GT(Leaf::kMaxEntries, 5);
 
   auto& leaf = manager.Create<Leaf>();
-  EXPECT_THAT(leaf.GetElements(), IsEmpty());
+  EXPECT_THAT(leaf.GetEntries(), IsEmpty());
 
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(2));
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(2));
 
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(2, 1));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(2, 1));
 
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(4, 2, 1));
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(4, 2, 1));
 
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(4, 3, 2, 1));
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(4, 3, 2, 1));
 }
 
 TEST(LeafNode, DuplicateElementsAreIgnored) {
   using Leaf = LeafNode<int>;
   TestPageManager manager;
-  ASSERT_GT(Leaf::kMaxElements, 5);
+  ASSERT_GT(Leaf::kMaxEntries, 5);
 
   auto& leaf = manager.Create<Leaf>();
-  EXPECT_THAT(leaf.GetElements(), IsEmpty());
+  EXPECT_THAT(leaf.GetEntries(), IsEmpty());
 
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
 
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementPresent{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryPresent{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
 
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementPresent{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryPresent{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
 }
 
 TEST(LeafNode, InsertionTriggersSplitIfTooFull) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 4);
+  ASSERT_EQ(Leaf::kMaxEntries, 4);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 3, 4));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 3, 4));
 
   // The next element triggers a split.
   EXPECT_THAT(leaf.Insert(0, 5, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4, 5));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4, 5));
 }
 
 TEST(LeafNode, SplitWithElementOnTheRightIsBalanced) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 4);
+  ASSERT_EQ(Leaf::kMaxEntries, 4);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 5, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 3, 4, 5));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 5, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 3, 4, 5));
 
   // Trigger the split with an element that should end up on the left.
   EXPECT_THAT(leaf.Insert(0, 2, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4, 5));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4, 5));
 }
 
 TEST(LeafNode, NewElementCanBeTheSplitKey) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 4);
+  ASSERT_EQ(Leaf::kMaxEntries, 4);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 5, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 4, 5));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 5, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 4, 5));
 
   // Trigger the split with an element that should end up on the left.
   EXPECT_THAT(leaf.Insert(0, 3, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4, 5));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4, 5));
 }
 
 TEST(LeafNode, SplittingOddCapacityNodeLeadsToLargerLeftNode_InsertLeft) {
-  using Leaf = LeafNode<int, std::less<int>, 3>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 3>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 3);
+  ASSERT_EQ(Leaf::kMaxEntries, 3);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 3, 4));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 3, 4));
 
   // Trigger the split with an element that should end up on the left.
   EXPECT_THAT(leaf.Insert(0, 2, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4));
 }
 
 TEST(LeafNode, SplittingOddCapacityNodeLeadsToLargerLeftNode_InsertRight) {
-  using Leaf = LeafNode<int, std::less<int>, 3>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 3>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 3);
+  ASSERT_EQ(Leaf::kMaxEntries, 3);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 3, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 3));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 3, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 3));
 
   // Trigger the split with an element that should end up on the left.
   EXPECT_THAT(leaf.Insert(0, 4, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4));
 }
 
 TEST(LeafNode, SplittingOddCapacityNodeLeadsToLargerLeftNode_InsertCenter) {
-  using Leaf = LeafNode<int, std::less<int>, 3>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 3>;
   TestPageManager manager;
-  ASSERT_EQ(Leaf::kMaxElements, 3);
+  ASSERT_EQ(Leaf::kMaxEntries, 3);
 
   auto& leaf = manager.Create<Leaf>();
 
   // Fill the leaf to the limit.
-  EXPECT_THAT(leaf.Insert(0, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 2, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(0, 4, manager), ElementAdded{});
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2, 4));
+  EXPECT_THAT(leaf.Insert(0, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 2, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(0, 4, manager), EntryAdded{});
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 4));
 
   // Trigger the split with an element that should end up on the left.
   EXPECT_THAT(leaf.Insert(0, 3, manager), (Split<int>{3, PageId(1)}));
-  EXPECT_THAT(leaf.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
-  EXPECT_THAT(overflow.GetElements(), ElementsAre(4));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(4));
+}
+
+TEST(LeafNode, SplittingMapLeafsKeepsCopyOfKeyInLeaf) {
+  using Leaf = LeafNode<int, int, std::less<int>, 4>;
+  using E = typename Leaf::entry_t;
+  TestPageManager manager;
+  ASSERT_EQ(Leaf::kMaxEntries, 4);
+
+  // Create a full map leaf.
+  auto& leaf = Create<Leaf>(manager, Node(1, 2, 4, 5));
+  EXPECT_THAT(leaf.GetEntries(),
+              ElementsAre(E(1, 1), E(2, 2), E(4, 4), E(5, 5)));
+
+  // The next element triggers a split, but all keys remain in leafs.
+  EXPECT_THAT(leaf.Insert(0, E(3, 3), manager), (Split<int>{4, PageId(1)}));
+  EXPECT_THAT(leaf.GetEntries(), ElementsAre(E(1, 1), E(2, 2), E(3, 3)));
+  ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
+  EXPECT_THAT(overflow.GetEntries(), ElementsAre(E(4, 4), E(5, 5)));
+}
+
+TEST(LeafNode, SplittingMapLeafsRemainsBalancedForEvenLength) {
+  using Leaf = LeafNode<int, int, std::less<int>, 4>;
+  using E = typename Leaf::entry_t;
+  for (int i = 1; i <= 5; i++) {
+    TestPageManager manager;
+    ASSERT_EQ(Leaf::kMaxEntries, 4);
+
+    // Fill the leaf to the limit with all elements except i.
+    auto& leaf = manager.Create<Leaf>();
+    for (int j = 1; j <= 5; j++) {
+      if (i != j) {
+        EXPECT_THAT(leaf.Insert(0, E(j, j), manager), EntryAdded{});
+      }
+    }
+
+    // Inserting i triggers the split, the result should always be the same.
+    EXPECT_THAT(leaf.Insert(0, E(i, i), manager), (Split<int>{4, PageId(1)}));
+    EXPECT_THAT(leaf.GetEntries(), ElementsAre(E(1, 1), E(2, 2), E(3, 3)));
+    ASSERT_OK_AND_ASSIGN(Leaf & overflow, manager.Get<Leaf>(1));
+    EXPECT_THAT(overflow.GetEntries(), ElementsAre(E(4, 4), E(5, 5)));
+  }
 }
 
 TEST(LeafNode, InsertingNewElementMarksPageAsDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 3>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 3>;
   MockPageManager manager;
   auto& leaf = Create<Leaf>(manager, Node());
 
   EXPECT_CALL(manager, MarkAsDirty(12)).Times(2);  // once per insert
 
-  EXPECT_THAT(leaf.Insert(12, 1, manager), ElementAdded{});
-  EXPECT_THAT(leaf.Insert(12, 2, manager), ElementAdded{});
+  EXPECT_THAT(leaf.Insert(12, 1, manager), EntryAdded{});
+  EXPECT_THAT(leaf.Insert(12, 2, manager), EntryAdded{});
 }
 
 TEST(LeafNode, InsertingExistingElementDoesNotMarkNodeAsDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 3>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 3>;
   MockPageManager manager;
   auto& leaf = Create<Leaf>(manager, Node(1));
 
   EXPECT_CALL(manager, MarkAsDirty(12)).Times(0);  // No call expected.
-  EXPECT_THAT(leaf.Insert(12, 1, manager), ElementPresent{});
+  EXPECT_THAT(leaf.Insert(12, 1, manager), EntryPresent{});
 }
 
 TEST(LeafNode, SplitMarksOldAndNewNodeDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   testing::NiceMock<MockPageManager> manager;
   auto& leaf = Create<Leaf>(manager, Node(1, 2));
 
@@ -538,7 +601,7 @@ TEST(LeafNode, SplitMarksOldAndNewNodeDirty) {
 
 TEST(LeafNode, ContainsFindsPresentElements) {
   using Leaf = LeafNode<int>;
-  auto data = GetRandomSequence<int>(Leaf::kMaxElements);
+  auto data = GetRandomSequence<int>(Leaf::kMaxEntries);
 
   TestPageManager manager;
   auto& leaf = manager.Create<Leaf>();
@@ -546,7 +609,7 @@ TEST(LeafNode, ContainsFindsPresentElements) {
     for (std::size_t j = 0; j < data.size(); j++) {
       EXPECT_THAT(leaf.Contains(data[j]), j < i);
     }
-    EXPECT_THAT(leaf.Insert(0, data[i], manager), ElementAdded{});
+    EXPECT_THAT(leaf.Insert(0, data[i], manager), EntryAdded{});
     for (std::size_t j = 0; j < data.size(); j++) {
       EXPECT_THAT(leaf.Contains(data[j]), j <= i);
     }
@@ -554,7 +617,7 @@ TEST(LeafNode, ContainsFindsPresentElements) {
 }
 
 TEST(LeafNode, CheckAcceptsAnyNumberOfElementsInRoot) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
   auto& leaf = manager.Create<Leaf>();
 
@@ -568,7 +631,7 @@ TEST(LeafNode, CheckAcceptsAnyNumberOfElementsInRoot) {
 }
 
 TEST(LeafNode, CheckDetectsTooFewElementsForInnerNodes) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
   auto& leaf = manager.Create<Leaf>();
 
@@ -576,41 +639,39 @@ TEST(LeafNode, CheckDetectsTooFewElementsForInnerNodes) {
   const int high = 10;
   EXPECT_THAT(
       leaf.Check(&low, &high),
-      StatusIs(
-          kInternal,
-          StrEq("Invalid number of elements, expected at least 2, got 0")));
+      StatusIs(kInternal,
+               StrEq("Invalid number of entries, expected at least 2, got 0")));
 
   EXPECT_OK(leaf.Insert(0, 1, manager));
   EXPECT_THAT(
       leaf.Check(&low, &high),
-      StatusIs(
-          kInternal,
-          StrEq("Invalid number of elements, expected at least 2, got 1")));
+      StatusIs(kInternal,
+               StrEq("Invalid number of entries, expected at least 2, got 1")));
 
   EXPECT_OK(leaf.Insert(0, 2, manager));
   EXPECT_OK(leaf.Check(&low, &high));
 }
 
 TEST(LeafNode, OrderInconsistenciesAreDetected) {
-  using Leaf = LeafNode<int, std::less<int>>;
+  using Leaf = LeafNode<int, Unit, std::less<int>>;
   TestPageManager manager;
   auto& leaf = Create<Leaf>(manager, Node(1, 3, 2, 4));
-  ASSERT_THAT(leaf.GetElements(), ElementsAre(1, 3, 2, 4));
+  ASSERT_THAT(leaf.GetEntries(), ElementsAre(1, 3, 2, 4));
   EXPECT_THAT(leaf.Check(nullptr, nullptr),
-              StatusIs(kInternal, StrEq("Invalid order of elements")));
+              StatusIs(kInternal, StrEq("Invalid order of entries")));
 }
 
 TEST(LeafNode, DuplicatedElementsAreDetectedAsOrderInconsistencies) {
-  using Leaf = LeafNode<int, std::less<int>>;
+  using Leaf = LeafNode<int, Unit, std::less<int>>;
   TestPageManager manager;
   auto& leaf = Create<Leaf>(manager, Node(1, 2, 2, 4));
-  ASSERT_THAT(leaf.GetElements(), ElementsAre(1, 2, 2, 4));
+  ASSERT_THAT(leaf.GetEntries(), ElementsAre(1, 2, 2, 4));
   EXPECT_THAT(leaf.Check(nullptr, nullptr),
-              StatusIs(kInternal, StrEq("Invalid order of elements")));
+              StatusIs(kInternal, StrEq("Invalid order of entries")));
 }
 
 TEST(LeafNode, BoundViolationsAreDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   TestPageManager manager;
   auto& leaf = manager.Create<Leaf>();
 
@@ -624,11 +685,11 @@ TEST(LeafNode, BoundViolationsAreDetected) {
   limit = 1;
   EXPECT_THAT(
       leaf.Check(&limit, nullptr),
-      StatusIs(_, StrEq("Lower boundary is not less than smallest element")));
+      StatusIs(_, StrEq("Lower boundary is not less than smallest entry")));
   limit = 3;
   EXPECT_THAT(
       leaf.Check(nullptr, &limit),
-      StatusIs(_, StrEq("Biggest element is not less than upper boundary")));
+      StatusIs(_, StrEq("Biggest entry is not less than upper boundary")));
   limit = 4;
   EXPECT_OK(leaf.Check(nullptr, &limit));
 }
@@ -659,7 +720,7 @@ TEST(InnerNode, CapacityFillsFullNode) {
 }
 
 TEST(TestInfrastructure, TreeStructureUtilsWork) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
 
@@ -671,97 +732,97 @@ TEST(TestInfrastructure, TreeStructureUtilsWork) {
 }
 
 TEST(InnerNode, InsertingElementsToTheLeftChildWorks) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node, Create<Inner>(manager, {1, 3}, 5, {7, 9}));
   ASSERT_OK_AND_ASSIGN(Leaf & left, manager.Get<Leaf>(node.GetChildren()[0]));
   ASSERT_OK_AND_ASSIGN(Leaf & right, manager.Get<Leaf>(node.GetChildren()[1]));
-  EXPECT_THAT(node.Insert(0, 1, 2, manager), ElementAdded{});
-  EXPECT_THAT(left.GetElements(), ElementsAre(1, 2, 3));
-  EXPECT_THAT(right.GetElements(), ElementsAre(7, 9));
+  EXPECT_THAT(node.Insert(0, 1, 2, manager), EntryAdded{});
+  EXPECT_THAT(left.GetEntries(), ElementsAre(1, 2, 3));
+  EXPECT_THAT(right.GetEntries(), ElementsAre(7, 9));
 }
 
 TEST(InnerNode, InsertingElementsToTheRightChildWorks) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node, Create<Inner>(manager, {1, 3}, 5, {7, 9}));
   ASSERT_OK_AND_ASSIGN(Leaf & left, manager.Get<Leaf>(node.GetChildren()[0]));
   ASSERT_OK_AND_ASSIGN(Leaf & right, manager.Get<Leaf>(node.GetChildren()[1]));
-  EXPECT_THAT(node.Insert(0, 1, 8, manager), ElementAdded{});
-  EXPECT_THAT(left.GetElements(), ElementsAre(1, 3));
-  EXPECT_THAT(right.GetElements(), ElementsAre(7, 8, 9));
+  EXPECT_THAT(node.Insert(0, 1, 8, manager), EntryAdded{});
+  EXPECT_THAT(left.GetEntries(), ElementsAre(1, 3));
+  EXPECT_THAT(right.GetEntries(), ElementsAre(7, 8, 9));
 }
 
 TEST(InnerNode, InsertingElementsPresentInLeftChildIsDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node, Create<Inner>(manager, {1, 3}, 5, {7, 9}));
-  EXPECT_THAT(node.Insert(0, 1, 3, manager), ElementPresent{});
+  EXPECT_THAT(node.Insert(0, 1, 3, manager), EntryPresent{});
 }
 
 TEST(InnerNode, InsertingElementsPresentAsKeyIsDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node, Create<Inner>(manager, {1, 3}, 5, {7, 9}));
-  EXPECT_THAT(node.Insert(0, 1, 5, manager), ElementPresent{});
+  EXPECT_THAT(node.Insert(0, 1, 5, manager), EntryPresent{});
 }
 
 TEST(InnerNode, InsertingElementsPresentInRightChildIsDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node, Create<Inner>(manager, {1, 3}, 5, {7, 9}));
-  EXPECT_THAT(node.Insert(0, 1, 7, manager), ElementPresent{});
+  EXPECT_THAT(node.Insert(0, 1, 7, manager), EntryPresent{});
 }
 
 TEST(InnerNode, LeftNodeSplitExtendsInnerNode) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node,
                        Create<Inner>(manager, {1, 2, 3, 5}, 6, {7, 8}));
 
   // The inner node gets a new entry.
-  EXPECT_THAT(node.Insert(0, 1, 4, manager), ElementAdded{});
+  EXPECT_THAT(node.Insert(0, 1, 4, manager), EntryAdded{});
   EXPECT_THAT(node.GetKeys(), ElementsAre(3, 6));
   ASSERT_THAT(node.GetChildren(), ElementsAre(PageId(1), PageId(3), PageId(2)));
 
   // The leaf nodes are properly split.
   ASSERT_OK_AND_ASSIGN(Leaf & a, manager.Get<Leaf>(PageId(1)));
-  EXPECT_THAT(a.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(a.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & b, manager.Get<Leaf>(PageId(3)));
-  EXPECT_THAT(b.GetElements(), ElementsAre(4, 5));
+  EXPECT_THAT(b.GetEntries(), ElementsAre(4, 5));
   ASSERT_OK_AND_ASSIGN(Leaf & c, manager.Get<Leaf>(PageId(2)));
-  EXPECT_THAT(c.GetElements(), ElementsAre(7, 8));
+  EXPECT_THAT(c.GetEntries(), ElementsAre(7, 8));
 }
 
 TEST(InnerNode, RightNodeSplitExtendsInnerNode) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node,
                        Create<Inner>(manager, {1, 2}, 3, {4, 5, 7, 8}));
 
   // The inner node gets a new entry.
-  EXPECT_THAT(node.Insert(0, 1, 6, manager), ElementAdded{});
+  EXPECT_THAT(node.Insert(0, 1, 6, manager), EntryAdded{});
   EXPECT_THAT(node.GetKeys(), ElementsAre(3, 6));
   ASSERT_THAT(node.GetChildren(), ElementsAre(PageId(1), PageId(2), PageId(3)));
 
   // The leaf nodes are properly split.
   ASSERT_OK_AND_ASSIGN(Leaf & a, manager.Get<Leaf>(PageId(1)));
-  EXPECT_THAT(a.GetElements(), ElementsAre(1, 2));
+  EXPECT_THAT(a.GetEntries(), ElementsAre(1, 2));
   ASSERT_OK_AND_ASSIGN(Leaf & b, manager.Get<Leaf>(PageId(2)));
-  EXPECT_THAT(b.GetElements(), ElementsAre(4, 5));
+  EXPECT_THAT(b.GetEntries(), ElementsAre(4, 5));
   ASSERT_OK_AND_ASSIGN(Leaf & c, manager.Get<Leaf>(PageId(3)));
-  EXPECT_THAT(c.GetElements(), ElementsAre(7, 8));
+  EXPECT_THAT(c.GetEntries(), ElementsAre(7, 8));
 }
 
 TEST(InnerNode, FullInnerNodeIsSplit) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node,
@@ -790,7 +851,7 @@ TEST(InnerNode, FullInnerNodeIsSplit) {
 }
 
 TEST(InnerNode, FullInnerNodeSplitByMiddleElementUsesNewElementAsKey) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node,
@@ -807,7 +868,7 @@ TEST(InnerNode, FullInnerNodeSplitByMiddleElementUsesNewElementAsKey) {
 }
 
 TEST(InnerNode, InsertOnRightSubTreeCausingSplitWorks) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   TestPageManager manager;
   ASSERT_OK_AND_ASSIGN(Inner & node,
@@ -824,7 +885,7 @@ TEST(InnerNode, InsertOnRightSubTreeCausingSplitWorks) {
 }
 
 TEST(InnerNode, SplitInLeftHalfKeepsSiblingsBalanced) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
 
@@ -845,7 +906,7 @@ TEST(InnerNode, SplitInLeftHalfKeepsSiblingsBalanced) {
 }
 
 TEST(InnerNode, SplitInRightHalfKeepsSiblingsBalanced) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
 
@@ -866,17 +927,17 @@ TEST(InnerNode, SplitInRightHalfKeepsSiblingsBalanced) {
 }
 
 TEST(InnerNode, InsertingNewEntryInSubTreeDoesNotMarkInnerNodeDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   MockPageManager manager;
   auto& node = Create<Inner>(manager, Node(Node(1), 4, Node(5)));
 
   EXPECT_CALL(manager, MarkAsDirty(1));  // the {1} node updated to {1,3}
-  EXPECT_THAT(node.Insert(12, 1, 3, manager), ElementAdded{});
+  EXPECT_THAT(node.Insert(12, 1, 3, manager), EntryAdded{});
 }
 
 TEST(InnerNode, InsertingNewKeyMarksNodeDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   MockPageManager manager;
   auto& node = Create<Inner>(manager, Node(Node(1, 3), 4, Node(5)));
@@ -884,11 +945,11 @@ TEST(InnerNode, InsertingNewKeyMarksNodeDirty) {
   EXPECT_CALL(manager, MarkAsDirty(12));  // the inner node targeted
   EXPECT_CALL(manager, MarkAsDirty(1));   // the {1,3} node
   EXPECT_CALL(manager, MarkAsDirty(3));   // the new overflow node
-  EXPECT_THAT(node.Insert(12, 1, 2, manager), ElementAdded{});
+  EXPECT_THAT(node.Insert(12, 1, 2, manager), EntryAdded{});
 }
 
 TEST(InnerNode, SplittingMarksTheOldAndNewNodeDirty) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 2>;
   MockPageManager manager;
   auto& node = Create<Inner>(manager, Node(Node(1, 3), 4, Node(5), 6, Node(7)));
@@ -901,7 +962,7 @@ TEST(InnerNode, SplittingMarksTheOldAndNewNodeDirty) {
 }
 
 TEST(InnerNode, ContainsFindsElementsInSubTree) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
 
@@ -918,7 +979,7 @@ TEST(InnerNode, ContainsFindsElementsInSubTree) {
 }
 
 TEST(InnerNode, CheckRequiresAtLeastOneKeyInRoot) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   auto& root = manager.Create<Inner>();
@@ -929,7 +990,7 @@ TEST(InnerNode, CheckRequiresAtLeastOneKeyInRoot) {
 }
 
 TEST(InnerNode, SingleKeyRootNodePassesTest) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   auto& root = Create<Inner>(manager, Node(Node(1, 2), 3, Node(4, 5)));
@@ -938,7 +999,7 @@ TEST(InnerNode, SingleKeyRootNodePassesTest) {
 }
 
 TEST(InnerNode, SingleKeyInnerNodeFailsWithTooFewKeys) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   auto& node = Create<Inner>(manager, Node(Node(1, 2), 3, Node(4, 5)));
@@ -951,7 +1012,7 @@ TEST(InnerNode, SingleKeyInnerNodeFailsWithTooFewKeys) {
 }
 
 TEST(InnerNode, LargeEnoughInnerNodePasses) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   auto& node =
@@ -962,7 +1023,7 @@ TEST(InnerNode, LargeEnoughInnerNodePasses) {
 }
 
 TEST(InnerNode, IncorrectlyOrderedKeysAreDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   // Keys are not in order, 6 > 3
@@ -974,7 +1035,7 @@ TEST(InnerNode, IncorrectlyOrderedKeysAreDetected) {
 }
 
 TEST(InnerNode, BoundViolationsAreDetected) {
-  using Leaf = LeafNode<int, std::less<int>, 2>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 2>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   auto& node =
@@ -997,30 +1058,29 @@ TEST(InnerNode, BoundViolationsAreDetected) {
 }
 
 TEST(InnerNode, ChildErrorsArePropagated) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   {
-    // The leaf storing 4 has too few elements.
+    // The leaf storing 4 has too few entries.
     auto& node =
         Create<Inner>(manager, Node(Node(1, 2), 3, Node(4), 6, Node(7, 8)));
     EXPECT_THAT(
         node.Check(1, nullptr, nullptr, manager),
         StatusIs(
-            _,
-            StrEq("Invalid number of elements, expected at least 2, got 1")));
+            _, StrEq("Invalid number of entries, expected at least 2, got 1")));
   }
   {
     // The middle leaf is out-of-order.
     auto& node =
         Create<Inner>(manager, Node(Node(1, 2), 3, Node(5, 4), 6, Node(7, 8)));
     EXPECT_THAT(node.Check(1, nullptr, nullptr, manager),
-                StatusIs(_, StrEq("Invalid order of elements")));
+                StatusIs(_, StrEq("Invalid order of entries")));
   }
 }
 
 TEST(InnerNode, BoundariesArePropagated) {
-  using Leaf = LeafNode<int, std::less<int>, 4>;
+  using Leaf = LeafNode<int, Unit, std::less<int>, 4>;
   using Inner = InnerNode<Leaf, 4>;
   TestPageManager manager;
   {
@@ -1029,7 +1089,7 @@ TEST(InnerNode, BoundariesArePropagated) {
         Create<Inner>(manager, Node(Node(1, 2), 3, Node(2, 5), 6, Node(7, 8)));
     EXPECT_THAT(
         node.Check(1, nullptr, nullptr, manager),
-        StatusIs(_, StrEq("Lower boundary is not less than smallest element")));
+        StatusIs(_, StrEq("Lower boundary is not less than smallest entry")));
   }
   {
     // The value 7 should not be in the middle node.
@@ -1037,7 +1097,7 @@ TEST(InnerNode, BoundariesArePropagated) {
         Create<Inner>(manager, Node(Node(1, 2), 3, Node(4, 7), 6, Node(7, 8)));
     EXPECT_THAT(
         node.Check(1, nullptr, nullptr, manager),
-        StatusIs(_, StrEq("Biggest element is not less than upper boundary")));
+        StatusIs(_, StrEq("Biggest entry is not less than upper boundary")));
   }
   {
     auto& node =
@@ -1045,7 +1105,7 @@ TEST(InnerNode, BoundariesArePropagated) {
     int limit = 2;
     EXPECT_THAT(
         node.Check(1, &limit, nullptr, manager),
-        StatusIs(_, StrEq("Lower boundary is not less than smallest element")));
+        StatusIs(_, StrEq("Lower boundary is not less than smallest entry")));
   }
   {
     auto& node =
@@ -1053,7 +1113,7 @@ TEST(InnerNode, BoundariesArePropagated) {
     int limit = 8;
     EXPECT_THAT(
         node.Check(1, nullptr, &limit, manager),
-        StatusIs(_, StrEq("Biggest element is not less than upper boundary")));
+        StatusIs(_, StrEq("Biggest entry is not less than upper boundary")));
   }
 }
 

--- a/cpp/backend/common/btree/test_util.cc
+++ b/cpp/backend/common/btree/test_util.cc
@@ -1,0 +1,24 @@
+#include "backend/common/btree/test_util.h"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+namespace carmen::backend {
+
+std::vector<int> GetSequence(int size) {
+  std::vector<int> data;
+  for (int i = 0; i < size; i++) {
+    data.push_back(i);
+  }
+  return data;
+}
+
+std::vector<int> Shuffle(std::vector<int> data) {
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(data.begin(), data.end(), g);
+  return data;
+}
+
+}  // namespace carmen::backend

--- a/cpp/backend/common/btree/test_util.h
+++ b/cpp/backend/common/btree/test_util.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vector>
+
+namespace carmen::backend {
+
+// Generates a vector containing the elements [0,...,size-1].
+std::vector<int> GetSequence(int size);
+
+// Shuffles the provided vector and returns the shuffled version.
+std::vector<int> Shuffle(std::vector<int> data);
+
+}  // namespace carmen::backend


### PR DESCRIPTION
This PR generalizes the former BtreeSet implementation into a generic Btree implementation which is inherited by the BtreeSet and BtreeMap classes. All essential operations are part of the Btree, the derived classes only contributed interface adaptations according to their Set and Map use cases.

The key for sharing most of the code between the set and map implementation is the utilization of a `Entry` type that has a specialization for the value type `Unit`, in which case there is no value field present. Thus, a map of `Entry<Key,Unit>` behaves like a set of `Key`s.
