### PR TITLE
Fix support for Archive reading in Aida

### DIFF
--- a/go/common/update.go
+++ b/go/common/update.go
@@ -32,6 +32,16 @@ type Update struct {
 	Slots           []SlotUpdate
 }
 
+// IsEmpty is true if there is no change covered by this update.
+func (u *Update) IsEmpty() bool {
+	return len(u.DeletedAccounts) == 0 &&
+		len(u.CreatedAccounts) == 0 &&
+		len(u.Balances) == 0 &&
+		len(u.Nonces) == 0 &&
+		len(u.Codes) == 0 &&
+		len(u.Slots) == 0
+}
+
 // AppendDeleteAccount registers an account to be deleted in this block. Delete
 // operations are the first to be carried out, leading to a clearing of the
 // account's storage. Subsequent account creations or balance / nonce / slot

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -44,7 +44,7 @@ type State interface {
 	// GetMemoryFootprint computes an approximation of the memory used by this state.
 	GetMemoryFootprint() *common.MemoryFootprint
 
-	// GetArchiveState provides a historical State for given block.
+	// GetArchiveState provides a historical State view for given block.
 	GetArchiveState(block uint64) (State, error)
 }
 


### PR DESCRIPTION
To make the Go / SQLite archive accessible in Aida, the following minor changes have been required:
 - allow archives to be re-opened (use "IF NOT EXIST" in table creation statements until an actual schema check is implemented)
 - ignore empty updates to keep the priming code in Aida simple
 - export the `GetArchiveState` also in the `StateDB` interface, in addition to the `State` interface
 - redirect bulk loading through the apply-update interface to also include priming data in the archive