### PR TITLE
corrects dirty flag for pages

### DIFF
--- a/go/backend/index/file/indexpage.go
+++ b/go/backend/index/file/indexpage.go
@@ -217,6 +217,10 @@ func (c *IndexPage[K, V]) IsDirty() bool {
 	return c.isDirty
 }
 
+func (c *IndexPage[K, V]) SetDirty(dirty bool) {
+	c.isDirty = dirty
+}
+
 func (c *IndexPage[K, V]) Clear() {
 	c.next = 0
 	c.hasNext = false

--- a/go/backend/pagepool/page.go
+++ b/go/backend/pagepool/page.go
@@ -20,4 +20,7 @@ type Page interface {
 
 	// IsDirty should return true if the was modified after it has been last saved
 	IsDirty() bool
+
+	// SetDirty sets the dirty flag of this page
+	SetDirty(dirty bool)
 }

--- a/go/backend/pagepool/page_test.go
+++ b/go/backend/pagepool/page_test.go
@@ -14,7 +14,8 @@ type RawPage struct {
 // NewRawPage creates a new page with the size given in bytes
 func NewRawPage(byteSize int) *RawPage {
 	return &RawPage{
-		data: make([]byte, 0, byteSize),
+		data:  make([]byte, 0, byteSize),
+		dirty: true,
 	}
 }
 
@@ -29,6 +30,7 @@ func (p *RawPage) FromBytes(pageData []byte) {
 
 func (p *RawPage) Clear() {
 	p.data = p.data[0:0]
+	p.dirty = true
 }
 
 func (p *RawPage) Size() int {
@@ -37,6 +39,10 @@ func (p *RawPage) Size() int {
 
 func (p *RawPage) IsDirty() bool {
 	return p.dirty
+}
+
+func (p *RawPage) SetDirty(dirty bool) {
+	p.dirty = dirty
 }
 
 func (p *RawPage) GetMemoryFootprint() *common.MemoryFootprint {

--- a/go/backend/pagepool/pagepool_test.go
+++ b/go/backend/pagepool/pagepool_test.go
@@ -44,13 +44,16 @@ func TestPageOverflows(t *testing.T) {
 	evictedPage := NewRawPage(common.PageSize)
 	evictedPage.FromBytes(data[:]) // to track a non-empty page
 
-	page := NewRawPage(common.PageSize)
+	page1 := NewRawPage(common.PageSize)
+	page2 := NewRawPage(common.PageSize)
+	page3 := NewRawPage(common.PageSize)
+
 	// 3 pages with 4 items each
 	_ = pagePool.put(pageA, evictedPage)
-	_ = pagePool.put(pageB, page)
-	_ = pagePool.put(pageC, page)
+	_ = pagePool.put(pageB, page1)
+	_ = pagePool.put(pageC, page2)
 
-	_ = pagePool.put(pageD, page)
+	_ = pagePool.put(pageD, page3)
 
 	// Here a page is loaded from the persistent storage.
 	// If the page exists there, it verifies the page was evicted from the page pool

--- a/go/backend/pagepool/pagestorage.go
+++ b/go/backend/pagepool/pagestorage.go
@@ -76,6 +76,7 @@ func (c *FilePageStorage) Load(pageId int, page Page) error {
 	}
 
 	page.FromBytes(c.buffer)
+	page.SetDirty(false)
 	return nil
 }
 
@@ -90,6 +91,7 @@ func (c *FilePageStorage) Store(pageId int, page Page) (err error) {
 	}
 
 	c.updateUse(pageId)
+	page.SetDirty(false)
 	return
 }
 


### PR DESCRIPTION
I noticed that the page dirty flag was not correctly set - once a page was set dirty, it was not never reverted. This could lead to unnecessary I/O while storing actually unchanged pages 