### PR TITLE
Add go archive benchmark

### DIFF
--- a/go/backend/archive/benchmark_test.go
+++ b/go/backend/archive/benchmark_test.go
@@ -6,6 +6,13 @@ import (
 	"testing"
 )
 
+const (
+	bmAddressToCreate                = 100
+	bmBlocksToInsert                 = 1_000
+	bmAddressToUseParBlock           = 20
+	bmKeysToInsertParAddressAndBlock = 50
+)
+
 func BenchmarkAdding(b *testing.B) {
 	for _, factory := range getArchiveFactories(b) {
 		a := factory.getArchive(b.TempDir())
@@ -13,7 +20,7 @@ func BenchmarkAdding(b *testing.B) {
 
 		// initialize
 		var update common.Update
-		for i := byte(0); i < byte(100); i++ {
+		for i := byte(0); i < byte(bmAddressToCreate); i++ {
 			update.AppendCreateAccount(common.Address{i})
 			update.AppendBalanceUpdate(common.Address{i}, common.Balance{i})
 		}
@@ -23,12 +30,12 @@ func BenchmarkAdding(b *testing.B) {
 
 		var block uint64 = 2
 		b.Run(factory.label, func(b *testing.B) {
-			for i := 0; i < 1_000; i++ {
+			for i := 0; i < bmBlocksToInsert; i++ {
 				var update common.Update
-				for addrIt := 0; addrIt < 20; addrIt++ {
-					addr := byte(rand.Intn(100))
-					for keyIt := 0; keyIt < 50; keyIt++ {
-						key := byte(rand.Intn(250))
+				for addrIt := 0; addrIt < bmAddressToUseParBlock; addrIt++ {
+					addr := byte(rand.Intn(bmAddressToCreate))
+					for keyIt := 0; keyIt < bmKeysToInsertParAddressAndBlock; keyIt++ {
+						key := byte(rand.Intn(0xFF))
 						update.AppendSlotUpdate(common.Address{addr}, common.Key{key}, common.Value{addr + key})
 					}
 				}
@@ -40,11 +47,7 @@ func BenchmarkAdding(b *testing.B) {
 				}
 				block++
 			}
-			// add flush here if parallel archives will be implemented
+			// add flush here if parallel archives are implemented
 		})
-
-		if err := a.Close(); err != nil {
-			b.Fatalf("failed to close; %s", err)
-		}
 	}
 }


### PR DESCRIPTION
Archive benchmarks for archives optimalizations.

Benchmarks only blocks adding, which is the most important for us now.