### PR TITLE
Replace AccountState with Exist boolean

### DIFF
--- a/go/state/archive_state.go
+++ b/go/state/archive_state.go
@@ -13,7 +13,7 @@ type ArchiveState struct {
 	block   uint64
 }
 
-func (s *ArchiveState) Exist(address common.Address) (bool, error) {
+func (s *ArchiveState) Exists(address common.Address) (bool, error) {
 	return s.archive.Exists(s.block, address)
 }
 

--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -67,7 +67,7 @@ func (cs *CppState) createAccount(address common.Address) error {
 	return cs.applyToState(update)
 }
 
-func (cs *CppState) Exist(address common.Address) (bool, error) {
+func (cs *CppState) Exists(address common.Address) (bool, error) {
 	var res common.AccountState
 	C.Carmen_GetAccountState(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&res))
 	return res == common.Exists, nil

--- a/go/state/cpp_state_test.go
+++ b/go/state/cpp_state_test.go
@@ -16,7 +16,7 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 			}
 			defer state.Close()
 
-			account_state, _ := state.Exist(address1)
+			account_state, _ := state.Exists(address1)
 			if account_state != false {
 				t.Errorf("Initial account is not unknown, got %v", account_state)
 			}
@@ -34,7 +34,7 @@ func TestAccountsCanBeCreated(t *testing.T) {
 			defer state.Close()
 
 			state.createAccount(address1)
-			account_state, _ := state.Exist(address1)
+			account_state, _ := state.Exists(address1)
 			if account_state != true {
 				t.Errorf("Created account does not exist, got %v", account_state)
 			}
@@ -53,7 +53,7 @@ func TestAccountsCanBeDeleted(t *testing.T) {
 
 			state.createAccount(address1)
 			state.deleteAccount(address1)
-			account_state, _ := state.Exist(address1)
+			account_state, _ := state.Exists(address1)
 			if account_state != false {
 				t.Errorf("Deleted account is not deleted, got %v", account_state)
 			}

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -49,7 +49,7 @@ func (s *GoState) createAccount(address common.Address) (err error) {
 	return s.clearAccount(idx)
 }
 
-func (s *GoState) Exist(address common.Address) (bool, error) {
+func (s *GoState) Exists(address common.Address) (bool, error) {
 	idx, err := s.addressIndex.Get(address)
 	if err != nil {
 		if err == index.ErrNotFound {

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -57,7 +57,7 @@ func TestMissingKeys(t *testing.T) {
 			}
 			defer state.Close()
 
-			accountState, err := state.Exist(address1)
+			accountState, err := state.Exists(address1)
 			if err != nil || accountState != false {
 				t.Errorf("Account must not exist in the initial state, but it exists. err: %s", err)
 			}
@@ -112,7 +112,7 @@ func TestBasicOperations(t *testing.T) {
 			}
 
 			// fetch values
-			if val, err := state.Exist(address1); err != nil || val != true {
+			if val, err := state.Exists(address1); err != nil || val != true {
 				t.Errorf("Created account does not exists: Val: %t, Err: %s", val, err)
 			}
 			if val, err := state.GetNonce(address1); (err != nil || val != common.Nonce{123}) {
@@ -135,7 +135,7 @@ func TestBasicOperations(t *testing.T) {
 			if err := state.deleteAccount(address1); err != nil {
 				t.Errorf("Error: %s", err)
 			}
-			if val, err := state.Exist(address1); err != nil || val != false {
+			if val, err := state.Exists(address1); err != nil || val != false {
 				t.Errorf("Deleted account is not deleted: Val: %t, Err: %s", val, err)
 			}
 

--- a/go/state/mock_state.go
+++ b/go/state/mock_state.go
@@ -62,19 +62,19 @@ func (mr *MockStateMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockState)(nil).Close))
 }
 
-// Exist mocks base method.
-func (m *MockState) Exist(address common.Address) (bool, error) {
+// Exists mocks base method.
+func (m *MockState) Exists(address common.Address) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exist", address)
+	ret := m.ctrl.Call(m, "Exists", address)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Exist indicates an expected call of Exist.
-func (mr *MockStateMockRecorder) Exist(address interface{}) *gomock.Call {
+// Exists indicates an expected call of Exists.
+func (mr *MockStateMockRecorder) Exists(address interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exist", reflect.TypeOf((*MockState)(nil).Exist), address)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockState)(nil).Exists), address)
 }
 
 // Flush mocks base method.
@@ -276,19 +276,19 @@ func (mr *MockdirectUpdateStateMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockdirectUpdateState)(nil).Close))
 }
 
-// Exist mocks base method.
-func (m *MockdirectUpdateState) Exist(address common.Address) (bool, error) {
+// Exists mocks base method.
+func (m *MockdirectUpdateState) Exists(address common.Address) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exist", address)
+	ret := m.ctrl.Call(m, "Exists", address)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Exist indicates an expected call of Exist.
-func (mr *MockdirectUpdateStateMockRecorder) Exist(address interface{}) *gomock.Call {
+// Exists indicates an expected call of Exists.
+func (mr *MockdirectUpdateStateMockRecorder) Exists(address interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exist", reflect.TypeOf((*MockdirectUpdateState)(nil).Exist), address)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockdirectUpdateState)(nil).Exists), address)
 }
 
 // Flush mocks base method.

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -8,8 +8,8 @@ import (
 
 // State interfaces provides access to accounts and smart contract values memory.
 type State interface {
-	// Exist obtains the current state of the provided account.
-	Exist(address common.Address) (bool, error)
+	// Exists obtains the current state of the provided account.
+	Exists(address common.Address) (bool, error)
 
 	// GetBalance provides balance for the input account address.
 	GetBalance(address common.Address) (common.Balance, error)

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -285,7 +285,7 @@ func (s *stateDB) Exist(addr common.Address) bool {
 	if val, exists := s.accounts[addr]; exists {
 		return val.current
 	}
-	state, err := s.state.Exist(addr)
+	state, err := s.state.Exists(addr)
 	if err != nil {
 		panic(fmt.Errorf("failed to get account state for address %v: %v", addr, err))
 	}
@@ -890,7 +890,7 @@ func (s *stateDB) EndBlock(block uint64) {
 		// In case we do not know the account state yet, we need to fetch it
 		// from the DB to decide whether the account state has changed.
 		if value.original == nil {
-			state, err := s.state.Exist(addr)
+			state, err := s.state.Exists(addr)
 			if err != nil {
 				panic(fmt.Sprintf("failed to fetch account state from DB: %v", err))
 			}

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -40,7 +40,7 @@ func TestCarmenStateAccountsCanBeCreatedAndDeleted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// the account creation needs to check whether the account exists
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	db.CreateAccount(address1)
 
 	if !db.Exist(address1) {
@@ -72,7 +72,7 @@ func TestCarmenStateCreateAccountSetsNonceCodeAndBalanceToZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.CreateAccount(address1)
 
@@ -99,7 +99,7 @@ func TestCarmenStateRecreatingAccountSetsNonceCodeAndBalanceToZero(t *testing.T)
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a previously deleted account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.CreateAccount(address1)
 
@@ -127,7 +127,7 @@ func TestCarmenStateRecreatingAccountResetsStorage(t *testing.T) {
 	zero := common.Value{}
 
 	// Initially the account is non-exisiting, it gets recreated.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setBalance(address1, common.Balance{}).Return(nil)
 	mock.EXPECT().setNonce(address1, common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}).Return(nil)
@@ -181,7 +181,7 @@ func TestCarmenStateRecreatingAccountResetsStorageButRetainsNewState(t *testing.
 	zero := common.Value{}
 
 	// Initially the account exists with some state.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 
@@ -238,7 +238,7 @@ func TestCarmenStateStorageOfDestroyedAccountIsStillAccessibleTillEndOfTransacti
 	zero := common.Value{}
 
 	// Initially the account existis with some values inside.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 
@@ -290,7 +290,7 @@ func TestCarmenStateStoreDataCacheIsResetAfterSuicide(t *testing.T) {
 	zero := common.Value{}
 
 	// Initially the account exists and has a slot value set.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 
 	// During the processing the account is deleted.
@@ -344,7 +344,7 @@ func TestCarmenStateRollingBackSuicideRestoresValues(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account is exisiting with a view stored values.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 
@@ -383,7 +383,7 @@ func TestCarmenStateDestroyingAndRecreatingAnAccountInTheSameTransactionCallsDel
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account is exisiting with a view stored values.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	// The account is to be re-created.
 	mock.EXPECT().createAccount(address1).Return(nil)
@@ -414,7 +414,7 @@ func TestCarmenStateDoubleDestroyedAccountThatIsOnceRolledBackIsStillCleared(t *
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account is exisiting with a view stored values.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	// The account is to be re-created.
 	mock.EXPECT().createAccount(address1).Return(nil)
@@ -453,7 +453,7 @@ func TestCarmenStateRecreatingExistingAccountSetsNonceAndCodeToZeroAndPreservesB
 	if err != nil {
 		t.Fatalf("failed to set up test case: %v", err)
 	}
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 	db.SetNonce(address1, 14)
 	db.SetCode(address1, []byte{1, 2, 3})
@@ -483,7 +483,7 @@ func TestCarmenStateCreateAccountCanBeRolledBack(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// this test will cause one call to the DB to check for the existence of the account
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	snapshot := db.Snapshot()
 
@@ -504,7 +504,7 @@ func TestCarmenStateSuicideIndicatesExistingAccountAsBeingDeleted(t *testing.T) 
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	// An existing account is indicated as being deleted.
 	if exists := db.Suicide(address1); !exists {
@@ -532,7 +532,7 @@ func TestCarmenStateSetCodeShouldNotStopSuicide(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{1}, nil)
 
 	// An existing account is indicated as being deleted.
@@ -559,7 +559,7 @@ func TestCarmenStateRepeatedSuicide(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	// An existing account is indicated as being deleted.
 	if exists := db.Suicide(address1); !exists {
@@ -610,7 +610,7 @@ func TestCarmenStateSuicideIndicatesUnknownAccountAsNotBeingDeleted(t *testing.T
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an unknown account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	// An unknown account is indicated as not being deleted.
 	if exists := db.Suicide(address1); exists {
@@ -629,7 +629,7 @@ func TestCarmenStateSuicideIndicatesDeletedAccountAsNotBeingDeleted(t *testing.T
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a deleted account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	// An already deleted account is indicated as not being deleted during the suicide.
 	if exists := db.Suicide(address1); exists {
@@ -652,7 +652,7 @@ func TestCarmenStateSuicideRemovesBalanceFromAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing test: %v", err)
 	}
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 
 	want := big.NewInt(12)
@@ -678,7 +678,7 @@ func TestCarmenStateSuicideCanBeRolledBack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing test: %v", err)
 	}
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 
 	if !db.Exist(address1) {
@@ -715,7 +715,7 @@ func TestCarmenStateSuicideIsExecutedAtEndOfTransaction(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// the nonce and code will be set at the end of the block since suicide is canceled.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().deleteAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(0)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -736,7 +736,7 @@ func TestCarmenStateSuicideCanBeCanceledThroughRollback(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// the nonce and code will be set at the end of the block since suicide is canceled.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(5)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{1, 2, 3}).Return(nil)
 
@@ -757,7 +757,7 @@ func TestCarmenStateCreatedAccountsAreStoredAtEndOfBlock(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The new account is created at the end of the transaction.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(1)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -775,7 +775,7 @@ func TestCarmenStateCreatedAccountsAreForgottenAtEndOfBlock(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The created account is only created once, and nonces and code are initialized.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(1)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -794,7 +794,7 @@ func TestCarmenStateCreatedAccountsAreDiscardedOnEndOfAbortedTransaction(t *test
 	db := CreateStateDBUsing(mock)
 
 	// Needs to check whether the account already existed before the creation.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.CreateAccount(address1)
 	db.AbortTransaction()
@@ -808,7 +808,7 @@ func TestCarmenStateDeletedAccountsAreStoredAtEndOfBlock(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The new account is deleted at the end of the transaction.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().deleteAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(0)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -825,7 +825,7 @@ func TestCarmenStateDeletedAccountsRetainCodeUntilEndOfTransaction(t *testing.T)
 	db := CreateStateDBUsing(mock)
 
 	// The new account is deleted at the end of the transaction.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().deleteAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(0)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -863,7 +863,7 @@ func TestCarmenStateDeletedAccountsAreIgnoredAtAbortedTransaction(t *testing.T) 
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.Suicide(address1)
 	db.AbortTransaction()
@@ -876,7 +876,7 @@ func TestCarmenStateCreatedAndDeletedAccountsAreDeletedAtEndOfTransaction(t *tes
 	db := CreateStateDBUsing(mock)
 
 	// The new account is deleted at the end of the transaction.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().deleteAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(0)).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
@@ -894,7 +894,7 @@ func TestCarmenStateCreatedAndDeletedAccountsAreIgnoredAtAbortedTransaction(t *t
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.CreateAccount(address1)
 	db.Suicide(address1)
@@ -923,7 +923,7 @@ func TestCarmenStateSettingTheBalanceMakesAccountNonEmpty(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// An empty account must have its balance and nonce set to zero.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(common.Balance{}, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
 	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
@@ -946,7 +946,7 @@ func TestCarmenStateSettingTheBalanceCreatesAccount(t *testing.T) {
 	balance, _ := common.ToBalance(addedBalance)
 
 	// The account have not existed - must be created by AddBalance call.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setBalance(address1, balance).Return(nil)
 
@@ -964,7 +964,7 @@ func TestCarmenStateSettingTheNonceMakesAccountNonEmpty(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// An empty account must have its nonce and code set to zero.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(1)).Return(nil)
@@ -989,7 +989,7 @@ func TestCarmenStateCreatesAccountOnNonceSetting(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The account does not exist, is expected to be created automatically.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setBalance(address1, common.Balance{}).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(1)).Return(nil)
@@ -1074,7 +1074,7 @@ func TestCarmenStateBalancesCanBeSnapshottedAndReverted(t *testing.T) {
 	// Balance is initially 10. This should only be fetched once.
 	want := big.NewInt(10)
 	balance, _ := common.ToBalance(want)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
 
 	snapshot0 := db.Snapshot()
@@ -1129,7 +1129,7 @@ func TestCarmenStateBalanceIsWrittenToStateIfChangedAtEndOfBlock(t *testing.T) {
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
 	balance, _ = common.ToBalance(big.NewInt(12))
 	mock.EXPECT().setBalance(address1, balance).Return(nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.AddBalance(address1, big.NewInt(2))
 	db.EndTransaction()
@@ -1152,7 +1152,7 @@ func TestCarmenStateBalanceOnlyFinalValueIsWrittenAtEndOfBlock(t *testing.T) {
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
 	balance, _ = common.ToBalance(big.NewInt(14))
 	mock.EXPECT().setBalance(address1, balance).Return(nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.AddBalance(address1, big.NewInt(5))
 	db.SubBalance(address1, big.NewInt(3))
@@ -1171,7 +1171,7 @@ func TestCarmenStateBalanceUnchangedValuesAreNotWritten(t *testing.T) {
 	want := big.NewInt(10)
 	balance, _ := common.ToBalance(want)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.AddBalance(address1, big.NewInt(10))
 	db.SubBalance(address1, big.NewInt(5))
@@ -1189,7 +1189,7 @@ func TestCarmenStateBalanceIsNotWrittenToStateIfTransactionIsAborted(t *testing.
 	want := big.NewInt(10)
 	balance, _ := common.ToBalance(want)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.AddBalance(address1, big.NewInt(10))
 	db.AbortTransaction()
@@ -1232,7 +1232,7 @@ func TestCarmenStateNoncesCanBeWrittenAndReadWithoutStateAccess(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetNonce creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	var want uint64 = 12
 	db.SetNonce(address1, want)
@@ -1266,14 +1266,14 @@ func TestCarmenStateNonceOfADeletedAccountIsZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The side-effects of the creation of the account in the first transactions are expected.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setNonce(address1, common.ToNonce(12)).Return(nil)
 	mock.EXPECT().setBalance(address1, common.Balance{}).Return(nil)
 	mock.EXPECT().setCode(address1, []byte{}).Return(nil)
 
 	// Also the fetch of the Nonce value in the second transaction is expected.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(12), nil)
 
 	// Create an account and set the nonce.
@@ -1311,7 +1311,7 @@ func TestCarmenStateNonceOfADeletedAccountGetsResetAtEndOfTransaction(t *testing
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
 
 	var want uint64 = 0
@@ -1349,7 +1349,7 @@ func TestCarmenStateNoncesCanBeSnapshottedAndReverted(t *testing.T) {
 
 	// Nonce is initially 10. This should only be fetched once.
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	snapshot0 := db.Snapshot()
 
@@ -1398,7 +1398,7 @@ func TestCarmenStateNoncesOnlySetCanBeReverted(t *testing.T) {
 
 	// Nonce is initially 10. This should only be fetched once.
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	snapshot0 := db.Snapshot()
 
@@ -1423,7 +1423,7 @@ func TestCarmenStateNoncesIsWrittenToStateIfChangedAtEndOfBlock(t *testing.T) {
 	// The updated value is expected to be written to the state.
 	mock.EXPECT().setNonce(address1, common.ToNonce(10)).Return(nil)
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.SetNonce(address1, 10)
 	db.EndTransaction()
@@ -1442,7 +1442,7 @@ func TestCarmenStateNoncesOnlyFinalValueIsWrittenAtEndOfBlock(t *testing.T) {
 	// Only the last value is to be written to the state.
 	mock.EXPECT().setNonce(address1, common.ToNonce(12)).Return(nil)
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.SetNonce(address1, 10)
 	db.SetNonce(address1, 11)
@@ -1460,7 +1460,7 @@ func TestCarmenStateNoncesUnchangedValuesAreNotWritten(t *testing.T) {
 	// Nonce is only read, never written.
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	value := db.GetNonce(address1)
 	db.SetNonce(address1, value)
@@ -1474,7 +1474,7 @@ func TestCarmenStateNoncesIsNotWrittenToStateIfTransactionIsAborted(t *testing.T
 	db := CreateStateDBUsing(mock)
 
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	// No other mock call is expected.
 
 	db.SetNonce(address1, 10)
@@ -1773,7 +1773,7 @@ func TestCarmenStateCodesCanBeSet(t *testing.T) {
 	mock := prepareMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	want := []byte{0xAC, 0xDC}
 	db.SetCode(address1, want)
@@ -1788,7 +1788,7 @@ func TestCarmenStateCodeUpdatesCoveredByRollbacks(t *testing.T) {
 	mock := prepareMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	want1 := []byte{0xAC, 0xDC}
 	want2 := []byte{0xFE, 0xEF}
@@ -1832,7 +1832,7 @@ func TestCarmenStateUpdatedCodesAreStored(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().setCode(address1, want).Return(nil)
@@ -1848,7 +1848,7 @@ func TestCarmenStateUpdatedCodesAreStoredOnlyOnce(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().setCode(address1, want).Return(nil)
@@ -1868,7 +1868,7 @@ func TestCarmenStateSettingCodesCreatesAccountsImplicitly(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().createAccount(address1).Return(nil)
 	mock.EXPECT().setBalance(address1, common.Balance{}).Return(nil)
 
@@ -1899,7 +1899,7 @@ func TestCarmenStateCodeSizeCanBeReadAfterModification(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	want := []byte{0xAC, 0xDC}
 	db.SetCode(address1, want)
@@ -1928,7 +1928,7 @@ func TestCarmenStateCodeSizeOfADeletedAccountIsZeroAfterEndOfTransaction(t *test
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.SetCode(address1, []byte{1, 2, 3})
 	db.Suicide(address1)
@@ -1954,7 +1954,7 @@ func TestCarmenStateCodeHashOfNonExistingAccountIsZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The state DB is asked for the accounts existence, but not for the hash.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	want := common.Hash{}
 	if got := db.GetCodeHash(address1); got != want {
@@ -1968,7 +1968,7 @@ func TestCarmenStateCodeHashOfAnExistingAccountIsTheHashOfTheEmptyCode(t *testin
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account with empty code.
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetCodeHash(address1).Return(common.GetKeccak256Hash([]byte{}), nil)
 
 	want := common.GetKeccak256Hash([]byte{})
@@ -1983,7 +1983,7 @@ func TestCarmenStateCodeHashOfNewlyCreatedAccountIsTheHashOfTheEmptyCode(t *test
 	db := CreateStateDBUsing(mock)
 
 	// At the start the account does not exist.
-	mock.EXPECT().Exist(address1).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
 
 	db.CreateAccount(address1)
 	want := common.GetKeccak256Hash([]byte{})
@@ -1999,7 +1999,7 @@ func TestCarmenStateCodeHashCanBeRead(t *testing.T) {
 
 	want := common.Hash{0xAC, 0xDC}
 	mock.EXPECT().GetCodeHash(address1).Return(want, nil)
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	if got := db.GetCodeHash(address1); got != want {
 		t.Errorf("error retrieving code hash, wanted %v, got %v", want, got)
@@ -2012,7 +2012,7 @@ func TestCarmenStateSetCodeSizeCanBeRolledBack(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	want := []byte{0xAB, 0xCD}
 	db.SetCode(address1, want)
@@ -2034,7 +2034,7 @@ func TestCarmenStateCodeHashCanBeReadAfterModification(t *testing.T) {
 	mock := prepareMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exist(address1).Return(true, nil)
+	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	code := []byte{0xAC, 0xDC}
 	db.SetCode(address1, code)
@@ -2467,9 +2467,9 @@ func TestCarmenNeverCreatesEmptyAccountsEip161(t *testing.T) {
 	mock := prepareMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exist(address1).Return(false, nil)
-	mock.EXPECT().Exist(address2).Return(false, nil)
-	mock.EXPECT().Exist(address3).Return(false, nil)
+	mock.EXPECT().Exists(address1).Return(false, nil)
+	mock.EXPECT().Exists(address2).Return(false, nil)
+	mock.EXPECT().Exists(address3).Return(false, nil)
 	mock.EXPECT().GetNonce(address2).Return(common.Nonce{}, nil)
 	mock.EXPECT().GetNonce(address3).Return(common.Nonce{}, nil)
 	mock.EXPECT().GetCodeSize(address2).Return(0, nil)

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -257,10 +257,10 @@ func TestDeleteNotExistingAccount(t *testing.T) {
 			t.Fatalf("Error: %s", err)
 		}
 
-		if newState, err := s.Exist(address1); err != nil || newState != true {
+		if newState, err := s.Exists(address1); err != nil || newState != true {
 			t.Errorf("Unrelated existing state: %t, Error: %s", newState, err)
 		}
-		if newState, err := s.Exist(address2); err != nil || newState != false {
+		if newState, err := s.Exists(address2); err != nil || newState != false {
 			t.Errorf("Delete never-existing state: %t, Error: %s", newState, err)
 		}
 	})
@@ -394,10 +394,10 @@ func TestArchive(t *testing.T) {
 				t.Fatalf("failed to get state of block 2; %s", err)
 			}
 
-			if as, err := state1.Exist(address1); err != nil || as != true {
+			if as, err := state1.Exists(address1); err != nil || as != true {
 				t.Errorf("invalid account state at block 1: %t, %s", as, err)
 			}
-			if as, err := state2.Exist(address1); err != nil || as != true {
+			if as, err := state2.Exists(address1); err != nil || as != true {
 				t.Errorf("invalid account state at block 2: %t, %s", as, err)
 			}
 			if balance, err := state1.GetBalance(address1); err != nil || balance != balance12 {
@@ -488,7 +488,7 @@ func TestStateRead(t *testing.T) {
 		_ = s.Close()
 	}()
 
-	if state, err := s.Exist(address1); err != nil || state != true {
+	if state, err := s.Exists(address1); err != nil || state != true {
 		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", state, true, err)
 	}
 	if balance, err := s.GetBalance(address1); err != nil || balance != balance1 {


### PR DESCRIPTION
AccountState type is replaced with bool in StateDB and State interface.
AccountState type is still used as States internal type - in stores etc.
Follows removing of third state "deleted" from AccountState type.