### PR TITLE
Adds a LevelDB based Archive implementation in C++

### DIFF
--- a/cpp/archive/leveldb/BUILD
+++ b/cpp/archive/leveldb/BUILD
@@ -1,0 +1,98 @@
+cc_library(
+    name = "archive",
+    srcs = ["archive.cc"],
+    hdrs = ["archive.h"],
+    visibility = [
+        "//state:__subpackages__",
+        "//tools:__subpackages__",
+    ],
+    deps = [
+        ":keys",
+        ":values",
+        "//backend/common/leveldb",
+        "//common:byte_util",
+        "//common:status_util",
+        "//common:type",
+        "//state:update",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+cc_test(
+    name = "archive_test",
+    srcs = ["archive_test.cc"],
+    deps = [
+        ":archive",
+        "//archive:archive_test_suite",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "encoding",
+    srcs = ["encoding.cc"],
+    hdrs = ["encoding.h"],
+    deps = [
+        "//common:type",
+    ],
+)
+
+cc_test(
+    name = "encoding_test",
+    srcs = ["encoding_test.cc"],
+    deps = [
+        ":encoding",
+        "//common:type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "keys",
+    srcs = ["keys.cc"],
+    hdrs = ["keys.h"],
+    deps = [
+        ":encoding",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "keys_test",
+    srcs = ["keys_test.cc"],
+    deps = [
+        ":keys",
+        "//common:status_test_util",
+        "//common:type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "values",
+    srcs = ["values.cc"],
+    hdrs = ["values.h"],
+    deps = [
+        ":encoding",
+        ":keys",
+        "//common:status_util",
+        "//common:type",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "values_test",
+    srcs = ["values_test.cc"],
+    deps = [
+        ":values",
+        "//common:status_test_util",
+        "//common:type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/cpp/archive/leveldb/archive.cc
+++ b/cpp/archive/leveldb/archive.cc
@@ -1,0 +1,824 @@
+#include "archive/leveldb/archive.h"
+
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <span>
+#include <type_traits>
+
+#include "absl/base/attributes.h"
+#include "absl/container/btree_map.h"
+#include "absl/strings/str_format.h"
+#include "archive/leveldb/keys.h"
+#include "archive/leveldb/values.h"
+#include "backend/common/leveldb/leveldb.h"
+#include "common/byte_util.h"
+#include "common/hash.h"
+#include "common/status_util.h"
+
+namespace carmen::archive::leveldb {
+
+using ::carmen::backend::LDBEntry;
+using ::carmen::backend::LevelDb;
+using ::carmen::backend::LevelDbIterator;
+using ::carmen::backend::LevelDbWriteBatch;
+
+namespace internal {
+
+namespace {
+
+// Utility function to check whether one span is a prefix of another.
+bool IsPrefix(std::span<const char> prefix, std::span<const char> value) {
+  return prefix.size() <= value.size() &&
+         std::memcmp(prefix.data(), value.data(), prefix.size()) == 0;
+}
+
+// Utility function to compare two spans of charaters for equaltity.
+bool Equal(std::span<const char> a, std::span<const char> b) {
+  return a.size() == b.size() && std::memcmp(a.data(), b.data(), a.size()) == 0;
+}
+
+// An abstract utility class to iterate over a range of key/value pairs in a
+// LevelDB instance with a common prefix. It provides a common base type for
+// iterating over ranges with fixed key/value format (see TypedKeyRangeIterator
+// below).
+class KeyRangeIterator {
+ public:
+  // True, if all elements in the range have been consumed.
+  bool Finished() const { return finished_; }
+
+  // Moves this iterator to the next element. If there is no more element in the
+  // range, the iterator is marked as finished.
+  absl::Status Next() {
+    RETURN_IF_ERROR(iterator_.Next());
+    UpdateFinishState();
+    return absl::OkStatus();
+  }
+
+  // Retrieves the block number referenced by the current iterator position.
+  virtual absl::StatusOr<BlockId> GetBlock() const = 0;
+
+ protected:
+  KeyRangeIterator(LevelDbIterator iter, std::span<const char> prefix)
+      : iterator_(std::move(iter)), prefix_(prefix) {
+    UpdateFinishState();
+  }
+
+  LevelDbIterator iterator_;
+
+ private:
+  void UpdateFinishState() {
+    finished_ = iterator_.IsEnd() || !IsPrefix(prefix_, iterator_.Key());
+  }
+
+  std::span<const char> prefix_;
+  bool finished_ = false;
+};
+
+// A Key range iterator for a specific type of key and value, simplifying the
+// implementation of the verification of archives.
+template <Trivial K, typename V>
+class TypedKeyRangeIterator final : public KeyRangeIterator {
+ public:
+  // Creates a range for the given prefix in the DB.
+  static absl::StatusOr<TypedKeyRangeIterator> Get(const LevelDb& db,
+                                                   const K& example_key) {
+    auto prefix = GetAccountPrefix(example_key);
+    ASSIGN_OR_RETURN(auto iter, db.GetLowerBound(prefix));
+    return TypedKeyRangeIterator(std::move(iter), prefix);
+  }
+
+  // The block the entry pointed to by the iterator is associated to. Invalid if
+  // the iterator is finished.
+  absl::StatusOr<BlockId> GetBlock() const override {
+    ASSIGN_OR_RETURN(const K& key, Key());
+    return GetBlockFromKey(key);
+  }
+
+  // Returns a length-checked view on the current key.
+  StatusOrRef<const K> Key() const {
+    auto key = iterator_.Key();
+    if (key.size() != sizeof(K)) {
+      return absl::InternalError(
+          absl::StrFormat("Invalid key length, expected %d byte, got %d",
+                          sizeof(K), key.size()));
+    }
+    return *reinterpret_cast<const K*>(key.data());
+  }
+
+  // Returns a length-checked view on the current value.
+  absl::StatusOr<V> Value() const {
+    auto value = iterator_.Value();
+    if constexpr (std::is_same_v<V, AccountState>) {
+      if (value.size() != sizeof(AccountState().Encode())) {
+        return absl::InternalError(
+            absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                            sizeof(AccountState().Encode()), value.size()));
+      }
+      return AccountState::From(value);
+    } else if constexpr (std::is_same_v<V, Code>) {
+      return Code(value);
+    } else {
+      static_assert(Trivial<V>);
+      if (value.size() != sizeof(V)) {
+        return absl::InternalError(
+            absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                            sizeof(V), value.size()));
+      }
+      return *reinterpret_cast<const V*>(value.data());
+    }
+  }
+
+ private:
+  using KeyRangeIterator::KeyRangeIterator;
+};
+
+}  // namespace
+
+// The Archive is the actual implementation of the LevelDbArchive, hidding in
+// the implementation file to avoid overloading headers.
+class Archive {
+ public:
+  static absl::StatusOr<std::unique_ptr<Archive>> Open(
+      const std::filesystem::path directory) {
+    ASSIGN_OR_RETURN(auto db, LevelDb::Open(directory));
+    return std::unique_ptr<Archive>(new Archive(std::move(db)));
+  }
+
+  absl::Status Add(BlockId block, const Update& update) {
+    absl::MutexLock guard(&update_lock_);
+    ASSIGN_OR_RETURN(std::int64_t latest, GetLatestBlock());
+    if (std::int64_t(block) <= latest) {
+      return absl::InternalError(absl::StrFormat(
+          "Unable to insert block %d, archive already contains block %d", block,
+          latest));
+    }
+
+    // Empty updates are ignored, no hashes are altered.
+    if (update.Empty()) {
+      return absl::OkStatus();
+    }
+
+    // Compute hashes of account updates.
+    absl::btree_map<Address, Hash> diff_hashes;
+    for (const auto& [addr, diff] : AccountUpdate::From(update)) {
+      diff_hashes[addr] = diff.GetHash();
+    }
+
+    // Utility to fetch the latest reincarnation number of an account.
+    auto get_reincarnation =
+        [&](const Address& addr) -> absl::StatusOr<ReincarnationNumber> {
+      auto pos = reincarnation_cache_.find(addr);
+      if (pos != reincarnation_cache_.end()) {
+        return pos->second;
+      }
+      ASSIGN_OR_RETURN((auto [_, r]), GetAccountState(block, addr));
+      reincarnation_cache_[addr] = r;
+      return r;
+    };
+
+    LevelDbWriteBatch batch;
+    for (const auto& addr : update.GetDeletedAccounts()) {
+      ASSIGN_OR_RETURN((auto state), GetAccountState(block, addr));
+      state.exists = false;
+      state.reincarnation_number++;
+      reincarnation_cache_[addr] = state.reincarnation_number;
+      batch.Put(GetAccountStateKey(addr, block), state.Encode());
+    }
+
+    for (const auto& addr : update.GetCreatedAccounts()) {
+      ASSIGN_OR_RETURN((auto state), GetAccountState(block, addr));
+      state.exists = true;
+      state.reincarnation_number++;
+      reincarnation_cache_[addr] = state.reincarnation_number;
+      batch.Put(GetAccountStateKey(addr, block), state.Encode());
+    }
+
+    for (const auto& [addr, balance] : update.GetBalances()) {
+      batch.Put(GetBalanceKey(addr, block), AsChars(balance));
+    }
+
+    for (const auto& [addr, code] : update.GetCodes()) {
+      batch.Put(GetCodeKey(addr, block),
+                std::span<const char>(
+                    reinterpret_cast<const char*>(code.Data()), code.Size()));
+    }
+
+    for (const auto& [addr, nonce] : update.GetNonces()) {
+      batch.Put(GetNonceKey(addr, block), AsChars(nonce));
+    }
+
+    for (const auto& [addr, key, value] : update.GetStorage()) {
+      ASSIGN_OR_RETURN(auto r, get_reincarnation(addr));
+      batch.Put(GetStorageKey(addr, r, key, block), AsChars(value));
+    }
+
+    Sha256Hasher hasher;
+    ASSIGN_OR_RETURN(auto last_block_hash, GetHash(block));
+    hasher.Ingest(last_block_hash);
+
+    for (auto& [addr, hash] : diff_hashes) {
+      ASSIGN_OR_RETURN(auto last_hash, GetAccountHash(block, addr));
+      auto new_hash = GetSha256Hash(last_hash, hash);
+      batch.Put(GetAccountHashKey(addr, block), AsChars(new_hash));
+      hasher.Ingest(new_hash);
+    }
+
+    batch.Put(GetBlockKey(block), AsChars(hasher.GetHash()));
+
+    return db_.Add(std::move(batch));
+  }
+
+  absl::StatusOr<bool> Exists(BlockId block, const Address& address) {
+    ASSIGN_OR_RETURN((auto [exists, _]), GetAccountState(block, address));
+    return exists;
+  }
+
+  absl::StatusOr<Balance> GetBalance(BlockId block, const Address& address) {
+    return FindMostRecentFor<Balance>(block, GetBalanceKey(address, block));
+  }
+
+  absl::StatusOr<Code> GetCode(BlockId block, const Address& address) {
+    return FindMostRecentFor<Code>(block, GetCodeKey(address, block));
+  }
+
+  absl::StatusOr<Nonce> GetNonce(BlockId block, const Address& address) {
+    return FindMostRecentFor<Nonce>(block, GetNonceKey(address, block));
+  }
+
+  absl::StatusOr<Value> GetStorage(BlockId block, const Address& address,
+                                   const Key& key) {
+    ASSIGN_OR_RETURN((auto [_, r]), GetAccountState(block, address));
+    return FindMostRecentFor<Value>(block,
+                                    GetStorageKey(address, r, key, block));
+  }
+
+  // Gets the maximum block height insert so far, returns -1 if there is none.
+  absl::StatusOr<std::int64_t> GetLatestBlock() {
+    BlockId max_block = std::numeric_limits<BlockId>::max();
+    auto key = GetBlockKey(max_block);
+    ASSIGN_OR_RETURN(auto iter, db_.GetLowerBound(key));
+    if (iter.IsEnd()) {
+      RETURN_IF_ERROR(iter.Prev());
+    } else if (Equal(key, iter.Key())) {
+      return max_block;
+    } else {
+      RETURN_IF_ERROR(iter.Prev());
+    }
+    if (iter.IsBegin()) {
+      return -1;
+    }
+    auto got = iter.Key();
+    if (key.size() != got.size() || key[0] != got[0]) {
+      return -1;
+    }
+    return GetBlockFromKey(got);
+  }
+
+  absl::StatusOr<Hash> GetHash(BlockId block) {
+    return FindMostRecentFor<Hash>(block, GetBlockKey(block));
+  }
+
+  absl::StatusOr<std::vector<Address>> GetAccountList(BlockId block) {
+    std::vector<Address> result;
+    auto min_key = GetAccountHashKey(Address{}, 0);
+    ASSIGN_OR_RETURN(auto iter, db_.GetLowerBound(min_key));
+    while (!iter.IsEnd() && iter.Key()[0] == min_key[0]) {
+      auto current_block = GetBlockFromKey(iter.Key());
+      const Address* current =
+          reinterpret_cast<const Address*>(iter.Key().data() + 1);
+      if (current_block <= block &&
+          (result.empty() || result.back() != *current)) {
+        result.push_back(*current);
+      }
+      RETURN_IF_ERROR(iter.Next());
+    }
+    return result;
+  }
+
+  absl::StatusOr<Hash> GetAccountHash(BlockId block, const Address& address) {
+    return FindMostRecentFor<Hash>(block, GetAccountHashKey(address, block));
+  }
+
+  absl::Status Verify(
+      BlockId block, const Hash& expected_hash,
+      absl::FunctionRef<void(std::string_view)> progress_callback) {
+    // First, check the expected hash.
+    progress_callback("checking block hashes");
+    ASSIGN_OR_RETURN(auto hash, GetHash(block));
+    if (hash != expected_hash) {
+      return absl::InternalError("Archive hash does not match expected hash.");
+    }
+
+    // Verify that the block hashes are consistent within the archive.
+    RETURN_IF_ERROR(VerifyHashes(block));
+
+    // Validate all individual accounts.
+    progress_callback("getting list of accounts");
+    ASSIGN_OR_RETURN(auto accounts, GetAccountList(block));
+    progress_callback(absl::StrFormat("checking %d accounts", accounts.size()));
+    for (const auto& cur : accounts) {
+      RETURN_IF_ERROR(VerifyAccount(block, cur));
+    }
+
+    // Check that there is no extra information in any of the content tables.
+    progress_callback("checking for extra data not covered by hashes");
+    ASSIGN_OR_RETURN(auto latest_block, GetLatestBlock());
+    absl::flat_hash_set<Address> valid_accounts(accounts.begin(),
+                                                accounts.end());
+    for (KeyType type :
+         {KeyType::kAccountState, KeyType::kAccountHash, KeyType::kBalance,
+          KeyType::kCode, KeyType::kNonce, KeyType::kStorage}) {
+      char prefix = static_cast<char>(type);
+      ASSIGN_OR_RETURN(auto iter, db_.GetLowerBound(std::span(&prefix, 1)));
+      while (!iter.IsEnd() && iter.Key()[0] == prefix) {
+        auto current_block = GetBlockFromKey(iter.Key());
+
+        // Make sure there are no extra accounts included.
+        if (current_block <= block) {
+          auto& addr = GetAddressFromKey(iter.Key());
+          if (!valid_accounts.contains(addr)) {
+            return absl::InternalError(
+                absl::StrFormat("Found extra key/value pair in key space `%s`.",
+                                ToString(type)));
+          }
+        }
+
+        // Make sure there is are no future blocks included.
+        if (current_block > latest_block) {
+          return absl::InternalError(absl::StrFormat(
+              "Found entry of future block height in key space `%s`.",
+              ToString(type)));
+        }
+        RETURN_IF_ERROR(iter.Next());
+      }
+    }
+
+    // All checks have passed. DB is verified.
+    return absl::OkStatus();
+  }
+
+  // Verifies the consistency of the stored full archive hashes up until (and
+  // including) the given block number.
+  absl::Status VerifyHashes(BlockId max_block) {
+    // For the verification we need to have all account hashes indexed by block
+    // height. However, the key store is sorted by account. Thus, we need to
+    // create a temporary index. We place this currently in memory, if this
+    // becomes a problem, a disk-backed index (e.g. Btree) will be required.
+
+    // Used to index the diff hashes for each block, in order of the account
+    // addresses.
+    absl::btree_map<std::pair<BlockId, int>, Hash> account_hashes;
+
+    {
+      // Used to count the number of diffs per block.
+      absl::btree_map<BlockId, int> num_diffs;
+      char prefix = static_cast<char>(KeyType::kAccountHash);
+      ASSIGN_OR_RETURN(auto iter, db_.GetLowerBound(std::span(&prefix, 1)));
+      while (!iter.IsEnd() && iter.Key()[0] == prefix) {
+        if (iter.Key().size() != sizeof(AccountHashKey)) {
+          return absl::InternalError(
+              "Invalid account hash key length encountered.");
+        }
+        if (iter.Value().size() != sizeof(Hash)) {
+          return absl::InternalError(
+              "Invalid account hash value length encountered.");
+        }
+        BlockId block = GetBlockFromKey(iter.Key());
+        if (block <= max_block) {
+          auto pos = num_diffs[block]++;
+          account_hashes[{block, pos}].SetBytes(iter.Value());
+        }
+        RETURN_IF_ERROR(iter.Next());
+      }
+    }
+
+    // Verify the block hash for each block.
+    auto account_hash_iter = account_hashes.begin();
+
+    Hash hash{};
+    Sha256Hasher hasher;
+    char prefix = static_cast<char>(KeyType::kBlock);
+    ASSIGN_OR_RETURN(auto block_hash_iter,
+                     db_.GetLowerBound(std::span(&prefix, 1)));
+    while (!block_hash_iter.IsEnd() && block_hash_iter.Key()[0] == prefix) {
+      if (block_hash_iter.Key().size() != sizeof(BlockKey)) {
+        return absl::InternalError("Invalid block key length encountered.");
+      }
+      if (block_hash_iter.Value().size() != sizeof(Hash)) {
+        return absl::InternalError("Invalid block value length encountered.");
+      }
+
+      auto current_block = GetBlockFromKey(block_hash_iter.Key());
+      if (current_block > max_block) {
+        break;
+      }
+
+      if (account_hash_iter == account_hashes.end() ||
+          account_hash_iter->first.first > current_block) {
+        return absl::InternalError(
+            absl::StrFormat("No diff hash found for block %d.", current_block));
+      }
+      if (account_hash_iter->first.first < current_block) {
+        return absl::InternalError(absl::StrFormat(
+            "Found account update for block %d but no hash for this block.",
+            account_hash_iter->first.first));
+      }
+
+      // Re-compute hash for current block.
+      hasher.Reset();
+      hasher.Ingest(hash);
+      while (account_hash_iter != account_hashes.end() &&
+             account_hash_iter->first.first == current_block) {
+        hasher.Ingest(account_hash_iter->second);
+        account_hash_iter++;
+      }
+      hash = hasher.GetHash();
+
+      Hash have;
+      have.SetBytes(block_hash_iter.Value());
+      if (hash != have) {
+        return absl::InternalError(absl::StrFormat(
+            "Validation of hash of block %d failed.", current_block));
+      }
+
+      RETURN_IF_ERROR(block_hash_iter.Next());
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::Status VerifyAccount(BlockId block, const Address& account) const {
+    using ::carmen::backend::LevelDbIterator;
+
+    // Open iterators on various account properties.
+    auto account_hash_key = GetAccountHashKey(account, 0);
+    ASSIGN_OR_RETURN(auto hash_iter,
+                     (TypedKeyRangeIterator<AccountHashKey, Hash>::Get(
+                         db_, account_hash_key)));
+
+    auto state_key = GetAccountStateKey(account, 0);
+    ASSIGN_OR_RETURN(auto state_iter,
+                     (TypedKeyRangeIterator<AccountStateKey, AccountState>::Get(
+                         db_, state_key)));
+
+    auto balance_key = GetBalanceKey(account, 0);
+    ASSIGN_OR_RETURN(
+        auto balance_iter,
+        (TypedKeyRangeIterator<BalanceKey, Balance>::Get(db_, balance_key)));
+
+    auto nonce_key = GetNonceKey(account, 0);
+    ASSIGN_OR_RETURN(
+        auto nonce_iter,
+        (TypedKeyRangeIterator<NonceKey, Nonce>::Get(db_, nonce_key)));
+
+    auto code_key = GetCodeKey(account, 0);
+    ASSIGN_OR_RETURN(auto code_iter, (TypedKeyRangeIterator<CodeKey, Code>::Get(
+                                         db_, code_key)));
+
+    // Storage data is stored in DB using [account,reincarnation,key,block]
+    // order, but for the verification we need it in [account,block,key] order.
+    absl::btree_map<std::pair<BlockId, Key>,
+                    std::pair<ReincarnationNumber, Value>>
+        storage_data;
+
+    {
+      auto storage_key = GetStorageKey(account, 0, Key{}, 0);
+      ASSIGN_OR_RETURN(
+          auto storage_iter,
+          (TypedKeyRangeIterator<StorageKey, Value>::Get(db_, storage_key)));
+
+      while (!storage_iter.Finished()) {
+        ASSIGN_OR_RETURN(StorageKey storage_key, storage_iter.Key());
+        auto current_block = GetBlockFromKey(storage_key);
+        if (current_block <= block) {
+          auto key = GetSlotKey(storage_key);
+          auto reincarnation = GetReincarnationNumber(storage_key);
+          ASSIGN_OR_RETURN(Value value, storage_iter.Value());
+          storage_data[{current_block, key}] = {reincarnation, value};
+        }
+        RETURN_IF_ERROR(storage_iter.Next());
+      }
+    }
+    auto storage_iter = storage_data.begin();
+    auto storage_iter_end = storage_data.end();
+
+    KeyRangeIterator* property_iterators[] = {&state_iter, &balance_iter,
+                                              &nonce_iter, &code_iter};
+
+    // Find the first block referencing the account.
+    auto get_next_block = [&]() -> absl::StatusOr<BlockId> {
+      BlockId next = block + 1;
+      for (KeyRangeIterator* iter : property_iterators) {
+        if (!iter->Finished()) {
+          ASSIGN_OR_RETURN(auto block, iter->GetBlock());
+          next = std::min<BlockId>(next, block);
+        }
+      }
+      if (storage_iter != storage_iter_end) {
+        next = std::min<BlockId>(next, storage_iter->first.first);
+      }
+      return next;
+    };
+    ASSIGN_OR_RETURN(BlockId next, get_next_block());
+
+    // Keep track of the reincarnation number.
+    ReincarnationNumber reincarnation = 0;
+
+    Hash hash{};
+    std::optional<BlockId> last;
+    while (next <= block) {
+      BlockId current = next;
+      if (last.has_value() && current <= last) {
+        // This should only be possible if if the DB is corrupted and has
+        // multiple identical keys ore keys out-of-order.
+        return absl::InternalError(absl::StrFormat(
+            "Corrupted DB: multiple updates for block %d found", current));
+      }
+      last = current;
+
+      // --- Recreate Update for Current Block ---
+      AccountUpdate update;
+
+      if (!state_iter.Finished() && *state_iter.GetBlock() == current) {
+        ASSIGN_OR_RETURN(auto state, state_iter.Value());
+        if (state.exists) {
+          update.created = true;
+        } else {
+          update.deleted = true;
+        }
+        auto new_reincarnation_number = state.reincarnation_number;
+        if (new_reincarnation_number != reincarnation + 1) {
+          return absl::InternalError(absl::StrFormat(
+              "Reincarnation numbers are not incremental, at block %d the "
+              "value moves from %d to %d",
+              current, reincarnation, new_reincarnation_number));
+        }
+        reincarnation = new_reincarnation_number;
+        RETURN_IF_ERROR(state_iter.Next());
+      }
+
+      if (!balance_iter.Finished() && *balance_iter.GetBlock() == current) {
+        ASSIGN_OR_RETURN(update.balance, balance_iter.Value());
+        RETURN_IF_ERROR(balance_iter.Next());
+      }
+
+      if (!nonce_iter.Finished() && *nonce_iter.GetBlock() == current) {
+        ASSIGN_OR_RETURN(update.nonce, nonce_iter.Value());
+        RETURN_IF_ERROR(nonce_iter.Next());
+      }
+
+      if (!code_iter.Finished() && *code_iter.GetBlock() == current) {
+        ASSIGN_OR_RETURN(update.code, code_iter.Value());
+        RETURN_IF_ERROR(code_iter.Next());
+      }
+
+      while (storage_iter != storage_iter_end &&
+             storage_iter->first.first == current) {
+        ReincarnationNumber cur_reincarnation = storage_iter->second.first;
+        if (cur_reincarnation != reincarnation) {
+          return absl::InternalError(
+              absl::StrFormat("Invalid reincarnation number for storage value "
+                              "at block %d, expected %d, got %d",
+                              current, reincarnation, cur_reincarnation));
+        }
+        Key key = storage_iter->first.second;
+        Value value = storage_iter->second.second;
+        update.storage.push_back({key, value});
+        ++storage_iter;
+      }
+
+      // --- Check that the current update matches the current block ---
+
+      // Check the update against the list of per-account hashes.
+      if (hash_iter.Finished()) {
+        return absl::InternalError(absl::StrFormat(
+            "Archive contains update for block %d but no hash for it.",
+            current));
+      }
+      ASSIGN_OR_RETURN(BlockId diff_block, hash_iter.GetBlock());
+      if (diff_block != current) {
+        if (diff_block < current) {
+          return absl::InternalError(
+              absl::StrFormat("Archive contains hash for update at block %d "
+                              "but no change for it.",
+                              diff_block));
+        } else {
+          return absl::InternalError(absl::StrFormat(
+              "Archive contains update for block %d but no hash for it.",
+              current));
+        }
+      }
+
+      // Compute the hash based on the diff.
+      hash = GetSha256Hash(hash, update.GetHash());
+
+      // Compare with hash stored in DB.
+      ASSIGN_OR_RETURN(Hash should, hash_iter.Value());
+      if (hash != should) {
+        return absl::InternalError(absl::StrFormat(
+            "Hash for diff at block %d does not match.", current));
+      }
+      RETURN_IF_ERROR(hash_iter.Next());
+
+      // Find next block to be processed.
+      ASSIGN_OR_RETURN(next, get_next_block());
+    }
+
+    // Check whether there are additional updates in the hash table.
+    if (!hash_iter.Finished() && *hash_iter.GetBlock() < block) {
+      return absl::InternalError(absl::StrFormat(
+          "Found change in block %d not covered by archive hash.",
+          *hash_iter.GetBlock()));
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::Status Flush() { return db_.Flush(); }
+
+  absl::Status Close() { return db_.Close(); }
+
+  MemoryFootprint GetMemoryFootprint() const {
+    MemoryFootprint res(*this);
+    res.Add("leveldb", db_.GetMemoryFootprint());
+    return res;
+  }
+
+ private:
+  Archive(LevelDb db) : db_(std::move(db)) {}
+
+  // A utility function to locate the value mapped to the given key, or, if not
+  // present, the value mapped to the same key with the next smaller block
+  // number. If there is no such entry, the default value is returned.
+  template <typename Value>
+  absl::StatusOr<Value> FindMostRecentFor(BlockId block,
+                                          std::span<const char> key) {
+    ASSIGN_OR_RETURN(auto iter, db_.GetLowerBound(key));
+    if (iter.IsEnd()) {
+      RETURN_IF_ERROR(iter.Prev());
+    } else {
+      if (!Equal(key, iter.Key())) {
+        RETURN_IF_ERROR(iter.Prev());
+      }
+    }
+    if (!iter.Valid() || iter.Key().size() != key.size()) {
+      return Value{};
+    }
+
+    auto want_without_block = key.subspan(0, key.size() - sizeof(BlockId));
+    auto have_without_block =
+        iter.Key().subspan(0, key.size() - sizeof(BlockId));
+    if (block < GetBlockFromKey(iter.Key()) ||
+        !Equal(want_without_block, have_without_block)) {
+      return Value{};
+    }
+
+    auto expected_size = std::is_same_v<Value, AccountState>
+                             ? sizeof(AccountState().Encode())
+                             : sizeof(Value);
+    if (!std::is_same_v<Value, Code> && iter.Value().size() != expected_size) {
+      return absl::InternalError("stored value has wrong format");
+    }
+
+    if constexpr (std::is_same_v<Value, AccountState>) {
+      return AccountState::From(iter.Value());
+    } else {
+      Value result;
+      result.SetBytes(std::as_bytes(iter.Value()));
+      return result;
+    }
+  }
+
+  absl::StatusOr<AccountState> GetAccountState(BlockId block,
+                                               const Address& account) {
+    return FindMostRecentFor<AccountState>(block,
+                                           GetAccountStateKey(account, block));
+  }
+
+  LevelDb db_;
+
+  // A cache holding the reincarnation number of all addresses at the latest
+  // block height.
+  absl::flat_hash_map<Address, ReincarnationNumber> reincarnation_cache_;
+
+  // A mutex making sure that Archive updates are written with exclusive access
+  // to the DB. This exclusive access is required to keep the internal
+  // reincarnation cache in sync.
+  absl::Mutex update_lock_;
+};
+
+}  // namespace internal
+
+LevelDbArchive::LevelDbArchive(LevelDbArchive&&) = default;
+
+LevelDbArchive::LevelDbArchive(std::unique_ptr<internal::Archive> archive)
+    : impl_(std::move(archive)){};
+
+LevelDbArchive& LevelDbArchive::operator=(LevelDbArchive&&) = default;
+
+LevelDbArchive::~LevelDbArchive() { Close().IgnoreError(); };
+
+absl::StatusOr<LevelDbArchive> LevelDbArchive::Open(
+    std::filesystem::path directory) {
+  ASSIGN_OR_RETURN(auto impl, internal::Archive::Open(directory));
+  return LevelDbArchive(std::move(impl));
+}
+
+absl::Status LevelDbArchive::Add(BlockId block, const Update& update) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->Add(block, update);
+}
+
+absl::StatusOr<bool> LevelDbArchive::Exists(BlockId block,
+                                            const Address& account) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->Exists(block, account);
+}
+
+absl::StatusOr<Balance> LevelDbArchive::GetBalance(BlockId block,
+                                                   const Address& account) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetBalance(block, account);
+}
+
+absl::StatusOr<Code> LevelDbArchive::GetCode(BlockId block,
+                                             const Address& account) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetCode(block, account);
+}
+
+absl::StatusOr<Nonce> LevelDbArchive::GetNonce(BlockId block,
+                                               const Address& account) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetNonce(block, account);
+}
+
+absl::StatusOr<Value> LevelDbArchive::GetStorage(BlockId block,
+                                                 const Address& account,
+                                                 const Key& key) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetStorage(block, account, key);
+}
+
+absl::StatusOr<BlockId> LevelDbArchive::GetLatestBlock() {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetLatestBlock();
+}
+
+absl::StatusOr<Hash> LevelDbArchive::GetHash(BlockId block) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetHash(block);
+}
+
+absl::StatusOr<std::vector<Address>> LevelDbArchive::GetAccountList(
+    BlockId block) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetAccountList(block);
+}
+
+absl::StatusOr<Hash> LevelDbArchive::GetAccountHash(BlockId block,
+                                                    const Address& account) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->GetAccountHash(block, account);
+}
+
+absl::Status LevelDbArchive::Verify(
+    BlockId block, const Hash& expected_hash,
+    absl::FunctionRef<void(std::string_view)> progress_callback) {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->Verify(block, expected_hash, progress_callback);
+}
+
+absl::Status LevelDbArchive::VerifyAccount(BlockId block,
+                                           const Address& account) const {
+  RETURN_IF_ERROR(CheckState());
+  return impl_->VerifyAccount(block, account);
+}
+
+absl::Status LevelDbArchive::Flush() {
+  if (!impl_) return absl::OkStatus();
+  return impl_->Flush();
+}
+
+absl::Status LevelDbArchive::Close() {
+  if (!impl_) return absl::OkStatus();
+  auto result = impl_->Close();
+  impl_ = nullptr;
+  return result;
+}
+
+MemoryFootprint LevelDbArchive::GetMemoryFootprint() const {
+  MemoryFootprint res(*this);
+  if (impl_) {
+    res.Add("impl", impl_->GetMemoryFootprint());
+  }
+  return res;
+}
+
+absl::Status LevelDbArchive::CheckState() const {
+  if (impl_) return absl::OkStatus();
+  return absl::FailedPreconditionError("Archive not connected to DB.");
+}
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/archive.h
+++ b/cpp/archive/leveldb/archive.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string_view>
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "common/memory_usage.h"
+#include "common/type.h"
+#include "state/update.h"
+
+namespace carmen::archive::leveldb {
+
+namespace internal {
+class Archive;
+}
+
+// A LevelDB key/value store based implementation of an Archive.
+class LevelDbArchive {
+ public:
+  // Opens the archive located in the given directory. May fail if the directory
+  // can not be accessed or the data format in the contained database does not
+  // match requirements.
+  static absl::StatusOr<LevelDbArchive> Open(std::filesystem::path directory);
+
+  LevelDbArchive(LevelDbArchive&&);
+  LevelDbArchive& operator=(LevelDbArchive&&);
+  ~LevelDbArchive();
+
+  // Adds the changes of the given block to this archive.
+  absl::Status Add(BlockId block, const Update& update);
+
+  // Allows to test whether an account exists at the given block height.
+  absl::StatusOr<bool> Exists(BlockId block, const Address& account);
+
+  // Allows to fetch a historic balance values for a given account.
+  absl::StatusOr<Balance> GetBalance(BlockId block, const Address& account);
+
+  // Allows to fetch a historic code values for a given account.
+  absl::StatusOr<Code> GetCode(BlockId block, const Address& account);
+
+  // Allows to fetch a historic nonce values for a given account.
+  absl::StatusOr<Nonce> GetNonce(BlockId block, const Address& account);
+
+  // Allows to fetch a historic value for a given slot.
+  absl::StatusOr<Value> GetStorage(BlockId block, const Address& account,
+                                   const Key& key);
+
+  // Obtains the last block included in this archive, 0 if empty.
+  absl::StatusOr<BlockId> GetLatestBlock();
+
+  // Computes a hash for the entire archive up until the given block.
+  absl::StatusOr<Hash> GetHash(BlockId block);
+
+  // Obtains a full list of addresses encountered up until the given block.
+  absl::StatusOr<std::vector<Address>> GetAccountList(BlockId block);
+
+  // Obtains a hash on the content of the given hash at the given block height.
+  absl::StatusOr<Hash> GetAccountHash(BlockId block, const Address& account);
+
+  // Verifies that the content of this archive up until the given block.
+  absl::Status Verify(
+      BlockId block, const Hash& expected_hash,
+      absl::FunctionRef<void(std::string_view)> progress_callback =
+          [](std::string_view) {});
+
+  // Verifies the given account at the given block height.
+  absl::Status VerifyAccount(BlockId block, const Address& account) const;
+
+  // Flushes all temporary changes to disk.
+  absl::Status Flush();
+
+  // Closes the archive. This disconnects the archive from the underlying DB and
+  // no further member function calls will be successful.
+  absl::Status Close();
+
+  // Summarizes the memory usage of this archive.
+  MemoryFootprint GetMemoryFootprint() const;
+
+ private:
+  LevelDbArchive(std::unique_ptr<internal::Archive> archive);
+
+  absl::Status CheckState() const;
+
+  // The actual archive implementation is hidden using an opaque internal type.
+  std::unique_ptr<internal::Archive> impl_;
+};
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/archive_test.cc
+++ b/cpp/archive/leveldb/archive_test.cc
@@ -1,0 +1,657 @@
+#include "archive/leveldb/archive.h"
+
+#include "absl/strings/str_format.h"
+#include "archive/archive_test_suite.h"
+#include "archive/leveldb/keys.h"
+#include "archive/leveldb/values.h"
+#include "backend/common/leveldb/leveldb.h"
+#include "gtest/gtest.h"
+
+namespace carmen::archive::leveldb {
+namespace {
+
+using ::carmen::backend::LevelDb;
+
+// Instantiates common archive tests for the LevelDB implementation.
+INSTANTIATE_TYPED_TEST_SUITE_P(LevelDbTest, ArchiveTest, LevelDbArchive);
+
+template <typename Check>
+void TestCorruption(absl::FunctionRef<void(LevelDb& db)> change,
+                    const Check& check) {
+  TempDir dir;
+  Address addr{0x01};
+  Hash hash;
+  // Initialize an account with a bit of history.
+  {
+    ASSERT_OK_AND_ASSIGN(auto archive, LevelDbArchive::Open(dir));
+    Update update1;
+    update1.Create(addr);
+    update1.Set(addr, Balance{0x12});
+    update1.Set(addr, Nonce{0x13});
+    update1.Set(addr, Code{0x14});
+    update1.Set(addr, Key{0x15}, Value{0x16});
+    EXPECT_OK(archive.Add(1, update1));
+
+    Update update3;
+    update3.Delete(addr);
+    update3.Set(addr, Balance{0x31});
+    update3.Set(addr, Nonce{0x33});
+    update3.Set(addr, Code{0x34});
+    update3.Set(addr, Key{0x35}, Value{0x36});
+    EXPECT_OK(archive.Add(3, update3));
+
+    Update update5;
+    update5.Create(addr);
+    update5.Set(addr, Balance{0x51});
+    EXPECT_OK(archive.Add(5, update5));
+
+    for (BlockId i = 0; i < 10; i++) {
+      EXPECT_OK(archive.VerifyAccount(i, addr));
+    }
+
+    ASSERT_OK_AND_ASSIGN(hash, archive.GetHash(10));
+    EXPECT_OK(archive.Verify(10, hash));
+    EXPECT_OK(archive.Close());
+  }
+  // Allow the test case to mess with the DB.
+  {
+    ASSERT_OK_AND_ASSIGN(auto db, LevelDb::Open(dir));
+    change(db);
+    ASSERT_OK(db.Close());
+  }
+  // Reopen the archive and make sure the issue is detected.
+  {
+    ASSERT_OK_AND_ASSIGN(auto archive, LevelDbArchive::Open(dir));
+    check(archive, hash);
+  }
+}
+
+void TestAccountCorruption(absl::FunctionRef<void(LevelDb& db)> change,
+                           std::string_view error = "") {
+  TestCorruption(change, [&](LevelDbArchive& archive, const Hash&) {
+    EXPECT_THAT(archive.VerifyAccount(10, Address{0x01}),
+                StatusIs(_, HasSubstr(error)));
+  });
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingHash) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Delete(GetAccountHashKey(Address{0x01}, 3)));
+      },
+      "Archive contains update for block 3 but no hash for it.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedAccountHashKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetAccountHashKey(Address{0x01}, 3);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 24");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetAccountHashKey(Address{0x01}, 3);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 26");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedAccountHashValue) {
+  // Detects a too short value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Hash) - 1, 'x')));
+      },
+      "Invalid value length, expected 32 byte, got 31");
+
+  // Detects a too long value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Hash) + 1, 'x')));
+      },
+      "Invalid value length, expected 32 byte, got 33");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedStatusUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 1),
+                         AccountState{false, 1}.Encode()));
+      },
+      "Hash for diff at block 1 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsAdditionalStatusUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 2),
+                         AccountState{true, 2}.Encode()));
+      },
+      "Archive contains update for block 2 but no hash for it.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedReincarnationNumber) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 1),
+                         AccountState{true, 2}.Encode()));
+      },
+      "Reincarnation numbers are not incremental");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingStatusUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Delete(GetAccountStateKey(Address{0x01}, 3)));
+      },
+      "Invalid reincarnation number for storage value at block 3, expected 1, "
+      "got 2");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedAccountStatusKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetAccountStateKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 24");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetAccountStateKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 26");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedAccountStatusValue) {
+  static const auto kAccountStateSize = sizeof(AccountState{}.Encode());
+  // Detects a too short value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 3),
+                         std::vector<char>(kAccountStateSize - 1, 'x')));
+      },
+      "Invalid value length, expected 5 byte, got 4");
+
+  // Detects a too long value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 3),
+                         std::vector<char>(kAccountStateSize + 1, 'x')));
+      },
+      "Invalid value length, expected 5 byte, got 6");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingBalanceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Delete(GetBalanceKey(Address{0x01}, 1)));
+      },
+      "Hash for diff at block 1 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedBalanceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 3), Balance{0xFF}));
+      },
+      "Hash for diff at block 3 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsAdditionalBalanceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 4), Balance{0xFF}));
+      },
+      "Archive contains update for block 4 but no hash for it.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedBalanceKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetBalanceKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 24");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetBalanceKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 26");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedBalanceValue) {
+  // Detects a too short value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Balance) - 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Balance), sizeof(Balance) - 1));
+
+  // Detects a too long value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Balance) + 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Balance), sizeof(Balance) + 1));
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingNonceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) { ASSERT_OK(db.Delete(GetNonceKey(Address{0x01}, 1))); },
+      "Hash for diff at block 1 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedNonceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x01}, 3), Nonce{0xFF}));
+      },
+      "Hash for diff at block 3 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsAdditionalNonceUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x01}, 4), Nonce{0xFF}));
+      },
+      "Archive contains update for block 4 but no hash for it.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedNonceKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetNonceKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 24");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetNonceKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 26");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedNonceValue) {
+  // Detects a too short value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Nonce) - 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Nonce), sizeof(Nonce) - 1));
+
+  // Detects a too long value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x01}, 3),
+                         std::vector<char>(sizeof(Nonce) + 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Nonce), sizeof(Nonce) + 1));
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingCodeUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) { ASSERT_OK(db.Delete(GetCodeKey(Address{0x01}, 1))); },
+      "Hash for diff at block 1 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedCodeUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetCodeKey(Address{0x01}, 3), Code{0xFF}));
+      },
+      "Hash for diff at block 3 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsAdditionalCodeUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetCodeKey(Address{0x01}, 4), Code{0xFF}));
+      },
+      "Archive contains update for block 4 but no hash for it.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedCodeKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetCodeKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 24");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetCodeKey(Address{0x01}, 1);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 25 byte, got 26");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMissingStorageUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) { ASSERT_OK(db.Delete(GetCodeKey(Address{0x01}, 1))); },
+      "Hash for diff at block 1 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsModifiedStorageUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        // Change the key ..
+        ASSERT_OK(db.Delete(GetStorageKey(Address{0x01}, 2, Key{0x35}, 3)));
+        ASSERT_OK(
+            db.Add(GetStorageKey(Address{0x01}, 2, Key{0xFF}, 3), Value{0x36}));
+      },
+      "Hash for diff at block 3 does not match.");
+
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        // Change the value
+        ASSERT_OK(
+            db.Add(GetStorageKey(Address{0x01}, 2, Key{0x35}, 3), Value{0xFF}));
+      },
+      "Hash for diff at block 3 does not match.");
+
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        // Change the reincarnation number.
+        ASSERT_OK(db.Delete(GetStorageKey(Address{0x01}, 2, Key{0x35}, 3)));
+        ASSERT_OK(
+            db.Add(GetStorageKey(Address{0x01}, 3, Key{0x35}, 3), Value{0x36}));
+      },
+      "Invalid reincarnation number for storage value at block 3, expected 2, "
+      "got 3");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsAdditionalStorageUpdate) {
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(
+            db.Add(GetStorageKey(Address{0x01}, 2, Key{0xAB}, 4), Value{0xCD}));
+      },
+      "Archive contains update for block 4 but no hash for it.");
+
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(
+            db.Add(GetStorageKey(Address{0x01}, 2, Key{0xAB}, 3), Value{0xCD}));
+      },
+      "Hash for diff at block 3 does not match.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedStorageKey) {
+  // Detects a too short key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetStorageKey(Address{0x01}, 2, Key{0x35}, 3);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid key length, expected 61 byte, got 60");
+
+  // Detects a too long key.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        auto key = GetStorageKey(Address{0x01}, 2, Key{0x35}, 3);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid key length, expected 61 byte, got 62");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedStorageValue) {
+  // Detects a too short value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetStorageKey(Address{0x01}, 2, Key{0x35}, 3),
+                         std::vector<char>(sizeof(Value) - 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Value), sizeof(Value) - 1));
+
+  // Detects a too long value.
+  TestAccountCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetStorageKey(Address{0x01}, 2, Key{0x35}, 3),
+                         std::vector<char>(sizeof(Value) + 1, 'x')));
+      },
+      absl::StrFormat("Invalid value length, expected %d byte, got %d",
+                      sizeof(Value), sizeof(Value) + 1));
+}
+
+void TestArchiveCorruption(absl::FunctionRef<void(LevelDb& db)> change,
+                           std::string_view error = "") {
+  TestCorruption(change, [&](LevelDbArchive& archive, const Hash& hash) {
+    EXPECT_THAT(archive.Verify(10, hash), StatusIs(_, HasSubstr(error)));
+  });
+}
+
+TEST(LevelDbArchive, VerificationDetectsMissingHash) {
+  // Delete a most-recent account update.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Delete(GetAccountHashKey(Address{0x01}, 5)));
+      },
+      "No diff hash found for block 5.");
+
+  // Delete a historic account update hash.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Delete(GetAccountHashKey(Address{0x01}, 3)));
+      },
+      "No diff hash found for block 3.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsModifiedHashes) {
+  // A corrupted hash for a most-recent account update.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 5), Hash{}));
+      },
+      "Validation of hash of block 5 failed.");
+
+  // A corrupted hash for a past account update.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 3), Hash{}));
+      },
+      "Validation of hash of block 3 failed.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsAdditionalHashes) {
+  // An addition hash representing the most recent update.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 7), Hash{}));
+      },
+      "Found change in block 7 not covered by archive hash.");
+
+  // An additional hash somewhere in the history.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountHashKey(Address{0x01}, 4), Hash{}));
+      },
+      "Found account update for block 4 but no hash for this block.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedBlockKey) {
+  // Detects a too short key.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        auto key = GetBlockKey(3);
+        ASSERT_OK(db.Delete(key));
+        ASSERT_OK(db.Add(std::span(key).subspan(0, key.size() - 1), Hash{}));
+      },
+      "Invalid block key length encountered.");
+
+  // Detects a too long key.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        auto key = GetBlockKey(3);
+        ASSERT_OK(db.Delete(key));
+        std::vector<char> extended(key.begin(), key.end());
+        extended.push_back('x');
+        ASSERT_OK(db.Add(extended, Hash{}));
+      },
+      "Invalid block key length encountered.");
+}
+
+TEST(LevelDbArchive, AccountVerificationDetectsMailformedBlockValue) {
+  // Detects a too short value.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(
+            db.Add(GetBlockKey(3), std::vector<char>(sizeof(Hash) - 1, 'x')));
+      },
+      "Invalid block value length encountered.");
+
+  // Detects a too long value.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(
+            db.Add(GetBlockKey(3), std::vector<char>(sizeof(Hash) + 1, 'x')));
+      },
+      "Invalid block value length encountered.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsExtraAccountStatus) {
+  // An entry in the past with uncovered address.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x02}, 1),
+                         AccountState{true, 0}.Encode()));
+      },
+      "Found extra key/value pair in key space `account_state`.");
+
+  // An entry in the future.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetAccountStateKey(Address{0x01}, 20),
+                         AccountState{true, 0}.Encode()));
+      },
+      "Found entry of future block height in key space `account_state`.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsExtraBalance) {
+  // An entry in the past with uncovered address.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x02}, 1), Balance{}));
+      },
+      "Found extra key/value pair in key space `balance`.");
+
+  // An entry in the future.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 20), Balance{}));
+      },
+      "Found entry of future block height in key space `balance`.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsExtraNonce) {
+  // An entry in the past with uncovered address.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x02}, 1), Nonce{}));
+      },
+      "Found extra key/value pair in key space `nonce`.");
+
+  // An entry in the future.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetNonceKey(Address{0x01}, 20), Nonce{}));
+      },
+      "Found entry of future block height in key space `nonce`.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsExtraCode) {
+  // An entry in the past with uncovered address.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetCodeKey(Address{0x02}, 1), Code{}));
+      },
+      "Found extra key/value pair in key space `code`.");
+
+  // An entry in the future.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetCodeKey(Address{0x01}, 20), Code{}));
+      },
+      "Found entry of future block height in key space `code`.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsExtraStorage) {
+  // An entry in the past with uncovered address.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetStorageKey(Address{0x02}, 2, Key{}, 1), Value{}));
+      },
+      "Found extra key/value pair in key space `storage`.");
+
+  // An entry in the future.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetStorageKey(Address{0x01}, 2, Key{}, 20), Value{}));
+      },
+      "Found entry of future block height in key space `storage`.");
+}
+
+TEST(LevelDbArchive, VerificationDetectsCorruptedAccount) {
+  // Account verification is tested with its own set of tests. Here we only test
+  // that account verification is indeed involved in state verification.
+  TestArchiveCorruption(
+      [](LevelDb& db) {
+        ASSERT_OK(db.Add(GetBalanceKey(Address{0x01}, 3), Balance{0xFF}));
+      },
+      "Hash for diff at block 3 does not match.");
+}
+
+}  // namespace
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/encoding.cc
+++ b/cpp/archive/leveldb/encoding.cc
@@ -1,0 +1,19 @@
+#include "archive/leveldb/encoding.h"
+
+#include <cstdint>
+#include <span>
+
+namespace carmen::archive::leveldb {
+
+void Write(std::uint32_t value, std::span<char, 4> trg) {
+  for (int i = 0; i < 4; i++) {
+    trg[i] = value >> (3 - i) * 8;
+  }
+}
+
+std::uint32_t ReadUint32(std::span<const char, 4> src) {
+  auto byte = [&](int i) { return std::uint32_t(std::uint8_t(src[i])); };
+  return byte(0) << 24 | byte(1) << 16 | byte(2) << 8 | byte(3);
+}
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/encoding.h
+++ b/cpp/archive/leveldb/encoding.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "common/type.h"
+
+namespace carmen::archive::leveldb {
+
+// This file provides a few data encoding utilities, in particular for numerical
+// and trivial types. It is intended to be used for encoding keys and values in
+// LevelDB, such that a natural numeric ordering is achived. To that end,
+// integer values need to be encoded using the big-endian format.
+
+// Writes the given value into the provided target span.
+void Write(std::uint32_t value, std::span<char, 4> trg);
+
+// Writes the given trivial value (e.g. Balance, Nonce, Value) into the provided
+// target span. Trivial values are encoded as is.
+template <Trivial T>
+requires(!std::is_integral_v<T>) void Write(const T& value,
+                                            std::span<char, sizeof(T)> trg) {
+  std::memcpy(trg.data(), &value, sizeof(T));
+}
+
+// Reads a 32-bit unsigned integer from the given span, decoding it from its
+// big-endian encoding.
+std::uint32_t ReadUint32(std::span<const char, 4> src);
+
+// Interprets the provided data span as a trivial value.
+template <Trivial T>
+requires(!std::is_integral_v<T>) T& Read(std::span<char, sizeof(T)> trg) {
+  return *reinterpret_cast<T*>(trg.data());
+}
+
+// Interprets the provided data span as a constant trivial value.
+template <Trivial T>
+requires(!std::is_integral_v<T>) const T& Read(
+    std::span<const char, sizeof(T)> trg) {
+  return *reinterpret_cast<const T*>(trg.data());
+}
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/encoding_test.cc
+++ b/cpp/archive/leveldb/encoding_test.cc
@@ -1,0 +1,38 @@
+#include "archive/leveldb/encoding.h"
+
+#include <array>
+#include <span>
+
+#include "common/type.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace carmen::archive::leveldb {
+namespace {
+
+using ::testing::ElementsAre;
+
+TEST(Encoding, IntegersAreEncodedInBigEndianFormat) {
+  std::array<char, 4> trg;
+  Write(0x12345678, trg);
+  EXPECT_THAT(trg, ElementsAre(0x12, 0x34, 0x56, 0x78));
+}
+
+TEST(Encoding, EncodedIntegersCanBeDecoded) {
+  std::array<char, 4> trg;
+  for (std::uint32_t i = 0; i < 1000; i++) {
+    Write(i, trg);
+    EXPECT_EQ(ReadUint32(trg), i);
+  }
+}
+
+TEST(Encoding, EncodedTrivialValuesCanBeDecoded) {
+  std::array<char, sizeof(Value)> trg;
+  Value value{1, 2, 3, 4};
+  Write(value, trg);
+  EXPECT_EQ(Read<Value>(std::span<char, sizeof(Value)>(trg)), value);
+  EXPECT_EQ(Read<Value>(std::span<const char, sizeof(Value)>(trg)), value);
+}
+
+}  // namespace
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/keys.cc
+++ b/cpp/archive/leveldb/keys.cc
@@ -1,0 +1,121 @@
+#include "archive/leveldb/keys.h"
+
+#include <array>
+#include <cstring>
+#include <span>
+
+#include "archive/leveldb/encoding.h"
+#include "common/status_util.h"
+#include "common/type.h"
+
+namespace carmen::archive::leveldb {
+
+std::string_view ToString(KeyType type) {
+  switch (type) {
+    case KeyType::kAccountState:
+      return "account_state";
+    case KeyType::kAccountHash:
+      return "account_hash";
+    case KeyType::kBlock:
+      return "block";
+    case KeyType::kBalance:
+      return "balance";
+    case KeyType::kCode:
+      return "code";
+    case KeyType::kNonce:
+      return "nonce";
+    case KeyType::kStorage:
+      return "storage";
+  }
+  return "unknown";
+}
+
+namespace {
+
+template <std::size_t offset, std::size_t count, typename T, std::size_t Extend>
+std::span<T, count> subspan(std::array<T, Extend>& array) {
+  static_assert(Extend >= offset + count);
+  return std::span<T, count>(&array[offset], count);
+}
+
+template <std::size_t offset, std::size_t count, typename T, std::size_t Extend>
+std::span<const T, count> subspan(const std::array<T, Extend>& array) {
+  static_assert(Extend >= offset + count);
+  return std::span<const T, count>(&array[offset], count);
+}
+
+template <KeyType type, typename Key>
+Key Get(const Address& address, BlockId block) {
+  Key res;
+  res[0] = static_cast<char>(type);
+  Write(address, subspan<1, 20>(res));
+  Write(block, subspan<1 + 20, 4>(res));
+  return res;
+}
+
+}  // namespace
+
+BlockKey GetBlockKey(BlockId block) {
+  BlockKey res;
+  res[0] = static_cast<char>(KeyType::kBlock);
+  Write(block, subspan<1, 4>(res));
+  return res;
+}
+
+AccountStateKey GetAccountStateKey(const Address& address, BlockId block) {
+  return Get<KeyType::kAccountState, AccountStateKey>(address, block);
+}
+
+BalanceKey GetBalanceKey(const Address& address, BlockId block) {
+  return Get<KeyType::kBalance, BalanceKey>(address, block);
+}
+
+CodeKey GetCodeKey(const Address& address, BlockId block) {
+  return Get<KeyType::kCode, CodeKey>(address, block);
+}
+
+NonceKey GetNonceKey(const Address& address, BlockId block) {
+  return Get<KeyType::kNonce, NonceKey>(address, block);
+}
+
+AccountHashKey GetAccountHashKey(const Address& address, BlockId block) {
+  return Get<KeyType::kAccountHash, AccountHashKey>(address, block);
+}
+
+StorageKey GetStorageKey(const Address& address,
+                         ReincarnationNumber reincarnation, const Key& key,
+                         BlockId block) {
+  StorageKey res;
+  res[0] = static_cast<char>(KeyType::kStorage);
+  Write(address, subspan<1, 20>(res));
+  Write(reincarnation, subspan<1 + 20, 4>(res));
+  Write(key, subspan<1 + 20 + 4, 32>(res));
+  Write(block, subspan<1 + 20 + 4 + 32, 4>(res));
+  return res;
+}
+
+BlockId GetBlockFromKey(std::span<const char> key) {
+  // The block ID is always stored in the last 4 bytes.
+  assert(key.size() >= 4);
+  if (key.size() < 4) return 0;
+  return ReadUint32(std::span<const char, 4>(key.data() + key.size() - 4, 4));
+}
+
+std::span<const char> GetAccountPrefix(std::span<const char> key) {
+  return std::span(key).subspan(0, 1 + sizeof(Address));
+}
+
+const Address& GetAddressFromKey(std::span<const char> key) {
+  assert(key.size() >= 21);
+  return *reinterpret_cast<const Address*>(key.data() + 1);
+}
+
+ReincarnationNumber GetReincarnationNumber(const StorageKey& key) {
+  return ReadUint32(subspan<1 + 20, 4>(key));
+}
+
+const Key& GetSlotKey(const StorageKey& key) {
+  return Read<Key>(subspan<1 + 20 + 4, 32>(key));
+}
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/keys.h
+++ b/cpp/archive/leveldb/keys.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <array>
+#include <span>
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "common/type.h"
+
+namespace carmen::archive::leveldb {
+
+// Prefixes for LevelDB keys to differentiated between different table spaces.
+// These keys are aligned with the Go implementation of the Carmen archive, and
+// should be kept aligned for compatiblity.
+enum class KeyType : char {
+  kBlock = '1',
+  kAccountState = '2',
+  kBalance = '3',
+  kCode = '4',
+  kNonce = '5',
+  kStorage = '6',
+  kAccountHash = '7',
+};
+
+// Provides a label for each key type, or `unknown` for everything else.
+std::string_view ToString(KeyType type);
+
+// To differentiate multiple reincarnations of accounts, reincarnation numbers
+// are utilized in the LevelDB archive. Each time an account is created or
+// deleted, it is increased by 1, starting at 0.
+using ReincarnationNumber = std::uint32_t;
+
+// The key type used for per-block information.
+using BlockKey = std::array<char, 1 + sizeof(BlockId)>;
+
+// Most account properties share a common key format.
+using PropertyKey = std::array<char, 1 + sizeof(Address) + sizeof(BlockId)>;
+using AccountStateKey = PropertyKey;
+using BalanceKey = PropertyKey;
+using CodeKey = PropertyKey;
+using NonceKey = PropertyKey;
+using AccountHashKey = PropertyKey;
+
+// The key to store storage information includes the reincarnation number to
+// suppor efficient state clearing.
+using StorageKey =
+    std::array<char, 1 + sizeof(Address) + sizeof(ReincarnationNumber) +
+                         sizeof(Key) + sizeof(BlockId)>;
+
+// -- Factory functions for storage keys ---
+
+BlockKey GetBlockKey(BlockId block);
+
+AccountStateKey GetAccountStateKey(const Address& address, BlockId block);
+
+AccountHashKey GetAccountHashKey(const Address& address, BlockId block);
+
+BalanceKey GetBalanceKey(const Address& address, BlockId block);
+
+CodeKey GetCodeKey(const Address& address, BlockId block);
+
+NonceKey GetNonceKey(const Address& address, BlockId block);
+
+StorageKey GetStorageKey(const Address& address,
+                         ReincarnationNumber reincarnation, const Key& key,
+                         BlockId block);
+
+// Retrieves the block ID from any type of key. Note: for performance reasons it
+// does not check that the given span encodes a valid key. It only interprets
+// the portion of the provided span that is expected to contain the BlockId.
+BlockId GetBlockFromKey(std::span<const char> key);
+
+// Returns the prefix of the key covering the key space and account.
+std::span<const char> GetAccountPrefix(std::span<const char> key);
+
+// Returns the address encoded in the key. Note: for performance reasons it does
+// not check that the given span encodes a valid key. It merely interprets the
+// protion of the span where an address would be expected.
+const Address& GetAddressFromKey(std::span<const char> data);
+
+// Returns the reincarnation number encoded in a storage key.
+ReincarnationNumber GetReincarnationNumber(const StorageKey& key);
+
+// Returns the slot key encoded in a storage key.
+const Key& GetSlotKey(const StorageKey& key);
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/keys_test.cc
+++ b/cpp/archive/leveldb/keys_test.cc
@@ -1,0 +1,93 @@
+#include "archive/leveldb/keys.h"
+
+#include <span>
+
+#include "common/type.h"
+#include "gtest/gtest.h"
+
+namespace carmen::archive::leveldb {
+namespace {
+
+TEST(Keys, BlockIdIsEncodedUsingBigEndian) {
+  BlockId id = 0x12345678;
+  auto key = GetBlockKey(id);
+  auto span = std::span(key).subspan(1);
+  EXPECT_EQ(span[0], 0x12);
+  EXPECT_EQ(span[1], 0x34);
+  EXPECT_EQ(span[2], 0x56);
+  EXPECT_EQ(span[3], 0x78);
+}
+
+TEST(Keys, StorageKeyEncodesValuesCorrectly) {
+  Address addr{1, 2, 3, 4, 5};
+  ReincarnationNumber r = 0x12345678;
+  Key key{6, 7, 8, 9};
+  BlockId b = 0x12345678;
+  auto res = GetStorageKey(addr, r, key, b);
+
+  EXPECT_EQ(res[0], '6');
+
+  Address restored_addr;
+  restored_addr.SetBytes(std::as_bytes(std::span<char, 20>(&res[1], 20)));
+  EXPECT_EQ(addr, restored_addr);
+
+  // The reincarnation number is encoded using big-endian order.
+  auto r_span = std::span(res).subspan(1 + 20);
+  EXPECT_EQ(r_span[0], 0x12);
+  EXPECT_EQ(r_span[1], 0x34);
+  EXPECT_EQ(r_span[2], 0x56);
+  EXPECT_EQ(r_span[3], 0x78);
+
+  Key restored_key;
+  restored_key.SetBytes(
+      std::as_bytes(std::span<char, 32>(&res[1 + 20 + 4], 32)));
+  EXPECT_EQ(key, restored_key);
+
+  auto span = std::span(res).subspan(1 + 20 + 4 + 32);
+  EXPECT_EQ(span[0], 0x12);
+  EXPECT_EQ(span[1], 0x34);
+  EXPECT_EQ(span[2], 0x56);
+  EXPECT_EQ(span[3], 0x78);
+}
+
+TEST(Keys, BlockIdCanBeExtractedFromBlockKey) {
+  for (BlockId i = 1; i < (BlockId(1) << 31); i <<= 1) {
+    auto key = GetBlockKey(i);
+    EXPECT_EQ(GetBlockFromKey(key), i);
+  }
+}
+
+TEST(Keys, BlockIdCanBeExtractedFromPropertyKey) {
+  Address addr{};
+  for (BlockId i = 1; i < (BlockId(1) << 31); i <<= 1) {
+    auto key = GetBalanceKey(addr, i);
+    EXPECT_EQ(GetBlockFromKey(key), i);
+  }
+}
+
+TEST(Keys, AccountPrefixCanBeExtractedFromPropertyKey) {
+  Address addr{1, 2, 3, 4};
+  auto key = GetBalanceKey(addr, 12);
+  auto span = GetAccountPrefix(key);
+  EXPECT_EQ(span.data(), key.data());
+  EXPECT_EQ(span.size(), 1 + sizeof(Address));
+}
+
+TEST(Keys, BlockIdCanBeExtractedFromStorageKey) {
+  Address addr{};
+  Key slot{};
+  for (BlockId i = 1; i < (BlockId(1) << 31); i <<= 1) {
+    auto key = GetStorageKey(addr, 12, slot, i);
+    EXPECT_EQ(GetBlockFromKey(key), i);
+  }
+}
+
+TEST(Keys, SlotKeyBeExtractedFromStorageKey) {
+  Address addr{};
+  Key slot{1, 2, 3, 4};
+  auto key = GetStorageKey(addr, 12, slot, 0);
+  EXPECT_EQ(GetSlotKey(key), slot);
+}
+
+}  // namespace
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/values.cc
+++ b/cpp/archive/leveldb/values.cc
@@ -1,0 +1,31 @@
+
+#include "archive/leveldb/values.h"
+
+#include <array>
+#include <span>
+
+#include "archive/leveldb/encoding.h"
+#include "common/status_util.h"
+#include "common/type.h"
+
+namespace carmen::archive::leveldb {
+
+absl::StatusOr<AccountState> AccountState::From(std::span<const char> data) {
+  if (data.size() != 5) {
+    return absl::InvalidArgumentError("Invalid encoding of AccountState");
+  }
+  AccountState res;
+  res.exists = (std::uint8_t(data[0]) != 0);
+  res.reincarnation_number =
+      ReadUint32(std::span<const char, 4>(data.data() + 1, 4));
+  return res;
+}
+
+std::array<char, 1 + 4> AccountState::Encode() const {
+  std::array<char, 5> res;
+  res[0] = exists ? 1 : 0;
+  Write(reincarnation_number, std::span<char, 4>(res.data() + 1, 4));
+  return res;
+}
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/values.h
+++ b/cpp/archive/leveldb/values.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "absl/status/statusor.h"
+#include "archive/leveldb/keys.h"
+#include "common/type.h"
+
+namespace carmen::archive::leveldb {
+
+// An AccountState summarizes the meta information maintained per account in the
+// archive. For an associated block height it describes whether the account
+// existed and what its reincarnation number was.
+struct AccountState {
+  // Parses the given byte sequence and produces an account state.
+  static absl::StatusOr<AccountState> From(std::span<const char>);
+
+  // Encodes the state into a character sequence.
+  std::array<char, 5> Encode() const;
+
+  // True, if the account exists, false if it never existed or was deleted.
+  bool exists = false;
+
+  // The reincarnation counter for the account. The counter is 0 if the account
+  // was never touched, and is incremented by 1 each time the account is created
+  // or deleted.
+  ReincarnationNumber reincarnation_number = 0;
+};
+
+}  // namespace carmen::archive::leveldb

--- a/cpp/archive/leveldb/values_test.cc
+++ b/cpp/archive/leveldb/values_test.cc
@@ -1,0 +1,25 @@
+#include "archive/leveldb/values.h"
+
+#include <span>
+
+#include "common/status_test_util.h"
+#include "common/type.h"
+#include "gtest/gtest.h"
+
+namespace carmen::archive::leveldb {
+namespace {
+
+TEST(AccountState, ReincarnationNumberCanBeEncodedAndDecoded) {
+  AccountState state;
+  for (ReincarnationNumber i = 1; i < (ReincarnationNumber(1) << 31); i <<= 1) {
+    state.reincarnation_number = i;
+    state.exists = !state.exists;
+    auto encoded = state.Encode();
+    ASSERT_OK_AND_ASSIGN(auto restored, AccountState::From(encoded));
+    EXPECT_EQ(state.exists, restored.exists);
+    EXPECT_EQ(state.reincarnation_number, restored.reincarnation_number);
+  }
+}
+
+}  // namespace
+}  // namespace carmen::archive::leveldb


### PR DESCRIPTION
This PR adds a LevelDB-based implementation of a Carmen Archive. It covers the following features:
 - recording and replaying historic state data
 - hashing of state data and the efficient reproduction of hashes for each block height
 - verification of the content of an archive, identifying potential modifications

Differences compared to the Go-based implementation:
 - block numbers are encoded using 4 instead of 8 byte
 - block numbers are stored unmodified, unlike in Go, where MAX_BLOCK - block-number is stored for inversing the key ordering