### PR TITLE
Kjezek/enable snapsync file index

### DIFF
--- a/go/backend/index/file/file_test.go
+++ b/go/backend/index/file/file_test.go
@@ -260,4 +260,14 @@ func TestFileHashMemoryFootprint(t *testing.T) {
 	if freeIdsOverflow == nil {
 		t.Errorf("Mem footprint wrong")
 	}
+
+	reverse := footPrint.GetChild("keys")
+	if size := reverse.Value(); size == 0 {
+		t.Errorf("Mem footprint wrong: %d", size)
+	}
+
+	hashes := footPrint.GetChild("hashes")
+	if size := hashes.Value(); size == 0 {
+		t.Errorf("Mem footprint wrong: %d", size)
+	}
 }

--- a/go/backend/index/index_test.go
+++ b/go/backend/index/index_test.go
@@ -129,7 +129,7 @@ func TestIndexesHashesAgainstReferenceOutput(t *testing.T) {
 
 func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndRestored(t *testing.T) {
 	for name, idx := range initIndexesMap() {
-		for _, size := range []int{0, 1, 5, 1000} {
+		for _, size := range []int{0, 1, 5, 1000, 12345} {
 			t.Run(fmt.Sprintf("index %s size %d", name, size), func(t *testing.T) {
 
 				originalIndex := idx(t)
@@ -175,6 +175,69 @@ func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndRestored(t *testing.T) {
 				}
 
 				checkIndexContent(t, recoveredIndex, size)
+
+				if err := snapshot.Release(); err != nil {
+					t.Errorf("failed to release snapshot: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestIndexSnapshot_IndexCrosscheckSnapshotCanBeCreatedAndRestored(t *testing.T) {
+	for name, idx := range initIndexesMap() {
+		for _, size := range []int{0, 1, 5, 1000, 12345} {
+			t.Run(fmt.Sprintf("index %s size %d", name, size), func(t *testing.T) {
+
+				originalIndex := idx(t)
+				original, ok := originalIndex.(backend.Snapshotable)
+				if !ok {
+					t.Skip(fmt.Sprintf("index: %s is not Snapshotable", name))
+				}
+
+				fillIndex(t, originalIndex, size)
+				originalProof, err := original.GetProof()
+				if err != nil {
+					t.Errorf("failed to produce a proof for the original state")
+				}
+
+				snapshot, err := original.CreateSnapshot()
+				if err != nil {
+					t.Errorf("failed to create snapshot: %v", err)
+					return
+				}
+				if snapshot == nil {
+					t.Errorf("failed to create snapshot")
+					return
+				}
+
+				if !originalProof.Equal(snapshot.GetRootProof()) {
+					t.Errorf("snapshot proof does not match data structure proof")
+				}
+
+				for recoveredName, idx := range initIndexesMap() {
+					recoveredIndex := idx(t)
+					recovered, ok := recoveredIndex.(backend.Snapshotable)
+					if !ok {
+						continue // this index is not Snapshotable
+					}
+
+					if err := recovered.Restore(snapshot.GetData()); err != nil {
+						t.Errorf("failed to sync to %s snapshot: %v", recoveredName, err)
+						return
+					}
+
+					recoveredProof, err := recovered.GetProof()
+					if err != nil {
+						t.Errorf("failed to produce a proof for the recovered state")
+					}
+
+					if !recoveredProof.Equal(snapshot.GetRootProof()) {
+						t.Errorf("snapshot proof does not match recovered proof")
+					}
+
+					checkIndexContent(t, recoveredIndex, size)
+				}
 
 				if err := snapshot.Release(); err != nil {
 					t.Errorf("failed to release snapshot: %v", err)
@@ -341,7 +404,8 @@ func compareIds(ids []uint32) error {
 
 func fillIndex(t *testing.T, index index.Index[common.Address, uint32], size int) {
 	for i := 0; i < size; i++ {
-		if idx, err := index.GetOrAdd(common.Address{byte(i), byte(i >> 8), byte(i >> 16)}); idx != uint32(i) || err != nil {
+		addr := common.AddressFromNumber(i)
+		if idx, err := index.GetOrAdd(addr); idx != uint32(i) || err != nil {
 			t.Errorf("failed to add address %d", i)
 		}
 	}
@@ -349,7 +413,8 @@ func fillIndex(t *testing.T, index index.Index[common.Address, uint32], size int
 
 func checkIndexContent(t *testing.T, index index.Index[common.Address, uint32], size int) {
 	for i := 0; i < size; i++ {
-		if idx, err := index.GetOrAdd(common.Address{byte(i), byte(i >> 8), byte(i >> 16)}); idx != uint32(i) || err != nil {
+		addr := common.AddressFromNumber(i)
+		if idx, err := index.GetOrAdd(addr); idx != uint32(i) || err != nil {
 			t.Errorf("failed to locate address %d", i)
 		}
 	}


### PR DESCRIPTION
This PR implements snapsync support for the `file/index`. 

It stores a copy of keys and hashes using the new `Array` structure, which maps:
```
index -> key
index -> hash

```

this has been updated according to @HerbertJordan suggestion. 