### PR TITLE
Remove hash-altering behaviour of store Get calls

### DIFF
--- a/cpp/backend/store/leveldb/store.h
+++ b/cpp/backend/store/leveldb/store.h
@@ -68,7 +68,6 @@ class LevelDbStore {
   StatusOrRef<const V> Get(const K& key) const {
     constexpr static const V default_value{};
     static V result;
-    hashes_.RegisterPage(GetPageId(key));
     auto buffer = db_->Get(AsChars(key));
     if (absl::IsNotFound(buffer.status())) {
       return default_value;

--- a/cpp/backend/store/memory/store.h
+++ b/cpp/backend/store/memory/store.h
@@ -74,7 +74,6 @@ class InMemoryStore {
   StatusOrRef<const V> Get(const K& key) const {
     constexpr static const V default_value{};
     auto page_number = key / elements_per_page;
-    hashes_.RegisterPage(page_number);
     if (page_number >= pages_->size()) {
       return default_value;
     }


### PR DESCRIPTION
With this change, read operations on stores should no longer affect hashes.