### PR TITLE
implement snapshot support for memory index

### DIFF
--- a/go/backend/index/index.go
+++ b/go/backend/index/index.go
@@ -2,7 +2,6 @@ package index
 
 import (
 	"errors"
-
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -32,9 +31,9 @@ type Index[K comparable, I common.Identifier] interface {
 	// Also, indexes need to be flush and closable.
 	common.FlushAndCloser
 
-	// Also, indexes need to be snapshotable.
-	// TODO: enable this once ready
-	// backend.Snapshotable
+	// Snapshotable indexes.
+	// TODO: snapshot is not implemented by all indexes
+	//backend.Snapshotable
 }
 
 var (

--- a/go/backend/index/index_test.go
+++ b/go/backend/index/index_test.go
@@ -2,7 +2,9 @@ package index_test
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
+	"github.com/Fantom-foundation/Carmen/go/backend/index/cache"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/file"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/memory"
@@ -10,36 +12,54 @@ import (
 	"testing"
 )
 
-func initIndexes(t *testing.T) (indexes []index.Index[common.Address, uint32]) {
-	db, err := common.OpenLevelDb(t.TempDir(), nil)
-	if err != nil {
-		t.Fatalf("failed to init leveldb; %s", err)
-	}
+func initIndexesMap() map[string]func(t *testing.T) index.Index[common.Address, uint32] {
 
 	keySerializer := common.AddressSerializer{}
 	idSerializer := common.Identifier32Serializer{}
 
-	memindex := memory.NewIndex[common.Address, uint32](keySerializer)
-	memLinearHashIndex := memory.NewLinearHashIndex[common.Address, uint32](keySerializer, idSerializer, common.AddressHasher{}, common.AddressComparator{})
-	ldbindex, _ := ldb.NewIndex[common.Address, uint32](db, common.BalanceStoreKey, keySerializer, idSerializer)
-	fileIndex, _ := file.NewIndex[common.Address, uint32](t.TempDir(), keySerializer, idSerializer, common.AddressHasher{}, common.AddressComparator{})
-
-	t.Cleanup(func() {
-		_ = memindex.Close()
-		_ = ldbindex.Close()
-		_ = db.Close()
-		_ = memLinearHashIndex.Close()
-		_ = fileIndex.Close()
-	})
-
-	return []index.Index[common.Address, uint32]{memindex, memLinearHashIndex, ldbindex, fileIndex}
+	return map[string]func(t *testing.T) index.Index[common.Address, uint32]{
+		"memindex": func(t *testing.T) index.Index[common.Address, uint32] {
+			return memory.NewIndex[common.Address, uint32](keySerializer)
+		},
+		"memLinearHashIndex": func(t *testing.T) index.Index[common.Address, uint32] {
+			return memory.NewLinearHashIndex[common.Address, uint32](keySerializer, idSerializer, common.AddressHasher{}, common.AddressComparator{})
+		},
+		"cachedindex": func(t *testing.T) index.Index[common.Address, uint32] {
+			return cache.NewIndex[common.Address, uint32](memory.NewIndex[common.Address, uint32](keySerializer), 10)
+		},
+		"ldbindex": func(t *testing.T) index.Index[common.Address, uint32] {
+			db, err := common.OpenLevelDb(t.TempDir(), nil)
+			if err != nil {
+				t.Fatalf("failed to init leveldb; %s", err)
+			}
+			ldbindex, err := ldb.NewIndex[common.Address, uint32](db, common.BalanceStoreKey, keySerializer, idSerializer)
+			if err != nil {
+				t.Fatalf("failed to init leveldb; %s", err)
+			}
+			t.Cleanup(func() {
+				_ = ldbindex.Close()
+				_ = db.Close()
+			})
+			return ldbindex
+		},
+		"fileIndex": func(t *testing.T) index.Index[common.Address, uint32] {
+			fileIndex, err := file.NewIndex[common.Address, uint32](t.TempDir(), keySerializer, idSerializer, common.AddressHasher{}, common.AddressComparator{})
+			if err != nil {
+				t.Fatalf("failed to init leveldb; %s", err)
+			}
+			t.Cleanup(func() {
+				_ = fileIndex.Close()
+			})
+			return fileIndex
+		},
+	}
 }
 
 func TestIndexesInitialHash(t *testing.T) {
-	indexes := initIndexes(t)
+	indexes := initIndexesMap()
 
-	for _, index := range indexes {
-		hash, err := index.GetStateHash()
+	for _, idx := range indexes {
+		hash, err := idx(t).GetStateHash()
 		if err != nil {
 			t.Fatalf("failed to hash empty index; %s", err)
 		}
@@ -50,13 +70,17 @@ func TestIndexesInitialHash(t *testing.T) {
 }
 
 func TestIndexesHashingByComparison(t *testing.T) {
-	indexes := initIndexes(t)
-
+	indexes := initIndexesMap()
 	for i := 0; i < 10; i++ {
 		ids := make([]uint32, len(indexes))
-		for indexId, index := range indexes {
-			var err error
-			ids[indexId], err = index.GetOrAdd(common.Address{byte(0x20 + i)})
+		indexInstances := make([]index.Index[common.Address, uint32], 0, len(indexes))
+		var indexId int
+		for _, idx := range indexes {
+			indexInstance := idx(t)
+			idx, err := indexInstance.GetOrAdd(common.Address{byte(0x20 + i)})
+			ids[indexId] = idx
+			indexId += 1
+			indexInstances = append(indexInstances, indexInstance)
 			if err != nil {
 				t.Fatalf("failed to set index item %d; %s", i, err)
 			}
@@ -64,14 +88,14 @@ func TestIndexesHashingByComparison(t *testing.T) {
 		if err := compareIds(ids); err != nil {
 			t.Errorf("ids for item %d does not match: %s", i, err)
 		}
-		if err := compareHashes(indexes); err != nil {
+		if err := compareHashes(indexInstances); err != nil {
 			t.Errorf("hashes does not match after inserting item %d: %s", i, err)
 		}
 	}
 }
 
 func TestIndexesHashesAgainstReferenceOutput(t *testing.T) {
-	indexes := initIndexes(t)
+	indexes := initIndexesMap()
 
 	// Tests the hashes for keys 0x01, 0x02 inserted in sequence.
 	// reference hashes from the C++ implementation
@@ -80,19 +104,211 @@ func TestIndexesHashesAgainstReferenceOutput(t *testing.T) {
 		"c28553369c52e217564d3f5a783e2643186064498d1b3071568408d49eae6cbe",
 	}
 
+	indexInstances := make([]index.Index[common.Address, uint32], 0, len(indexes))
+	for _, idx := range indexes {
+		indexInstances = append(indexInstances, idx(t))
+	}
+
 	for i, expectedHash := range expectedHashes {
-		for _, index := range indexes {
-			_, err := index.GetOrAdd(common.Address{byte(i + 1)}) // 0x01 - 0x02
+		for _, indexInstance := range indexInstances {
+			_, err := indexInstance.GetOrAdd(common.Address{byte(i + 1)}) // 0x01 - 0x02
 			if err != nil {
 				t.Fatalf("failed to set index item; %s", err)
 			}
-			hash, err := index.GetStateHash()
+			hash, err := indexInstance.GetStateHash()
 			if err != nil {
 				t.Fatalf("failed to hash index; %s", err)
 			}
 			if expectedHash != fmt.Sprintf("%x", hash) {
 				t.Fatalf("invalid hash: %x (expected %s)", hash, expectedHash)
 			}
+		}
+	}
+}
+
+func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndRestored(t *testing.T) {
+	for name, idx := range initIndexesMap() {
+		for _, size := range []int{0, 1, 5, 1000} {
+			t.Run(fmt.Sprintf("index %s size %d", name, size), func(t *testing.T) {
+
+				originalIndex := idx(t)
+				original, ok := originalIndex.(backend.Snapshotable)
+				if !ok {
+					t.Skip(fmt.Sprintf("index: %s is not Snapshotable", name))
+				}
+
+				fillIndex(t, originalIndex, size)
+				originalProof, err := original.GetProof()
+				if err != nil {
+					t.Errorf("failed to produce a proof for the original state")
+				}
+
+				snapshot, err := original.CreateSnapshot()
+				if err != nil {
+					t.Errorf("failed to create snapshot: %v", err)
+					return
+				}
+				if snapshot == nil {
+					t.Errorf("failed to create snapshot")
+					return
+				}
+
+				if !originalProof.Equal(snapshot.GetRootProof()) {
+					t.Errorf("snapshot proof does not match data structure proof")
+				}
+
+				recoveredIndex := idx(t)
+				recovered, _ := recoveredIndex.(backend.Snapshotable)
+				if err := recovered.Restore(snapshot.GetData()); err != nil {
+					t.Errorf("failed to sync to snapshot: %v", err)
+					return
+				}
+
+				recoveredProof, err := recovered.GetProof()
+				if err != nil {
+					t.Errorf("failed to produce a proof for the recovered state")
+				}
+
+				if !recoveredProof.Equal(snapshot.GetRootProof()) {
+					t.Errorf("snapshot proof does not match recovered proof")
+				}
+
+				checkIndexContent(t, recoveredIndex, size)
+
+				if err := snapshot.Release(); err != nil {
+					t.Errorf("failed to release snapshot: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestIndexSnapshot_IndexSnapshotIsShieldedFromMutations(t *testing.T) {
+	for name, idx := range initIndexesMap() {
+		t.Run(fmt.Sprintf("index %s", name), func(t *testing.T) {
+
+			originalIndex := idx(t)
+			original, ok := originalIndex.(backend.Snapshotable)
+			if !ok {
+				t.Skip(fmt.Sprintf("index: %s is not Snapshotable", name))
+			}
+
+			fillIndex(t, originalIndex, 20)
+			originalProof, err := original.GetProof()
+			if err != nil {
+				t.Errorf("failed to produce a proof for the original state")
+			}
+
+			snapshot, err := original.CreateSnapshot()
+			if err != nil {
+				t.Errorf("failed to create snapshot: %v", err)
+				return
+			}
+			if snapshot == nil {
+				t.Errorf("failed to create snapshot")
+				return
+			}
+
+			// Additional mutations of the original should not be affected.
+			if _, err := originalIndex.GetOrAdd(common.Address{0xaa}); err != nil {
+				t.Errorf("failed to add key: %v", err)
+			}
+
+			if !originalProof.Equal(snapshot.GetRootProof()) {
+				t.Errorf("snapshot proof does not match data structure proof")
+			}
+
+			recoveredIndex := idx(t)
+			recovered, _ := recoveredIndex.(backend.Snapshotable)
+
+			if err := recovered.Restore(snapshot.GetData()); err != nil {
+				t.Errorf("failed to sync to snapshot: %v", err)
+				return
+			}
+
+			if recoveredIndex.Contains(common.Address{0xaa}) {
+				t.Errorf("recovered state should not include elements added after snapshot creation")
+			}
+
+			if err := snapshot.Release(); err != nil {
+				t.Errorf("failed to release snapshot: %v", err)
+			}
+		})
+	}
+}
+
+func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndValidated(t *testing.T) {
+	for name, idx := range initIndexesMap() {
+		for _, size := range []int{0, 1, 5, 1000} {
+			t.Run(fmt.Sprintf("index %s size %d", name, size), func(t *testing.T) {
+
+				originalIndex := idx(t)
+				original, ok := originalIndex.(backend.Snapshotable)
+				if !ok {
+					t.Skip(fmt.Sprintf("index: %s is not Snapshotable", name))
+				}
+
+				fillIndex(t, originalIndex, size)
+
+				snapshot, err := original.CreateSnapshot()
+				if err != nil {
+					t.Errorf("failed to create snapshot: %v", err)
+					return
+				}
+				if snapshot == nil {
+					t.Errorf("failed to create snapshot")
+					return
+				}
+
+				remote, err := index.CreateIndexSnapshotFromData[common.Address](common.AddressSerializer{}, snapshot.GetData())
+				if err != nil {
+					t.Fatalf("failed to create snapshot from snapshot data: %v", err)
+				}
+
+				// Test direct and serialized snapshot data access.
+				for _, cur := range []backend.Snapshot{snapshot, remote} {
+
+					// The root proof should be equivalent.
+					want, err := original.GetProof()
+					if err != nil {
+						t.Errorf("failed to get root proof from data structure")
+					}
+
+					have := cur.GetRootProof()
+					if !want.Equal(have) {
+						t.Errorf("root proof of snapshot does not match proof of data structure")
+					}
+
+					if err := cur.VerifyRootProof(); err != nil {
+						t.Errorf("snapshot invalid, inconsistent proofs: %v", err)
+					}
+
+					// Verify all pages
+					for i := 0; i < cur.GetNumParts(); i++ {
+						want, err := cur.GetProof(i)
+						if err != nil {
+							t.Errorf("failed to fetch proof of part %d", i)
+						}
+						part, err := cur.GetPart(i)
+						if err != nil {
+							t.Errorf("failed to fetch part %d", i)
+						}
+						if !want.Equal(part.GetProof()) {
+							t.Errorf("proof of part does not equal proof provided by snapshot")
+						}
+						if !part.Verify() {
+							t.Errorf("failed to verify content of part %d", i)
+						}
+					}
+				}
+
+				if err := remote.Release(); err != nil {
+					t.Errorf("failed to release remote snapshot: %v", err)
+				}
+				if err := snapshot.Release(); err != nil {
+					t.Errorf("failed to release snapshot: %v", err)
+				}
+			})
 		}
 	}
 }
@@ -123,4 +339,20 @@ func compareIds(ids []uint32) error {
 		}
 	}
 	return nil
+}
+
+func fillIndex(t *testing.T, index index.Index[common.Address, uint32], size int) {
+	for i := 0; i < size; i++ {
+		if idx, err := index.GetOrAdd(common.Address{byte(i), byte(i >> 8), byte(i >> 16)}); idx != uint32(i) || err != nil {
+			t.Errorf("failed to add address %d", i)
+		}
+	}
+}
+
+func checkIndexContent(t *testing.T, index index.Index[common.Address, uint32], size int) {
+	for i := 0; i < size; i++ {
+		if idx, err := index.GetOrAdd(common.Address{byte(i), byte(i >> 8), byte(i >> 16)}); idx != uint32(i) || err != nil {
+			t.Errorf("failed to locate address %d", i)
+		}
+	}
 }

--- a/go/backend/index/indexhash/indexhash.go
+++ b/go/backend/index/indexhash/indexhash.go
@@ -70,6 +70,11 @@ func (hi *IndexHash[K]) Commit() (common.Hash, error) {
 	return hi.hash, nil
 }
 
+func (hi *IndexHash[K]) Clear() {
+	hi.hash = common.Hash{}
+	hi.keys = hi.keys[0:0]
+}
+
 // GetMemoryFootprint provides the size of the structure in memory in bytes
 func (hi *IndexHash[K]) GetMemoryFootprint() *common.MemoryFootprint {
 	var k K

--- a/go/backend/index/indexhash/indexhash_test.go
+++ b/go/backend/index/indexhash/indexhash_test.go
@@ -47,3 +47,31 @@ func TestCommit(t *testing.T) {
 	}
 
 }
+
+func TestClear(t *testing.T) {
+	hashIndex := NewIndexHash[common.Address](common.AddressSerializer{})
+
+	// add a key and compute the hash
+	h0, _ := hashIndex.Commit()
+	if (h0 != common.Hash{}) {
+		t.Errorf("the hash does not match the default one")
+	}
+
+	// the hash must change when adding a new item
+	hashIndex.AddKey(A)
+	ha1, _ := hashIndex.Commit()
+
+	if h0 == ha1 {
+		t.Errorf("the hash has not changed")
+	}
+
+	hashIndex.Clear()
+	hnew, _ := hashIndex.Commit()
+	if (hnew != common.Hash{}) {
+		t.Errorf("the hash does not match the default one")
+	}
+
+	if len(hashIndex.keys) != 0 {
+		t.Errorf("key list is not empty")
+	}
+}

--- a/go/backend/index/memory/memory.go
+++ b/go/backend/index/memory/memory.go
@@ -2,15 +2,20 @@ package memory
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/indexhash"
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"unsafe"
 )
 
+const initCapacity = 10_000
+
 // Index is an in-memory implementation of index.Index.
 type Index[K comparable, I common.Identifier] struct {
 	data          map[K]I
+	list          []K
+	hashes        []common.Hash
 	keySerializer common.Serializer[K]
 	hashIndex     *indexhash.IndexHash[K]
 }
@@ -18,7 +23,9 @@ type Index[K comparable, I common.Identifier] struct {
 // NewIndex constructs a new Index instance.
 func NewIndex[K comparable, I common.Identifier](serializer common.Serializer[K]) *Index[K, I] {
 	memory := Index[K, I]{
-		data:          make(map[K]I),
+		data:          make(map[K]I, initCapacity),
+		list:          make([]K, 0, initCapacity),
+		hashes:        make([]common.Hash, 0, initCapacity/4096),
 		keySerializer: serializer,
 		hashIndex:     indexhash.NewIndexHash[K](serializer),
 	}
@@ -29,9 +36,22 @@ func NewIndex[K comparable, I common.Identifier](serializer common.Serializer[K]
 func (m *Index[K, I]) GetOrAdd(key K) (I, error) {
 	idx, exists := m.data[key]
 	if !exists {
-		idx = I(len(m.data))
+		size := len(m.data)
+
+		// commit hash for the snapshot block height window
+		if size%index.GetKeysPerPart(m.keySerializer) == 0 {
+			hash, err := m.GetStateHash()
+			if err != nil {
+				return idx, err
+			}
+			m.hashes = append(m.hashes, hash)
+		}
+
+		idx = I(size)
 		m.data[key] = idx
 		m.hashIndex.AddKey(key)
+		m.list = append(m.list, key)
+
 	}
 	return idx, nil
 }
@@ -66,14 +86,102 @@ func (m *Index[K, I]) Close() error {
 	return nil
 }
 
+func (m *Index[K, I]) GetProof() (backend.Proof, error) {
+	hash, err := m.GetStateHash()
+	if err != nil {
+		return nil, err
+	}
+
+	return index.NewIndexProof(common.Hash{}, hash), nil
+}
+
+func (m *Index[K, I]) CreateSnapshot() (backend.Snapshot, error) {
+	hash, err := m.GetStateHash()
+	if err != nil {
+		return nil, err
+	}
+
+	return index.CreateIndexSnapshotFromIndex[K](
+		m.keySerializer,
+		hash,
+		len(m.list),
+		&indexSnapshotSource[K, I]{m, len(m.list), hash}), nil
+}
+
+func (m *Index[K, I]) Restore(data backend.SnapshotData) error {
+	snapshot, err := index.CreateIndexSnapshotFromData(m.keySerializer, data)
+	if err != nil {
+		return err
+	}
+
+	// Reset and re-initialize the index.
+	m.hashIndex.Clear()
+	m.hashes = m.hashes[0:0]
+	m.list = m.list[0:0]
+	m.data = make(map[K]I, initCapacity)
+
+	for j := 0; j < snapshot.GetNumParts(); j++ {
+		part, err := snapshot.GetPart(j)
+		if err != nil {
+			return err
+		}
+		indexPart, ok := part.(*index.IndexPart[K])
+		if !ok {
+			return fmt.Errorf("invalid part format encountered")
+		}
+		for _, key := range indexPart.GetKeys() {
+			if _, err := m.GetOrAdd(key); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type indexSnapshotSource[K comparable, I common.Identifier] struct {
+	index   *Index[K, I] // The index this snapshot is based on.
+	numKeys int          // The number of keys at the time the snapshot was created.
+	hash    common.Hash  // The hash at the time the snapshot was created.
+}
+
+func (m *indexSnapshotSource[K, I]) GetHash(keyHeight int) (common.Hash, error) {
+	keysPerPart := index.GetKeysPerPart(m.index.keySerializer)
+
+	if keyHeight == m.numKeys {
+		return m.hash, nil
+	}
+	if keyHeight > m.numKeys {
+		return common.Hash{}, fmt.Errorf("invalid key height, not covered by snapshot")
+	}
+
+	if keyHeight%keysPerPart != 0 {
+		return common.Hash{}, fmt.Errorf("invalid key height, only supported at part boundaries")
+	}
+	return m.index.hashes[keyHeight/keysPerPart], nil
+}
+
+func (m *indexSnapshotSource[K, I]) GetKeys(from, to int) ([]K, error) {
+	return m.index.list[from:to], nil
+}
+
+func (m *indexSnapshotSource[K, I]) Release() error {
+	// nothing to do
+	return nil
+}
+
 // GetMemoryFootprint provides the size of the index in memory in bytes.
 func (m *Index[K, I]) GetMemoryFootprint() *common.MemoryFootprint {
 	dataMapItemSize := unsafe.Sizeof(struct {
 		key K
 		idx I
 	}{})
+	var k K
+	var hash common.Hash
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*m) + uintptr(len(m.data))*dataMapItemSize)
 	mf.AddChild("hashIndex", m.hashIndex.GetMemoryFootprint())
+	mf.AddChild("list", common.NewMemoryFootprint(uintptr(len(m.list))*unsafe.Sizeof(k)))
+	mf.AddChild("hashes", common.NewMemoryFootprint(uintptr(len(m.hashes))*unsafe.Sizeof(hash)))
 	mf.SetNote(fmt.Sprintf("(items: %d)", len(m.data)))
 	return mf
 }

--- a/go/backend/index/snapshot.go
+++ b/go/backend/index/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
@@ -18,6 +17,10 @@ import (
 // first key (by definition Hash = 0) and the hash after the last added key.
 type IndexProof struct {
 	before, after common.Hash
+}
+
+func NewIndexProof(before, after common.Hash) *IndexProof {
+	return &IndexProof{before, after}
 }
 
 func createIndexProofFromData(data []byte) (*IndexProof, error) {


### PR DESCRIPTION
This PR implements snapsync support for in-memory index. It uses utility functions from @HerbertJordan 


not-implemented stubs are added into other index implementations
existing tests are generalised to test the snapshot feature 