### PR TITLE
Align padding of page data in store implementation

### DIFF
--- a/cpp/backend/store/file/store_test.cc
+++ b/cpp/backend/store/file/store_test.cc
@@ -13,23 +13,32 @@ namespace {
 
 using ::testing::IsOkAndHolds;
 
+template <typename K, typename V, std::size_t ps>
+using EagerInMemoryFileStore = EagerFileStore<K, V, InMemoryFile, ps>;
+
+template <typename K, typename V, std::size_t ps>
+using EagerSingleFileStore = EagerFileStore<K, V, SingleFile, ps>;
+
+template <typename K, typename V, std::size_t ps>
+using LazySingleFileStore = LazyFileStore<K, V, SingleFile, ps>;
+
 using StoreTypes = ::testing::Types<
     // Page size 32, branching size 32.
-    StoreTestConfig<EagerFileStore<int, Value, InMemoryFile, 32>, 32>,
-    StoreTestConfig<EagerFileStore<int, Value, SingleFile, 32>, 32>,
-    StoreTestConfig<LazyFileStore<int, Value, SingleFile, 32>, 32>,
+    StoreTestConfig<EagerInMemoryFileStore, 32, 32>,
+    StoreTestConfig<EagerSingleFileStore, 32, 32>,
+    StoreTestConfig<LazySingleFileStore, 32, 32>,
     // Page size 64, branching size 3.
-    StoreTestConfig<EagerFileStore<int, Value, InMemoryFile, 64>, 3>,
-    StoreTestConfig<EagerFileStore<int, Value, SingleFile, 64>, 3>,
-    StoreTestConfig<LazyFileStore<int, Value, SingleFile, 64>, 3>,
+    StoreTestConfig<EagerInMemoryFileStore, 64, 3>,
+    StoreTestConfig<EagerSingleFileStore, 64, 3>,
+    StoreTestConfig<LazySingleFileStore, 64, 3>,
     // Page size 64, branching size 8.
-    StoreTestConfig<EagerFileStore<int, Value, InMemoryFile, 64>, 8>,
-    StoreTestConfig<EagerFileStore<int, Value, SingleFile, 64>, 8>,
-    StoreTestConfig<LazyFileStore<int, Value, SingleFile, 64>, 8>,
+    StoreTestConfig<EagerInMemoryFileStore, 64, 8>,
+    StoreTestConfig<EagerSingleFileStore, 64, 8>,
+    StoreTestConfig<LazySingleFileStore, 64, 8>,
     // Page size 128, branching size 4.
-    StoreTestConfig<EagerFileStore<int, Value, InMemoryFile, 128>, 4>,
-    StoreTestConfig<EagerFileStore<int, Value, SingleFile, 128>, 4>,
-    StoreTestConfig<LazyFileStore<int, Value, SingleFile, 128>, 4>>;
+    StoreTestConfig<EagerInMemoryFileStore, 128, 4>,
+    StoreTestConfig<EagerSingleFileStore, 128, 4>,
+    StoreTestConfig<LazySingleFileStore, 128, 4>>;
 
 // Instantiates common store tests for the File store type.
 INSTANTIATE_TYPED_TEST_SUITE_P(File, StoreTest, StoreTypes);

--- a/cpp/backend/store/leveldb/store.h
+++ b/cpp/backend/store/leveldb/store.h
@@ -154,7 +154,7 @@ class LevelDbStore {
 
    private:
     const LevelDb& db_;
-    std::array<std::byte, kPageSize> page_buffer_;
+    std::array<std::byte, elements_per_page * sizeof(V)> page_buffer_;
   };
 
   // The underlying LevelDb instance. Wrapped in a unique_ptr to allow

--- a/cpp/backend/store/leveldb/store_test.cc
+++ b/cpp/backend/store/leveldb/store_test.cc
@@ -17,13 +17,13 @@ using TestStore = LevelDbStore<int, int>;
 
 using StoreTypes = ::testing::Types<
     // Page size 32, branching size 32.
-    StoreTestConfig<LevelDbStore<int, Value, 32>, 32>,
+    StoreTestConfig<LevelDbStore, 32, 32>,
     // Page size 64, branching size 3.
-    StoreTestConfig<LevelDbStore<int, Value, 64>, 3>,
+    StoreTestConfig<LevelDbStore, 64, 3>,
     // Page size 64, branching size 8.
-    StoreTestConfig<LevelDbStore<int, Value, 64>, 8>,
+    StoreTestConfig<LevelDbStore, 64, 8>,
     // Page size 128, branching size 4.
-    StoreTestConfig<LevelDbStore<int, Value, 128>, 4>>;
+    StoreTestConfig<LevelDbStore, 128, 4>>;
 
 // Instantiates common store tests for the LevelDb store type.
 INSTANTIATE_TYPED_TEST_SUITE_P(LevelDb, StoreTest, StoreTypes);

--- a/cpp/backend/store/memory/store_test.cc
+++ b/cpp/backend/store/memory/store_test.cc
@@ -18,13 +18,13 @@ using Store = InMemoryStore<int, int>;
 
 using StoreTypes = ::testing::Types<
     // Page size 32, branching size 32.
-    StoreTestConfig<InMemoryStore<int, Value, 32>, 32>,
+    StoreTestConfig<InMemoryStore, 32, 32>,
     // Page size 64, branching size 3.
-    StoreTestConfig<InMemoryStore<int, Value, 64>, 3>,
+    StoreTestConfig<InMemoryStore, 64, 3>,
     // Page size 64, branching size 8.
-    StoreTestConfig<InMemoryStore<int, Value, 64>, 8>,
+    StoreTestConfig<InMemoryStore, 64, 8>,
     // Page size 128, branching size 4.
-    StoreTestConfig<InMemoryStore<int, Value, 128>, 4>>;
+    StoreTestConfig<InMemoryStore, 128, 4>>;
 
 // Instantiates common store tests for the InMemory store type.
 INSTANTIATE_TYPED_TEST_SUITE_P(InMemory, StoreTest, StoreTypes);


### PR DESCRIPTION
For cases where values stored in C++ Store implementations are not completely filling an entire page (e.g. `sizeof(Value)=10` with `page_size=4096` leafes 6 byte unused) the hash of the pages was differently computed by the C++ storage implementations. This PR unifies this by only hashing the bytes containing values (the first 4090 bytes in the example above).

The only change need in the implementation was the adaptation of the internal buffer size in the LevelDB store (cpp/backend/store/leveldb/store.h, line 157). The rest is refactoring the test infrastructure to support generic testing of this new requirement for all current and future implementations.