### PR TITLE
Introduce materialized full archive hashes

### DIFF
--- a/cpp/backend/common/sqlite/BUILD
+++ b/cpp/backend/common/sqlite/BUILD
@@ -6,6 +6,7 @@ cc_library(
     deps = [
         "//common:memory_usage",
         "//common:status_util",
+        "//common:type",
         "@com_github_rockwotj_sqlite_bazel//:sqlite3",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -147,6 +147,7 @@ cc_library(
         ":update",
         "//backend/common/sqlite",
         "//common:type",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",

--- a/cpp/state/archive.cc
+++ b/cpp/state/archive.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <queue>
 
+#include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
@@ -43,6 +44,7 @@ class Archive {
 
     // Prepare query statements.
     ASSIGN_OR_RETURN(auto add_block, db.Prepare(kAddBlockStmt));
+    ASSIGN_OR_RETURN(auto get_block_hash, db.Prepare(kGetBlockHashStmt));
     ASSIGN_OR_RETURN(auto get_block_height, db.Prepare(kGetBlockHeightStmt));
 
     ASSIGN_OR_RETURN(auto add_account_hash, db.Prepare(kAddAccountHashStmt));
@@ -70,13 +72,14 @@ class Archive {
 
     return std::unique_ptr<Archive>(new Archive(
         std::move(db), wrap(std::move(add_block)),
-        wrap(std::move(get_block_height)), wrap(std::move(add_account_hash)),
-        wrap(std::move(get_account_hash)), wrap(std::move(create_account)),
-        wrap(std::move(delete_account)), wrap(std::move(get_status)),
-        wrap(std::move(add_balance)), wrap(std::move(get_balance)),
-        wrap(std::move(add_code)), wrap(std::move(get_code)),
-        wrap(std::move(add_nonce)), wrap(std::move(get_nonce)),
-        wrap(std::move(add_value)), wrap(std::move(get_value))));
+        wrap(std::move(get_block_hash)), wrap(std::move(get_block_height)),
+        wrap(std::move(add_account_hash)), wrap(std::move(get_account_hash)),
+        wrap(std::move(create_account)), wrap(std::move(delete_account)),
+        wrap(std::move(get_status)), wrap(std::move(add_balance)),
+        wrap(std::move(get_balance)), wrap(std::move(add_code)),
+        wrap(std::move(get_code)), wrap(std::move(add_nonce)),
+        wrap(std::move(get_nonce)), wrap(std::move(add_value)),
+        wrap(std::move(get_value))));
   }
 
   // Adds the block update for the given block.
@@ -90,7 +93,7 @@ class Archive {
     }
 
     // Compute hashes of account updates.
-    absl::flat_hash_map<Address, Hash> diff_hashes;
+    absl::btree_map<Address, Hash> diff_hashes;
     for (const auto& [addr, diff] : AccountUpdate::From(update)) {
       diff_hashes[addr] = diff.GetHash();
     }
@@ -99,8 +102,6 @@ class Archive {
     auto guard = absl::MutexLock(&mutation_lock_);
     if (!add_value_stmt_) return absl::FailedPreconditionError("DB Closed");
     RETURN_IF_ERROR(db_.Run("BEGIN TRANSACTION"));
-
-    RETURN_IF_ERROR(add_block_stmt_->Run(block));
 
     for (auto& addr : update.GetDeletedAccounts()) {
       RETURN_IF_ERROR(delete_account_stmt_->Run(addr, block));
@@ -126,11 +127,18 @@ class Archive {
       RETURN_IF_ERROR(add_value_stmt_->Run(addr, key, block, value));
     }
 
+    Sha256Hasher hasher;
+    ASSIGN_OR_RETURN(auto last_block_hash, GetHash(block));
+    hasher.Ingest(last_block_hash);
+
     for (auto& [addr, hash] : diff_hashes) {
       ASSIGN_OR_RETURN(auto last_hash, GetAccountHash(block, addr));
-      RETURN_IF_ERROR(add_account_hash_stmt_->Run(
-          addr, block, GetSha256Hash(last_hash, hash)));
+      auto new_hash = GetSha256Hash(last_hash, hash);
+      RETURN_IF_ERROR(add_account_hash_stmt_->Run(addr, block, new_hash));
+      hasher.Ingest(new_hash);
     }
+
+    RETURN_IF_ERROR(add_block_stmt_->Run(block, hasher.GetHash()));
 
     return db_.Run("END TRANSACTION");
   }
@@ -225,18 +233,16 @@ class Archive {
   }
 
   absl::StatusOr<Hash> GetHash(BlockId block) {
-    Sha256Hasher hasher;
-    ASSIGN_OR_RETURN(
-        auto query,
-        db_.Prepare(
-            "SELECT hash FROM account_hash a INNER JOIN (SELECT account, "
-            "MAX(block) as block FROM account_hash WHERE block <= ? GROUP BY "
-            "account) b ON a.account = b.account AND a.block = b.block ORDER "
-            "BY a.account"));
-    RETURN_IF_ERROR(query.BindParameters(block));
-    RETURN_IF_ERROR(query.Execute(
-        [&](const SqlRow& row) { hasher.Ingest(row.GetBytes(0)); }));
-    return hasher.GetHash();
+    auto guard = absl::MutexLock(&get_block_hash_lock_);
+    if (!get_block_hash_stmt_)
+      return absl::FailedPreconditionError("DB Closed");
+    RETURN_IF_ERROR(get_block_hash_stmt_->BindParameters(block));
+
+    // If there is no block in the archive, the hash is supposed to be zero.
+    Hash result{};
+    RETURN_IF_ERROR(get_block_hash_stmt_->Execute(
+        [&](const SqlRow& row) { result.SetBytes(row.GetBytes(0)); }));
+    return result;
   }
 
   absl::StatusOr<std::vector<Address>> GetAccountList(BlockId block) {
@@ -296,6 +302,9 @@ class Archive {
       return absl::InternalError("Archive hash does not match expected hash.");
     }
 
+    // Verify that the block hashes are consistent within the archive.
+    RETURN_IF_ERROR(VerifyHashes(block));
+
     // Validate all individual accounts.
     // TODO: run this in parallel
     ASSIGN_OR_RETURN(auto accounts, GetAccountList(block));
@@ -341,6 +350,58 @@ class Archive {
     }
 
     // All checks have passed. DB is verified.
+    return absl::OkStatus();
+  }
+
+  // Verifies the consistency of the stored full archive hashes up until (and
+  // including) the given block number.
+  absl::Status VerifyHashes(BlockId block) {
+    ASSIGN_OR_RETURN(auto block_hashes,
+                     db_.Query("SELECT number, hash FROM block WHERE number "
+                               "<= ? ORDER BY number",
+                               block));
+    ASSIGN_OR_RETURN(auto diff_hashes,
+                     db_.Query("SELECT block, hash FROM account_hash WHERE "
+                               "block <= ? ORDER BY block, account",
+                               block));
+
+    ASSIGN_OR_RETURN(auto block_iter, block_hashes.Iterator());
+    ASSIGN_OR_RETURN(auto diff_iter, diff_hashes.Iterator());
+    RETURN_IF_ERROR(block_iter.Next());
+    RETURN_IF_ERROR(diff_iter.Next());
+
+    Hash hash{};
+    Sha256Hasher hasher;
+    while (!block_iter.Finished()) {
+      hasher.Reset();
+      hasher.Ingest(hash);
+      auto block = block_iter->GetInt64(0);
+      while (!diff_iter.Finished()) {
+        auto diff_block = diff_iter->GetInt64(0);
+        if (diff_block == block) {
+          hasher.Ingest(diff_iter->Get<Hash>(1));
+          RETURN_IF_ERROR(diff_iter.Next());
+        } else if (diff_block < block) {
+          return absl::InternalError(absl::StrFormat(
+              "Found account update for block %d but no hash for this block.",
+              diff_block));
+        } else {
+          break;
+        }
+      }
+      hash = hasher.GetHash();
+      if (hash != block_iter->Get<Hash>(1)) {
+        return absl::InternalError(
+            absl::StrFormat("Validation of hash of block %d failed.", block));
+      }
+      RETURN_IF_ERROR(block_iter.Next());
+    }
+
+    if (!diff_iter.Finished()) {
+      return absl::InternalError(absl::StrFormat(
+          "Found change in block %d not covered by archive hash.",
+          diff_iter->GetInt64(0)));
+    }
     return absl::OkStatus();
   }
 
@@ -531,6 +592,10 @@ class Archive {
       add_account_hash_stmt_.reset();
     }
     {
+      auto guard = absl::MutexLock(&get_block_hash_lock_);
+      get_block_hash_stmt_.reset();
+    }
+    {
       auto guard = absl::MutexLock(&get_block_height_lock_);
       get_block_height_stmt_.reset();
     }
@@ -573,10 +638,13 @@ class Archive {
   // -- Blocks --
 
   static constexpr const std::string_view kCreateBlockTable =
-      "CREATE TABLE IF NOT EXISTS block (number INT PRIMARY KEY)";
+      "CREATE TABLE IF NOT EXISTS block (number INT PRIMARY KEY, hash BLOB)";
 
   static constexpr const std::string_view kAddBlockStmt =
-      "INSERT INTO block(number) VALUES (?)";
+      "INSERT INTO block(number,hash) VALUES (?,?)";
+
+  static constexpr const std::string_view kGetBlockHashStmt =
+      "SELECT hash FROM block WHERE number <= ? ORDER BY number DESC LIMIT 1";
 
   static constexpr const std::string_view kGetBlockHeightStmt =
       "SELECT number FROM block ORDER BY number DESC LIMIT 1";
@@ -603,14 +671,12 @@ class Archive {
   static constexpr const std::string_view kCreateAccountStmt =
       "INSERT INTO status(account,block,exist,reincarnation) VALUES "
       "(?1,?2,1,(SELECT IFNULL(MAX(reincarnation)+1,0) FROM status WHERE "
-      "account "
-      "= ?1))";
+      "account = ?1))";
 
   static constexpr const std::string_view kDeleteAccountStmt =
       "INSERT INTO status(account,block,exist,reincarnation) VALUES "
       "(?1,?2,0,(SELECT IFNULL(MAX(reincarnation)+1,0) FROM status WHERE "
-      "account "
-      "= ?1))";
+      "account = ?1))";
 
   static constexpr const std::string_view kGetStatusStmt =
       "SELECT exist FROM status WHERE account = ? AND block <= ? ORDER BY "
@@ -675,6 +741,7 @@ class Archive {
       "?3) AND slot = ?2 AND block <= ?3 ORDER BY block DESC LIMIT 1";
 
   Archive(Sqlite db, std::unique_ptr<SqlStatement> add_block,
+          std::unique_ptr<SqlStatement> get_block_hash,
           std::unique_ptr<SqlStatement> get_block_height,
           std::unique_ptr<SqlStatement> add_account_hash,
           std::unique_ptr<SqlStatement> get_account_hash,
@@ -691,6 +758,7 @@ class Archive {
           std::unique_ptr<SqlStatement> get_value)
       : db_(std::move(db)),
         add_block_stmt_(std::move(add_block)),
+        get_block_hash_stmt_(std::move(get_block_hash)),
         get_block_height_stmt_(std::move(get_block_height)),
         add_account_hash_stmt_(std::move(add_account_hash)),
         get_account_hash_stmt_(std::move(get_account_hash)),
@@ -714,8 +782,13 @@ class Archive {
   // Prepared statemetns for logging new data to the archive.
   absl::Mutex mutation_lock_;
 
-  absl::Mutex get_block_height_lock_;
   std::unique_ptr<SqlStatement> add_block_stmt_ GUARDED_BY(mutation_lock_);
+
+  absl::Mutex get_block_hash_lock_;
+  std::unique_ptr<SqlStatement> get_block_hash_stmt_
+      GUARDED_BY(get_block_hash_lock_);
+
+  absl::Mutex get_block_height_lock_;
   std::unique_ptr<SqlStatement> get_block_height_stmt_
       GUARDED_BY(get_block_height_lock_);
 


### PR DESCRIPTION
This PR refactors the method on how full-archive hashes are computed.

Previously, full-archive hashes for a given block height B have been computed by
 - creating a list of all existing accounts on block height B
 - fetching the account hashes of all existing accounts
 - concatenating those hashes and computing the hash over those

The first two steps have been merged in a single SQL statement, which, however, required a full table scan over the second largest table (in the case of 50M blocks, ~34GB of data). Since such hashes may be ultimately requested through some RPC interface, this is an unacceptable latency and a vulnerability for DoS attacks.

The new approach changes the algorithm of how the full-archive hash is computed, allowing it to be materialized in a table to facilitate quick lookup. The new full-archive hash is computed on a block basis as follows:
 - block i < 0 have hash zero
 - the hash of block i >= 0 is 
     - the hash of block i-1 if no accounts are changed in the update;
     - the hash of the concatenation of the hash of block i-1 and the hashes of the modified accounts otherwise

Per-Block archive hashes are then materialized in a table for fast retrieval. This PR introduces this table.

Future tasks:
 - the change in the algorithm for computing full-archive hashes also necessitates changes in the synchronization protocol
 - the retrieval of a list of existing accounts at a given block height is still slow; this can be improved by adding a table logging the first block an account has been referenced in;