### PR TITLE
Kjezek/introduce pagged array

### DIFF
--- a/go/backend/array/array.go
+++ b/go/backend/array/array.go
@@ -1,0 +1,20 @@
+package array
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// Array is a structure that allows to store and fetch a value to/from ordinal indexes.
+type Array[I common.Identifier, V any] interface {
+	// Set creates a new mapping from the index to the value
+	Set(id I, value V) error
+
+	// Get a value associated with the index (or a default value if not defined)
+	Get(id I) (V, error)
+
+	// provides the size of the store in memory in bytes
+	common.MemoryFootprintProvider
+
+	// Also, stores need to be flush and closable.
+	common.FlushAndCloser
+}

--- a/go/backend/array/array_test.go
+++ b/go/backend/array/array_test.go
@@ -1,0 +1,83 @@
+package array_test
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/array"
+	"github.com/Fantom-foundation/Carmen/go/backend/array/pagedarray"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"math/rand"
+	"testing"
+)
+
+const (
+	PageSize = 2 * 32
+	PoolSize = 10
+)
+
+var emptyAddress common.Address
+
+func getArrayFactories[I common.Identifier, V any](valSerializer common.Serializer[V], pageSize int64, poolSize int) map[string]func(t *testing.T) array.Array[I, V] {
+	return map[string]func(t *testing.T) array.Array[I, V]{
+		"pagedArray": func(t *testing.T) array.Array[I, V] {
+			arr, err := pagedarray.NewArray[I, V](t.TempDir(), valSerializer, pageSize, poolSize)
+			if err != nil {
+				t.Fatalf("cannot init array: %e", err)
+			}
+			t.Cleanup(func() {
+				_ = arr.Close()
+			})
+			return arr
+		},
+	}
+
+}
+
+func TestArrayGetSet(t *testing.T) {
+	for _, size := range []int{0, 1, 5, 1000, 123456} {
+		for name, factory := range getArrayFactories[uint32, common.Address](common.AddressSerializer{}, PageSize, PoolSize) {
+			t.Run(fmt.Sprintf("array %s size %d", name, size), func(t *testing.T) {
+				arr := factory(t)
+				flags := fill(t, arr, size)
+
+				for index, flag := range flags {
+					actual, err := arr.Get(uint32(index))
+					if err != nil {
+						t.Errorf("cannot get value: %e", err)
+					}
+
+					if flag && actual != common.AddressFromNumber(index) {
+						t.Errorf("value should be: %d and not: %d", index, actual)
+					}
+
+					if !flag && actual != emptyAddress {
+						t.Errorf("value should be empty, not: %d", actual)
+					}
+				}
+			})
+		}
+	}
+}
+
+// fill inits the input array with values at random indexes.
+// It returns true/false flag array saying if there should be a value at the index,
+// the values will be filled with the value matching the index.
+// The array will have elements at the number of indexes equal to the input size, while
+// the array will have the input size, i.e. the remaining positions will be empty
+func fill[I common.Identifier](t *testing.T, arr array.Array[I, common.Address], size int) []bool {
+	dimension := 100 * size
+	indexes := make([]bool, dimension)
+	for i := 0; i < dimension; i++ {
+		indexes[i] = i < size
+	}
+
+	rand.Shuffle(len(indexes), func(i, j int) { indexes[i], indexes[j] = indexes[j], indexes[i] })
+	for i := 0; i < dimension; i++ {
+		if indexes[i] {
+			if err := arr.Set(I(i), common.AddressFromNumber(i)); err != nil {
+				t.Fatalf("cannot fill array: %e", err)
+			}
+		}
+	}
+
+	return indexes
+}

--- a/go/backend/array/pagedarray/file.go
+++ b/go/backend/array/pagedarray/file.go
@@ -1,0 +1,168 @@
+package pagedarray
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"os"
+	"unsafe"
+)
+
+// Array is a filesystem-based array.Array implementation - it stores mapping of ID to value in binary files.
+type Array[I common.Identifier, V any] struct {
+	file         *os.File
+	pagePool     *common.Cache[int, *Page]
+	serializer   common.Serializer[V]
+	pageSize     int64 // the maximum size of a page in bytes
+	itemSize     int64 // the amount of bytes per one value
+	itemsPerPage int
+	freePage     *Page
+	onDirtyPage  func(pageId int) // callback called on page eviction to notify clients
+}
+
+// NewArray constructs a new instance of paged file backed array.
+func NewArray[I common.Identifier, V any](path string, serializer common.Serializer[V], pageSize int64, poolSize int) (*Array[I, V], error) {
+	itemSize := int64(serializer.Size())
+	if pageSize < itemSize {
+		return nil, fmt.Errorf("page size must not be less than one item size")
+	}
+	// create directory structure
+	f, err := os.OpenFile(path+"/data", os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open/create data file; %s", err)
+	}
+
+	return &Array[I, V]{
+		file:         f,
+		serializer:   serializer,
+		pageSize:     pageSize,
+		itemSize:     itemSize,
+		itemsPerPage: int(pageSize / itemSize),
+		pagePool:     common.NewCache[int, *Page](poolSize),
+		onDirtyPage:  func(pageId int) {},
+	}, nil
+}
+
+// itemPosition provides the position of an item in data pages
+func (m *Array[I, V]) itemPosition(id I) (page int, position int64) {
+	return int(id / I(m.itemsPerPage)), int64(id%I(m.itemsPerPage)) * m.itemSize
+}
+
+// ensurePageLoaded loads the page into the page pool if it is not there already
+func (m *Array[I, V]) ensurePageLoaded(pageId int) (page *Page, err error) {
+	page, exists := m.pagePool.Get(pageId)
+	if exists {
+		return
+	}
+	// get an empty page
+	page = m.getEmptyPage()
+	// load the page from the disk
+	err = page.Load(m.file, pageId)
+	if err != nil {
+		return
+	}
+	evictedPageId, evictedPage, evicted := m.pagePool.Set(pageId, page)
+	if evicted {
+		err = m.handleEvictedPage(evictedPageId, evictedPage)
+	}
+	return
+}
+
+// handleEvictedPage ensures storing an evicted page back to the disk
+func (m *Array[I, V]) handleEvictedPage(pageId int, page *Page) error {
+	if page.IsDirty() {
+		err := page.Store(m.file, pageId)
+		if err != nil {
+			return fmt.Errorf("failed to store evicted page; %s", err)
+		}
+		m.onDirtyPage(pageId)
+	}
+	m.freePage = page
+	return nil
+}
+
+// getEmptyPage provides an empty page for a page loading
+func (m *Array[I, V]) getEmptyPage() *Page {
+	if m.freePage != nil {
+		return m.freePage // reuse the last evicted page
+	} else {
+		return &Page{
+			data:  make([]byte, m.pageSize),
+			dirty: false,
+		}
+	}
+}
+
+// Set a value of an item
+func (m *Array[I, V]) Set(id I, value V) error {
+	pageId, itemPosition := m.itemPosition(id)
+	page, err := m.ensurePageLoaded(pageId)
+	if err != nil {
+		return fmt.Errorf("failed to load store page %d; %s", pageId, err)
+	}
+	pageItemBytes := page.Get(itemPosition, m.itemSize)
+	m.serializer.CopyBytes(value, pageItemBytes)
+	page.SetDirty()
+	return nil
+}
+
+// Get a value of the item (or a zero value, if not defined)
+func (m *Array[I, V]) Get(id I) (value V, err error) {
+	pageId, itemPosition := m.itemPosition(id)
+	page, err := m.ensurePageLoaded(pageId)
+	if err != nil {
+		return value, fmt.Errorf("failed to load store page %d; %s", pageId, err)
+	}
+	bytes := page.Get(itemPosition, m.itemSize)
+	return m.serializer.FromBytes(bytes), nil
+}
+
+// GetPage provides the page content for the HashTree
+func (m *Array[I, V]) GetPage(pageId int) ([]byte, error) {
+	page, err := m.ensurePageLoaded(pageId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load store page %d; %s", pageId, err)
+	}
+
+	return page.GetContent()[0 : m.pageSize/m.itemSize*m.itemSize], nil
+}
+
+// Flush all changes to the disk
+func (m *Array[I, V]) Flush() (err error) {
+	m.pagePool.Iterate(func(pageId int, page *Page) bool {
+		if page.IsDirty() {
+			// write the page to disk (but don't evict - keep in page pool as a clean page)
+			err = page.Store(m.file, pageId)
+			if err != nil {
+				return false
+			}
+			m.onDirtyPage(pageId)
+		}
+		return true
+	})
+
+	// flush data file changes to disk
+	if err = m.file.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close the array
+func (m *Array[I, V]) Close() (err error) {
+	if err = m.Flush(); err != nil {
+		return err
+	}
+	return m.file.Close()
+}
+
+// GetMemoryFootprint provides the size of the store in memory in bytes
+func (m *Array[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
+	pageSize := unsafe.Sizeof(Page{}) + uintptr(m.pageSize)
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*m))
+	mf.AddChild("pagePool", m.pagePool.GetMemoryFootprint(pageSize))
+	return mf
+}
+
+func (m *Array[I, V]) SetOnDirtyPageCallback(onDirtyPage func(pageId int)) {
+	m.onDirtyPage = onDirtyPage
+}

--- a/go/backend/array/pagedarray/file_test.go
+++ b/go/backend/array/pagedarray/file_test.go
@@ -1,0 +1,117 @@
+package pagedarray
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/array"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"io"
+	"testing"
+)
+
+func TestPagedArrayImplements(t *testing.T) {
+	var s Array[uint64, common.Value]
+	var _ array.Array[uint64, common.Value] = &s
+	var _ io.Closer = &s
+}
+
+var (
+	A = common.Value{0xAA}
+	B = common.Value{0xBB}
+	C = common.Value{0xCC}
+)
+
+func TestStoreInArray(t *testing.T) {
+	path := t.TempDir()
+	st := createArray(t, path)
+
+	err := st.Set(0, A)
+	if err != nil {
+		t.Fatalf("failed to set A; %s", err)
+	}
+	err = st.Set(1, B)
+	if err != nil {
+		t.Fatalf("failed to set B; %s", err)
+	}
+	err = st.Set(2, C)
+	if err != nil {
+		t.Fatalf("failed to set C; %s", err)
+	}
+
+	if value, err := st.Get(5); err != nil || value != (common.Value{}) {
+		t.Errorf("not-existing value is not reported as not-existing; err=%s", err)
+	}
+	if value, err := st.Get(0); err != nil || value != A {
+		t.Errorf("reading written A returned different value")
+	}
+	if value, err := st.Get(1); err != nil || value != B {
+		t.Errorf("reading written B returned different value")
+	}
+	if value, err := st.Get(2); err != nil || value != C {
+		t.Errorf("reading written C returned different value")
+	}
+}
+
+func TestStoringToArbitraryPosition(t *testing.T) {
+	path := t.TempDir()
+	st := createArray(t, path)
+
+	err := st.Set(5, A)
+	if err != nil {
+		t.Fatalf("failed to set A; %s", err)
+	}
+	err = st.Set(4, B)
+	if err != nil {
+		t.Fatalf("failed to set B; %s", err)
+	}
+	err = st.Set(9, C)
+	if err != nil {
+		t.Fatalf("failed to set C; %s", err)
+	}
+
+	if value, err := st.Get(1); err != nil || value != (common.Value{}) {
+		t.Errorf("not-existing value is not reported as not-existing")
+	}
+	if value, err := st.Get(5); err != nil || value != A {
+		t.Errorf("reading written A returned different value")
+	}
+	if value, err := st.Get(4); err != nil || value != B {
+		t.Errorf("reading written B returned different value")
+	}
+	if value, err := st.Get(9); err != nil || value != C {
+		t.Errorf("reading written C returned different value")
+	}
+}
+
+func TestStoringManyItemsIntoPagedFileStore(t *testing.T) {
+	path := t.TempDir()
+	st := createArray(t, path)
+
+	for i := uint32(0); i < 1000; i++ {
+		err := st.Set(i, common.Value{0x12, byte(i)})
+		if err != nil {
+			t.Fatalf("failed to set item %d; %s", i, err)
+		}
+	}
+
+	for i := uint32(0); i < 1000; i++ {
+		value, err := st.Get(i)
+		if err != nil {
+			t.Fatalf("failed to get item %d; %s", i, err)
+		}
+		if value != (common.Value{0x12, byte(i)}) {
+			t.Errorf("reading item %d returns unexpected value", i)
+		}
+	}
+}
+
+func createArray(t *testing.T, tmpDir string) *Array[uint32, common.Value] {
+	st, err := NewArray[uint32, common.Value](tmpDir, common.ValueSerializer{}, 8*32, 4)
+	if err != nil {
+		t.Fatalf("unable to create st; %s", err)
+	}
+
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+
+	return st
+}

--- a/go/backend/array/pagedarray/page.go
+++ b/go/backend/array/pagedarray/page.go
@@ -1,0 +1,59 @@
+package pagedarray
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Page is the in-memory version of a page of the file store.
+// It retains an in-memory copy of the binary data stored in the corresponding page file.
+// Furthermore, it provides index based access to the contained data.
+type Page struct {
+	data  []byte
+	dirty bool
+}
+
+func (p *Page) Load(file *os.File, pageId int) error {
+	n, err := file.ReadAt(p.data, int64(pageId)*int64(len(p.data)))
+	if err != nil && !errors.Is(err, io.EOF) { // EOF = the page does not exist in the data file yet
+		return err
+	}
+
+	for ; n < len(p.data); n++ {
+		p.data[n] = 0x00
+	}
+	p.dirty = false
+	return nil
+}
+
+func (p *Page) IsDirty() bool {
+	return p.dirty
+}
+
+func (p *Page) GetContent() []byte {
+	return p.data
+}
+
+func (p *Page) Set(position int64, bytes []byte) {
+	copy(p.data[position:position+int64(len(bytes))], bytes)
+	p.dirty = true
+}
+
+func (p *Page) SetDirty() {
+	p.dirty = true
+}
+
+func (p *Page) Get(position int64, size int64) []byte {
+	return p.data[position : position+size]
+}
+
+func (p *Page) Store(file *os.File, pageId int) error {
+	_, err := file.WriteAt(p.data, int64(pageId)*int64(len(p.data)))
+	if err != nil {
+		return fmt.Errorf("failed to write the page into file; %s", err)
+	}
+	p.dirty = false
+	return nil
+}


### PR DESCRIPTION
This PR introduces a new Array structure, which is basically the original Store structure without the hashing feature. 

It has been implemented for the `paged` variant only at the moment. 

Note for review: the newly introduced files in `backend/array/pagedarray` are 99% the same as original files in `backend/store/pagedfile `, with the only difference being removed hashing functionality

This functionality will be used for sharing the array between the file `Store` and the `Index`