### PR TITLE
Use uint64 for cpp state update, flush errors (fixes #383)

### DIFF
--- a/cpp/state/c_state.cc
+++ b/cpp/state/c_state.cc
@@ -174,7 +174,8 @@ template <typename State>
 WorldState* Open(const std::filesystem::path& directory, C_bool with_archive) {
   auto state = State::Open(directory, with_archive);
   if (!state.ok()) {
-    std::cout << "WARNING: Failed to open state: " << state.status() << "\n";
+    std::cout << "WARNING: Failed to open state: " << state.status() << "\n"
+              << std::flush;
     return nullptr;
   }
   return new WorldStateWrapper<State>(*std::move(state));
@@ -204,14 +205,16 @@ C_State Carmen_CreateLevelDbBasedState(const char* directory, int length,
 void Carmen_Flush(C_State state) {
   auto res = reinterpret_cast<carmen::WorldState*>(state)->Flush();
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to flush state: " << res << "\n";
+    std::cout << "WARNING: Failed to flush state: " << res << "\n"
+              << std::flush;
   }
 }
 
 void Carmen_Close(C_State state) {
   auto res = reinterpret_cast<carmen::WorldState*>(state)->Close();
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to close state: " << res << "\n";
+    std::cout << "WARNING: Failed to close state: " << res << "\n"
+              << std::flush;
   }
 }
 
@@ -232,7 +235,8 @@ void Carmen_GetAccountState(C_State state, C_Address addr,
   auto res = s.GetAccountState(a);
   if (!res.ok()) {
     std::cout << "WARNING: Failed to get account state: " << res.status()
-              << "\n";
+              << "\n"
+              << std::flush;
     return;
   }
   r = *res;
@@ -244,7 +248,8 @@ void Carmen_GetBalance(C_State state, C_Address addr, C_Balance out_balance) {
   auto& b = *reinterpret_cast<carmen::Balance*>(out_balance);
   auto res = s.GetBalance(a);
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to get balance: " << res.status() << "\n";
+    std::cout << "WARNING: Failed to get balance: " << res.status() << "\n"
+              << std::flush;
     return;
   }
   b = *res;
@@ -256,7 +261,8 @@ void Carmen_GetNonce(C_State state, C_Address addr, C_Nonce out_nonce) {
   auto& n = *reinterpret_cast<carmen::Nonce*>(out_nonce);
   auto res = s.GetNonce(a);
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to get nonce: " << res.status() << "\n";
+    std::cout << "WARNING: Failed to get nonce: " << res.status() << "\n"
+              << std::flush;
     return;
   }
   n = *res;
@@ -271,7 +277,8 @@ void Carmen_GetStorageValue(C_State state, C_Address addr, C_Key key,
   auto res = s.GetValue(a, k);
   if (!res.ok()) {
     std::cout << "WARNING: Failed to get storage value: " << res.status()
-              << "\n";
+              << "\n"
+              << std::flush;
     return;
   }
   v = *res;
@@ -283,14 +290,16 @@ void Carmen_GetCode(C_State state, C_Address addr, C_Code out_code,
   auto& a = *reinterpret_cast<carmen::Address*>(addr);
   auto code = s.GetCode(a);
   if (!code.ok()) {
-    std::cout << "WARNING: Failed to get code: " << code.status() << "\n";
+    std::cout << "WARNING: Failed to get code: " << code.status() << "\n"
+              << std::flush;
     return;
   }
   auto capacity = *out_length;
   *out_length = code->Size();
   if (code->Size() > capacity) {
     std::cout << "WARNING: Code buffer too small: " << code->Size() << " > "
-              << capacity << "\n";
+              << capacity << "\n"
+              << std::flush;
     return;
   }
   memcpy(out_code, code->Data(), code->Size());
@@ -302,7 +311,8 @@ void Carmen_GetCodeHash(C_State state, C_Address addr, C_Hash out_hash) {
   auto& h = *reinterpret_cast<carmen::Hash*>(out_hash);
   auto res = s.GetCodeHash(a);
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to get code hash: " << res.status() << "\n";
+    std::cout << "WARNING: Failed to get code hash: " << res.status() << "\n"
+              << std::flush;
     return;
   }
   h = *res;
@@ -313,26 +323,29 @@ void Carmen_GetCodeSize(C_State state, C_Address addr, uint32_t* out_length) {
   auto& a = *reinterpret_cast<carmen::Address*>(addr);
   auto res = s.GetCodeSize(a);
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to get code size: " << res.status() << "\n";
+    std::cout << "WARNING: Failed to get code size: " << res.status() << "\n"
+              << std::flush;
     return;
   }
   *out_length = *res;
 }
 
 void Carmen_Apply(C_State state, uint64_t block, C_Update update,
-                  uint32_t length) {
+                  uint64_t length) {
   auto& s = *reinterpret_cast<carmen::WorldState*>(state);
   std::span<const std::byte> data(reinterpret_cast<const std::byte*>(update),
                                   length);
   auto change = carmen::Update::FromBytes(data);
   if (!change.ok()) {
-    std::cout << "WARNING: Failed to decode update: " << change.status()
-              << "\n";
+    std::cout << "WARNING: Failed to decode update: " << change.status() << "\n"
+              << std::flush;
+
     return;
   }
   auto res = s.Apply(block, *std::move(change));
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to apply update: " << res << "\n";
+    std::cout << "WARNING: Failed to apply update: " << res << "\n"
+              << std::flush;
   }
 }
 
@@ -341,7 +354,8 @@ void Carmen_GetHash(C_State state, C_Hash out_hash) {
   auto& h = *reinterpret_cast<carmen::Hash*>(out_hash);
   auto res = s.GetHash();
   if (!res.ok()) {
-    std::cout << "WARNING: Failed to get hash: " << res.status() << "\n";
+    std::cout << "WARNING: Failed to get hash: " << res.status() << "\n"
+              << std::flush;
     return;
   }
   h = *res;

--- a/cpp/state/c_state.h
+++ b/cpp/state/c_state.h
@@ -106,7 +106,7 @@ void Carmen_GetCodeSize(C_State state, C_Address addr, uint32_t* out_length);
 
 // Applies the provided block update to the maintained state.
 void Carmen_Apply(C_State state, uint64_t block, C_Update update,
-                  uint32_t length);
+                  uint64_t length);
 
 // ------------------------------ Global Hash ---------------------------------
 

--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -168,7 +168,7 @@ func (cs *CppState) Apply(block uint64, update common.Update) error {
 	}
 	data := update.ToBytes()
 	dataPtr := unsafe.Pointer(&data[0])
-	C.Carmen_Apply(cs.state, C.uint64_t(block), dataPtr, C.uint32_t(len(data)))
+	C.Carmen_Apply(cs.state, C.uint64_t(block), dataPtr, C.uint64_t(len(data)))
 	// Apply code changes to Go-sided code cache.
 	for _, change := range update.Codes {
 		cs.codeCache.Set(change.Account, change.Code)

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -360,6 +360,7 @@ func (s *GoState) GetMemoryFootprint() *common.MemoryFootprint {
 	mf.AddChild("valuesStore", s.valuesStore.GetMemoryFootprint())
 	mf.AddChild("codesDepot", s.codesDepot.GetMemoryFootprint())
 	mf.AddChild("codeHashesStore", s.codeHashesStore.GetMemoryFootprint())
+	mf.AddChild("addressToSlots", s.addressToSlots.GetMemoryFootprint())
 	if s.archive != nil {
 		mf.AddChild("archive", s.archive.GetMemoryFootprint())
 	}


### PR DESCRIPTION
This fixes broken priming of cpp state by using uint64 for the update data length instead of uint32.
It also adds stdout flushing after error message printing to ensure it will be visible in the run-vm output. (otherwise it stays buffered and is not printed into the console/log)