### PR TITLE
optimise in-memory Btree

### DIFF
--- a/go/backend/btree/innernode.go
+++ b/go/backend/btree/innernode.go
@@ -35,7 +35,7 @@ func initNewInnerNode[K any](left, right node[K], middle K, capacity int, compar
 }
 
 func (m *InnerNode[K]) insert(key K) (right node[K], middle K, split bool) {
-	index, exists := m.findItem(key)
+	index, exists := m.findItem(&key)
 	if !exists {
 		// insert into child, when split has happened, insert result in this node
 		if right, middle, split := m.children[index].insert(key); split {
@@ -53,7 +53,7 @@ func (m *InnerNode[K]) insert(key K) (right node[K], middle K, split bool) {
 }
 
 func (m *InnerNode[K]) contains(key K) bool {
-	index, exists := m.findItem(key)
+	index, exists := m.findItem(&key)
 
 	if exists {
 		return true
@@ -137,7 +137,7 @@ func (m *InnerNode[K]) ForEach(callback func(k K)) {
 // is necessary for removing the key.
 // This implementation has been inspired by: https://www.geeksforgeeks.org/delete-operation-in-b-tree/
 func (m *InnerNode[K]) remove(key K) node[K] {
-	if index, exists := m.findItem(key); exists {
+	if index, exists := m.findItem(&key); exists {
 		// key is in this node - remove it potentially borrowing/merging from children
 		m.removeKeyAt(index)
 	} else {

--- a/go/backend/btree/innernode_test.go
+++ b/go/backend/btree/innernode_test.go
@@ -205,7 +205,9 @@ func TestInnerNodeIteratorNextCalledOnly(t *testing.T) {
 	n.insert(6)
 	n.insert(2)
 
-	it := newIterator[uint32](1, 5, n)
+	a := uint32(1)
+	b := uint32(5)
+	it := newIterator[uint32](&a, &b, n, make([]nestCtx[uint32], 0, 100))
 
 	expected := []uint32{1, 2, 3, 4}
 	for _, expectedKey := range expected {
@@ -228,7 +230,9 @@ func TestInnerNodeIteratorHasNextStable(t *testing.T) {
 	n.insert(6)
 	n.insert(2)
 
-	it := newIterator[uint32](1, 5, n)
+	a := uint32(1)
+	b := uint32(5)
+	it := newIterator[uint32](&a, &b, n, make([]nestCtx[uint32], 0, 100))
 
 	expected := []uint32{1, 2, 3, 4}
 	for _, expectedKey := range expected {
@@ -258,7 +262,9 @@ func TestInnerNodeIteratorHasNext(t *testing.T) {
 	n.insert(6)
 	n.insert(2)
 
-	it := newIterator[uint32](1, 5, n)
+	a := uint32(1)
+	b := uint32(5)
+	it := newIterator[uint32](&a, &b, n, make([]nestCtx[uint32], 0, 100))
 
 	// HasNext() work
 	if exists := it.HasNext(); !exists {
@@ -473,7 +479,7 @@ func getInnerKeys(n node[uint32]) []uint32 {
 
 func getNodeRange(n node[uint32], start, end uint32) []uint32 {
 	keys := make([]uint32, 0, 10)
-	it := newIterator[uint32](start, end, n)
+	it := newIterator[uint32](&start, &end, n, make([]nestCtx[uint32], 0, 100))
 	for it.HasNext() {
 		keys = append(keys, it.Next())
 	}

--- a/go/backend/btree/iterator.go
+++ b/go/backend/btree/iterator.go
@@ -2,17 +2,17 @@ package btree
 
 // Iterator of BTree elements
 type Iterator[K any] struct {
-	start, end K // start and end key to iterate
+	start, end *K // start and end key to iterate
 	visitChild bool
 	nestStack  nestStack[K]
 }
 
 // newIterator creates a new iterator for input key range.
 // The range is [start;end)
-func newIterator[K any](start, end K, n node[K]) *Iterator[K] {
+func newIterator[K any](start, end *K, n node[K], initStack nestStack[K]) *Iterator[K] {
 	startIndex, _ := n.findItem(start)
 	endIndex, _ := n.findItem(end)
-	it := &Iterator[K]{start, end, true, make([]nestCtx[K], 0, 100)}
+	it := &Iterator[K]{start, end, true, initStack}
 	it.nestStack.push(nestCtx[K]{startIndex, endIndex, n})
 	return it
 }

--- a/go/backend/btree/leafnode.go
+++ b/go/backend/btree/leafnode.go
@@ -23,7 +23,7 @@ func newLeafNode[K any](capacity int, comparator common.Comparator[K]) *LeafNode
 }
 
 func (m *LeafNode[K]) insert(key K) (right node[K], middle K, split bool) {
-	if index, exists := m.findItem(key); !exists {
+	if index, exists := m.findItem(&key); !exists {
 		m.insertAt(index, key, nil, nil)
 
 		// split when overflow
@@ -37,12 +37,12 @@ func (m *LeafNode[K]) insert(key K) (right node[K], middle K, split bool) {
 }
 
 func (m *LeafNode[K]) contains(key K) bool {
-	_, exists := m.findItem(key)
+	_, exists := m.findItem(&key)
 	return exists
 }
 
 func (m *LeafNode[K]) remove(key K) node[K] {
-	if index, exists := m.findItem(key); exists {
+	if index, exists := m.findItem(&key); exists {
 		m.removeAt(index)
 	}
 
@@ -116,12 +116,12 @@ func (m *LeafNode[K]) insertAt(index int, key K, left, right node[K]) {
 	return
 }
 
-func (m *LeafNode[K]) findItem(key K) (index int, exists bool) {
+func (m *LeafNode[K]) findItem(key *K) (index int, exists bool) {
 	end := len(m.keys) - 1
 	var res, start, mid int
 	for start <= end {
 		mid = (start + end) / 2
-		res = m.comparator.Compare(&m.keys[mid], &key)
+		res = m.comparator.Compare(&m.keys[mid], key)
 		if res == 0 {
 			return mid, true
 		} else if res < 0 {

--- a/go/backend/btree/node.go
+++ b/go/backend/btree/node.go
@@ -64,7 +64,7 @@ type node[K any] interface {
 	// The index is increased by one when the last visited key was lower than the input key
 	// so the new key may be inserted after this key.
 	// It means the index can be used as a position to insert the key in the list.
-	findItem(key K) (index int, exists bool)
+	findItem(key *K) (index int, exists bool)
 
 	//next moves position of the input iterator, and returns next key using the iterator.
 	next(iterator *Iterator[K]) (k K)


### PR DESCRIPTION
this PR improves performance of BTree, in-memory implementation. 

It is done so by introducing a few buffers and pointers instead of copying keys

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/7114574/220569460-01cc882f-abd2-49c4-a5bc-b6d098509e09.png">
