### PR TITLE
Add depot snapshot implementation utils

### DIFF
--- a/go/backend/depot/snapshot.go
+++ b/go/backend/depot/snapshot.go
@@ -1,0 +1,299 @@
+package depot
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// ---------------------------------- Proof -----------------------------------
+
+// DepotProof is the type of proof used by depot snapshots. For indiviudal
+// pages, this is merely the hash of its content, while for the full snapshot,
+// this is the result of the hash reduction using the depot's hash-tree
+// reduction algorithm.
+type DepotProof struct {
+	hash common.Hash
+}
+
+func createDepotProofFromData(data []byte) (*DepotProof, error) {
+	if len(data) != common.HashSize {
+		return nil, fmt.Errorf("invalid encoding of depot proof, invalid number of bytes")
+	}
+	var hash common.Hash
+	copy(hash[:], data[0:])
+	return &DepotProof{hash}, nil
+}
+
+func (p *DepotProof) Equal(proof backend.Proof) bool {
+	other, ok := proof.(*DepotProof)
+	return ok && other.hash == p.hash
+}
+
+func (p *DepotProof) ToBytes() []byte {
+	return p.hash.ToBytes()
+}
+
+// ----------------------------------- Part -----------------------------------
+
+// DepotPart is a part of a store snapshot covering exactly one page of values.
+// A proof of a part is the hash of the page content, which can be effectively
+// obtained from depot implementations.
+type DepotPart struct {
+	proof  *DepotProof
+	values [][]byte
+}
+
+func createDepotPartFromData(data []byte) (*DepotPart, error) {
+	if len(data) < common.HashSize {
+		return nil, fmt.Errorf("invalid encoding of depot part, invalid number of bytes")
+	}
+
+	proof, err := createDepotProofFromData(data[0:common.HashSize])
+	if err != nil {
+		return nil, err
+	}
+	data = data[common.HashSize:]
+
+	if len(data) < 2 {
+		return nil, fmt.Errorf("invalid encoding of depot part, not enough bytes for page size")
+	}
+	pageSize := int(binary.LittleEndian.Uint16(data))
+	data = data[2:]
+
+	if len(data) < pageSize*4 {
+		return nil, fmt.Errorf("invalid encoding of depot part, not enough bytes for data lengths")
+	}
+
+	lengths := make([]int, pageSize)
+	lengthsSum := 0
+	for i := 0; i < pageSize; i++ {
+		lengths[i] = int(binary.LittleEndian.Uint32(data))
+		data = data[4:]
+		lengthsSum += lengths[i]
+	}
+
+	if len(data) != lengthsSum {
+		return nil, fmt.Errorf("invalid encoding of depot part, invalid length of data section, wanted %d, got %d", lengthsSum, len(data))
+	}
+
+	values := make([][]byte, pageSize)
+	for i := 0; i < pageSize; i++ {
+		values[i] = data[0:lengths[i]]
+		data = data[lengths[i]:]
+	}
+
+	return &DepotPart{proof, values}, nil
+}
+
+func (p *DepotPart) GetProof() backend.Proof {
+	return p.proof
+}
+
+func (p *DepotPart) Verify() bool {
+	h := sha256.New()
+	for _, value := range p.values {
+		buffer := [4]byte{}
+		binary.LittleEndian.AppendUint32(buffer[0:0], uint32(len(value)))
+		h.Write(buffer[:])
+	}
+	for _, value := range p.values {
+		h.Write(value)
+	}
+	var hash common.Hash
+	h.Sum(hash[0:0])
+	return hash == p.proof.hash
+}
+
+func (p *DepotPart) ToBytes() []byte {
+	res := p.proof.ToBytes()
+	res = binary.LittleEndian.AppendUint16(res, uint16(len(p.values)))
+	for _, value := range p.values {
+		res = binary.LittleEndian.AppendUint32(res, uint32(len(value)))
+	}
+	for _, value := range p.values {
+		res = append(res, value...)
+	}
+	return res
+}
+
+func (p *DepotPart) GetValues() [][]byte {
+	return p.values
+}
+
+// --------------------------------- Snapshot ---------------------------------
+
+// DepotSnapshotSource is the interface to be implemented by Depot implementations
+// to provide snapshot data. It is a reduced version of the full Snapshot
+// interface, freeing implementations from common Depot Snapshot requirements.
+type DepotSnapshotSource interface {
+	GetHash(page int) (common.Hash, error)
+	GetValues(page int) ([][]byte, error)
+	Release() error
+}
+
+// DepotSnapshot is the snapshot format used by all depot implementations. Each
+// part of the snapshot contains a page of the depot. Proofs of parts are page
+// hashes, and the root proof is the result of the hierarchical reduction of
+// the page hashes using the depot's hash-tree algorithm.
+type DepotSnapshot struct {
+	branchingFactor int                 // The branching factor used in the hash computation.
+	proof           *DepotProof         // The root proof of the snapshot.
+	numPages        int                 // The number of pages (= parts) in this snapshot.
+	source          DepotSnapshotSource // Abstract access to the depot type to support alternative SnapshotData sources.
+}
+
+// CreateDepotSnapshotFromDepot creates a new depot snapshot utilizing the provided
+// source. This factory is intended to be used by Depot implementations when creating
+// a new snapshot.
+func CreateDepotSnapshotFromDepot(branchingFactor int, hash common.Hash, numPages int, source DepotSnapshotSource) *DepotSnapshot {
+	return &DepotSnapshot{branchingFactor, &DepotProof{hash}, numPages, source}
+}
+
+// CreateDepotSnapshotFromData creates a new depot snapshot utilizing the provided
+// snapshot data. This factory is intended to be used by Depot implementations to wrap
+// snapshot data into a DepotSnapshot to facilitate data restoration.
+func CreateDepotSnapshotFromData(data backend.SnapshotData) (*DepotSnapshot, error) {
+	metadata, err := data.GetMetaData()
+	if err != nil {
+		return nil, err
+	}
+
+	// Metadata contains the root hash/proof, 2 bytes for the branching factor, and 8 bytes for the number of pages.
+	if len(metadata) != common.HashSize+2+8 {
+		return nil, fmt.Errorf("invalid depot snapshot metadata encoding, invalid number of bytes")
+	}
+
+	var hash common.Hash
+	copy(hash[:], metadata[0:common.HashSize])
+	metadata = metadata[common.HashSize:]
+	branching := int(binary.LittleEndian.Uint16(metadata[0:]))
+	metadata = metadata[2:]
+	numPages := int(binary.LittleEndian.Uint64(metadata[:]))
+
+	return &DepotSnapshot{branching, &DepotProof{hash}, numPages, &depotSourceFromData{numPages, data}}, nil
+}
+
+func (s *DepotSnapshot) GetRootProof() backend.Proof {
+	return s.proof
+}
+
+func (s *DepotSnapshot) GetNumParts() int {
+	return s.numPages
+}
+
+func (s *DepotSnapshot) GetProof(partNumber int) (backend.Proof, error) {
+	hash, err := s.source.GetHash(partNumber)
+	if err != nil {
+		return nil, err
+	}
+	return &DepotProof{hash}, nil
+}
+
+func (s *DepotSnapshot) GetPart(partNumber int) (backend.Part, error) {
+	proof, err := s.GetProof(partNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := s.source.GetValues(partNumber)
+	if err != nil {
+		return nil, err
+	}
+	return &DepotPart{proof.(*DepotProof), values}, nil
+}
+
+func (s *DepotSnapshot) VerifyRootProof() error {
+	hash, err := s.computeRootHash()
+	if err != nil {
+		return err
+	}
+	if s.proof.hash != hash {
+		return fmt.Errorf("inconsistent root proof encountered")
+	}
+	return nil
+}
+
+func (s *DepotSnapshot) computeRootHash() (common.Hash, error) {
+	// Note: This should not use the lazy hash tree infrastructure, since this
+	// would require to fetch all the data from the pages. Instead, it should
+	// only verify that the proofs of the pages are consistent with the root.
+	return hashtree.ReduceHashes(s.branchingFactor, s.numPages, func(page int) (common.Hash, error) {
+		proof, err := s.GetProof(page)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		return proof.(*DepotProof).hash, nil
+	})
+}
+
+func (s *DepotSnapshot) GetData() backend.SnapshotData {
+	return s
+}
+
+func (s *DepotSnapshot) Release() error {
+	return s.source.Release()
+}
+
+func (s *DepotSnapshot) GetMetaData() ([]byte, error) {
+	res := make([]byte, 0, common.HashSize+2+8)
+	res = append(res, s.proof.hash[:]...)
+	res = binary.LittleEndian.AppendUint16(res, uint16(s.branchingFactor))
+	res = binary.LittleEndian.AppendUint64(res, uint64(s.numPages))
+	return res, nil
+}
+
+func (s *DepotSnapshot) GetProofData(partNumber int) ([]byte, error) {
+	proof, err := s.GetProof(partNumber)
+	if err != nil {
+		return nil, err
+	}
+	return proof.ToBytes(), nil
+}
+
+func (s *DepotSnapshot) GetPartData(partNumber int) ([]byte, error) {
+	proof, err := s.GetPart(partNumber)
+	if err != nil {
+		return nil, err
+	}
+	return proof.ToBytes(), nil
+}
+
+// depotSourceFromData is an implementation of the DepotSnapshotSource adapting
+// a SnapshotData to the interface required by the DepotSnapshot implementation.
+type depotSourceFromData struct {
+	numPages int
+	source   backend.SnapshotData
+}
+
+func (s *depotSourceFromData) GetHash(pageNumber int) (common.Hash, error) {
+	data, err := s.source.GetProofData(pageNumber)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	proof, err := createDepotProofFromData(data)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return proof.hash, nil
+}
+
+func (s *depotSourceFromData) GetValues(pageNumber int) ([][]byte, error) {
+	data, err := s.source.GetPartData(pageNumber)
+	if err != nil {
+		return nil, err
+	}
+	part, err := createDepotPartFromData(data)
+	if err != nil {
+		return nil, err
+	}
+	return part.GetValues(), nil
+}
+
+func (s *depotSourceFromData) Release() error {
+	return nil
+}

--- a/go/backend/depot/snapshot_test.go
+++ b/go/backend/depot/snapshot_test.go
@@ -1,0 +1,335 @@
+package depot
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree/htmemory"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func TestDepotProof_IsProof(t *testing.T) {
+	var _ backend.Proof = &DepotProof{}
+}
+
+func TestDepotPart_IsPart(t *testing.T) {
+	var _ backend.Part = &DepotPart{}
+}
+
+func TestDepotSnapshot_IsSnapshot(t *testing.T) {
+	var _ backend.Snapshot = &DepotSnapshot{}
+}
+
+const myBranchingFactor = 16
+
+// myDepot implements a simple depot to test and demonstrate the snapshotting on depots.
+type myDepot struct {
+	pages [][32][]byte
+}
+
+func (s *myDepot) Get(pos int) []byte {
+	pageId := pos / 32
+	if pos < 0 || pageId >= len(s.pages) {
+		return []byte{}
+	}
+	// Return a copy of the data to avoid mutation.
+	data := s.pages[pageId][pos%32]
+	res := make([]byte, len(data))
+	copy(res, data)
+	return res
+}
+
+func (s *myDepot) Set(pos int, value []byte) {
+	if pos < 0 {
+		return
+	}
+	if s.pages == nil {
+		s.pages = [][32][]byte{}
+	}
+	pageId := pos / 32
+	for len(s.pages) <= pageId {
+		s.pages = append(s.pages, [32][]byte{})
+	}
+	// Store a copy of the value, to avoid mutation.
+	trg := make([]byte, len(value))
+	copy(trg, value)
+	s.pages[pageId][pos%32] = trg
+}
+
+func (s *myDepot) getHash() common.Hash {
+	hashTree := htmemory.CreateHashTreeFactory(myBranchingFactor).Create(s)
+	for i := 0; i < len(s.pages); i++ {
+		hashTree.MarkUpdated(i)
+	}
+	hash, err := hashTree.HashRoot()
+	if err != nil {
+		panic(fmt.Sprintf("failed to compute hash of pages: %v", err))
+	}
+	return hash
+}
+
+func (s *myDepot) GetPage(page int) ([]byte, error) {
+	res := []byte{}
+	for _, value := range s.pages[page] {
+		res = binary.LittleEndian.AppendUint32(res, uint32(len(value)))
+	}
+	for _, value := range s.pages[page] {
+		res = append(res, value...)
+	}
+	return res, nil
+}
+
+func (s *myDepot) GetProof() (backend.Proof, error) {
+	return &DepotProof{s.getHash()}, nil
+}
+
+func (s *myDepot) CreateSnapshot() (backend.Snapshot, error) {
+	hash := s.getHash()
+
+	// Note: this is a shallow copy, exploiting the immutable nature of data.
+	copyOfPages := make([][32][]byte, len(s.pages))
+	copy(copyOfPages, s.pages)
+
+	return CreateDepotSnapshotFromDepot(
+		myBranchingFactor,
+		hash,
+		len(s.pages),
+		&myDepotSnapshotSource{hash, copyOfPages}), nil
+}
+
+func (s *myDepot) Restore(data backend.SnapshotData) error {
+	snapshot, err := CreateDepotSnapshotFromData(data)
+	if err != nil {
+		return err
+	}
+
+	// Reset the depot.
+	s.pages = s.pages[0:0]
+
+	for i := 0; i < snapshot.GetNumParts(); i++ {
+		part, err := snapshot.GetPart(i)
+		if err != nil {
+			return err
+		}
+		depotPart, ok := part.(*DepotPart)
+		if !ok {
+			return fmt.Errorf("invalid part format encountered")
+		}
+		for j, value := range depotPart.GetValues() {
+			s.Set(i*32+j, value)
+		}
+	}
+	return nil
+}
+
+type myDepotSnapshotSource struct {
+	// The hash at the time the snapshot was created.
+	hash common.Hash
+	// A shallow copy of the depot data at snapshot creation.
+	pages [][32][]byte
+}
+
+func (s *myDepotSnapshotSource) GetHash(page int) (common.Hash, error) {
+	if page < 0 || page >= len(s.pages) {
+		return common.Hash{}, fmt.Errorf("invalid page number, not covered by snapshot")
+	}
+
+	h := sha256.New()
+	for _, value := range s.pages[page] {
+		buffer := [4]byte{}
+		binary.LittleEndian.AppendUint32(buffer[0:0], uint32(len(value)))
+		h.Write(buffer[:])
+	}
+	for _, value := range s.pages[page] {
+		h.Write(value)
+	}
+	var hash common.Hash
+	h.Sum(hash[0:0])
+	return hash, nil
+}
+
+func (s *myDepotSnapshotSource) GetValues(page int) ([][]byte, error) {
+	if page < 0 || page >= len(s.pages) {
+		return nil, fmt.Errorf("invalid page number, not covered by snapshot")
+	}
+	return s.pages[page][:], nil
+}
+
+func (i *myDepotSnapshotSource) Release() error {
+	// nothing to do
+	return nil
+}
+
+func TestDepotSnapshot_MyDepotIsSnapshotable(t *testing.T) {
+	var _ backend.Snapshotable = &myDepot{}
+}
+
+func fillDepot(t *testing.T, depot *myDepot, size int) {
+	for i := 0; i < size; i++ {
+		depot.Set(i, []byte{byte(i), byte(i >> 8), byte(i >> 16)})
+	}
+}
+
+func checkDepotContent(t *testing.T, depot *myDepot, size int) {
+	for i := 0; i < size; i++ {
+		if !bytes.Equal(depot.Get(i), []byte{byte(i), byte(i >> 8), byte(i >> 16)}) {
+			t.Errorf("invalid value at position %d", i)
+		}
+	}
+}
+
+func TestDepotSnapshot_MyDepotSnapshotCanBeCreatedAndRestored(t *testing.T) {
+	for _, size := range []int{0, 1, 5, 1000} {
+		original := &myDepot{}
+		fillDepot(t, original, size)
+		originalProof, err := original.GetProof()
+		if err != nil {
+			t.Errorf("failed to produce a proof for the original state")
+		}
+
+		snapshot, err := original.CreateSnapshot()
+		if err != nil {
+			t.Errorf("failed to create snapshot: %v", err)
+			return
+		}
+		if snapshot == nil {
+			t.Errorf("failed to create snapshot")
+			return
+		}
+
+		if !originalProof.Equal(snapshot.GetRootProof()) {
+			t.Errorf("snapshot proof does not match data structure proof")
+		}
+
+		recovered := &myDepot{}
+		if err := recovered.Restore(snapshot.GetData()); err != nil {
+			t.Errorf("failed to sync to snapshot: %v", err)
+			return
+		}
+
+		recoveredProof, err := recovered.GetProof()
+		if err != nil {
+			t.Errorf("failed to produce a proof for the recovered state")
+		}
+
+		if !recoveredProof.Equal(snapshot.GetRootProof()) {
+			t.Errorf("snapshot proof does not match recovered proof")
+		}
+
+		checkDepotContent(t, recovered, size)
+
+		if err := snapshot.Release(); err != nil {
+			t.Errorf("failed to release snapshot: %v", err)
+		}
+	}
+}
+
+func TestDepotSnapshot_MyDepotSnapshotIsShieldedFromMutations(t *testing.T) {
+	original := &myDepot{}
+	fillDepot(t, original, 20)
+	originalProof, err := original.GetProof()
+	if err != nil {
+		t.Errorf("failed to produce a proof for the original state")
+	}
+
+	snapshot, err := original.CreateSnapshot()
+	if err != nil {
+		t.Errorf("failed to create snapshot: %v", err)
+		return
+	}
+	if snapshot == nil {
+		t.Errorf("failed to create snapshot")
+		return
+	}
+
+	// Additional mutations of the original should not be affected.
+	original.Set(15, []byte{0xaa})
+
+	if !originalProof.Equal(snapshot.GetRootProof()) {
+		t.Errorf("snapshot proof does not match data structure proof")
+	}
+
+	recovered := &myDepot{}
+	if err := recovered.Restore(snapshot.GetData()); err != nil {
+		t.Errorf("failed to sync to snapshot: %v", err)
+		return
+	}
+
+	if !bytes.Equal(recovered.Get(15), []byte{15, 0, 0}) {
+		t.Errorf("recovered state should not include elements added after snapshot creation")
+	}
+
+	if err := snapshot.Release(); err != nil {
+		t.Errorf("failed to release snapshot: %v", err)
+	}
+}
+
+func TestDepotSnapshot_MyDepotSnapshotCanBeCreatedAndValidated(t *testing.T) {
+	for _, size := range []int{0, 1, 5, 1000, 100000} {
+		original := &myDepot{}
+		fillDepot(t, original, size)
+
+		snapshot, err := original.CreateSnapshot()
+		if err != nil {
+			t.Errorf("failed to create snapshot: %v", err)
+			return
+		}
+		if snapshot == nil {
+			t.Errorf("failed to create snapshot")
+			return
+		}
+
+		remote, err := CreateDepotSnapshotFromData(snapshot.GetData())
+		if err != nil {
+			t.Fatalf("failed to create snapshot from snapshot data: %v", err)
+		}
+
+		// Test direct and serialized snapshot data access.
+		for _, cur := range []backend.Snapshot{snapshot, remote} {
+
+			// The root proof should be equivalent.
+			want, err := original.GetProof()
+			if err != nil {
+				t.Errorf("failed to get root proof from data structure")
+			}
+
+			have := cur.GetRootProof()
+			if !want.Equal(have) {
+				t.Errorf("root proof of snapshot does not match proof of data structure")
+			}
+
+			if err := cur.VerifyRootProof(); err != nil {
+				t.Errorf("snapshot invalid, inconsistent proofs")
+			}
+
+			// Verify all pages
+			for i := 0; i < cur.GetNumParts(); i++ {
+				want, err := cur.GetProof(i)
+				if err != nil {
+					t.Errorf("failed to fetch proof of part %d", i)
+				}
+				part, err := cur.GetPart(i)
+				if err != nil {
+					t.Errorf("failed to fetch part %d", i)
+				}
+				if !want.Equal(part.GetProof()) {
+					t.Errorf("proof of part does not equal proof provided by snapshot")
+				}
+				if !part.Verify() {
+					t.Errorf("failed to verify content of part %d", i)
+				}
+			}
+		}
+
+		if err := remote.Release(); err != nil {
+			t.Errorf("failed to release remote snapshot: %v", err)
+		}
+		if err := snapshot.Release(); err != nil {
+			t.Errorf("failed to release snapshot: %v", err)
+		}
+	}
+}

--- a/go/backend/hashtree/reduction.go
+++ b/go/backend/hashtree/reduction.go
@@ -1,0 +1,56 @@
+package hashtree
+
+import (
+	"crypto/sha256"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// ReduceHashes computes the hash of a tee with the given branching factor
+// and numPages hashes on the leaf level. Hashes for leaves are fetched on
+// demand through the source function.
+func ReduceHashes(branchingFactor int, numPages int, source func(int) (common.Hash, error)) (common.Hash, error) {
+
+	// If there are no pages, the procedure is simple.
+	if numPages <= 0 {
+		return common.Hash{}, nil
+	}
+
+	if numPages == 1 {
+		return source(0)
+	}
+
+	paddedSize := numPages
+	if paddedSize%branchingFactor != 0 {
+		paddedSize = paddedSize + branchingFactor - (paddedSize % branchingFactor)
+	}
+
+	// Collect all hashes from the individual pages.
+	hashes := make([]common.Hash, paddedSize)
+	for i := 0; i < numPages; i++ {
+		hash, err := source(i)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		hashes[i] = hash
+	}
+
+	// Perform the hash reduction.
+	h := sha256.New()
+	for len(hashes) > 1 {
+		for i := 0; i < len(hashes); i += branchingFactor {
+			h.Reset()
+			for j := 0; j < branchingFactor; j++ {
+				h.Write(hashes[i+j][:])
+			}
+			h.Sum(hashes[i/branchingFactor][0:0])
+		}
+		hashes = hashes[0 : len(hashes)/branchingFactor]
+		for len(hashes) > 1 && len(hashes)%branchingFactor != 0 {
+			hashes = append(hashes, common.Hash{})
+		}
+	}
+
+	return hashes[0], nil
+
+}

--- a/go/backend/hashtree/reduction_test.go
+++ b/go/backend/hashtree/reduction_test.go
@@ -1,0 +1,48 @@
+package hashtree
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func getSha256Hash(data []byte) common.Hash {
+	h := sha256.New()
+	h.Write(data)
+	var hash common.Hash
+	h.Sum(hash[0:0])
+	return hash
+}
+
+func reduceHashes(branchingFactor int, hashes []common.Hash) common.Hash {
+	hash, err := ReduceHashes(branchingFactor, len(hashes), func(i int) (common.Hash, error) {
+		return hashes[i], nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("an error was produced where none should be allowed: %v", err))
+	}
+	return hash
+}
+
+func TestKnownHashes(t *testing.T) {
+	// Tests the hashes for values 0x00, 0x11 ... 0x44 inserted in sequence.
+	// reference hashes from the C++ implementation
+	expectedHashes := []string{
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+		"6c5f701c7f179fe2f65970ec7105d8e5c156c94fdf5aaaa9583be12473c89f0f",
+		"d8474951058dfc020b3d9b62b06528130543884b9520a7542be52a2f6344cad4",
+		"3cd329e823a238ba7897f2ad62aeea1435a10999cbed87bec7fdd410a93d7096",
+		"1964521cc4a514e44c4395c9a23ee88263b4463717d43b0c57808867bcabfd4f",
+	}
+
+	hashes := []common.Hash{}
+	for i, expected := range expectedHashes {
+		if hash := reduceHashes(3, hashes); fmt.Sprintf("%x", hash) != expected {
+			t.Errorf("invalid hash for step %d, got %x, wanted %v", len(hashes), hash, expectedHashes[i])
+		}
+		hashes = append(hashes, getSha256Hash([]byte{byte(i<<4 | i)}))
+	}
+}


### PR DESCRIPTION
This PR ...
 - adds snapshot utilities for Depots
 - factors out the hash-reduction algorithm used by store and depot snapshots into a common utility function