### PR TITLE
Remove proofs from snapshot parts

### DIFF
--- a/go/backend/composed_snapshot_test.go
+++ b/go/backend/composed_snapshot_test.go
@@ -167,13 +167,10 @@ func TestMyComposedDataStructureSnapshotCanBeCreatedAndValidated(t *testing.T) {
 				t.Errorf("failed to fetch proof of part %d", i)
 			}
 			part, err := cur.GetPart(i)
-			if err != nil {
+			if err != nil || part == nil {
 				t.Errorf("failed to fetch part %d", i)
 			}
-			if !want.Equal(part.GetProof()) {
-				t.Errorf("proof of part does not equal proof provided by snapshot")
-			}
-			if !part.Verify() {
+			if part != nil && !part.Verify(want) {
 				t.Errorf("failed to verify content of part %d", i)
 			}
 		}

--- a/go/backend/depot/snapshot_test.go
+++ b/go/backend/depot/snapshot_test.go
@@ -313,13 +313,10 @@ func TestDepotSnapshot_MyDepotSnapshotCanBeCreatedAndValidated(t *testing.T) {
 					t.Errorf("failed to fetch proof of part %d", i)
 				}
 				part, err := cur.GetPart(i)
-				if err != nil {
+				if err != nil || part == nil {
 					t.Errorf("failed to fetch part %d", i)
 				}
-				if !want.Equal(part.GetProof()) {
-					t.Errorf("proof of part does not equal proof provided by snapshot")
-				}
-				if !part.Verify() {
+				if part != nil && !part.Verify(want) {
 					t.Errorf("failed to verify content of part %d", i)
 				}
 			}

--- a/go/backend/index/index_test.go
+++ b/go/backend/index/index_test.go
@@ -2,6 +2,8 @@ package index_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/cache"
@@ -9,7 +11,6 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/backend/index/ldb"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/memory"
 	"github.com/Fantom-foundation/Carmen/go/common"
-	"testing"
 )
 
 func initIndexesMap() map[string]func(t *testing.T) index.Index[common.Address, uint32] {
@@ -290,13 +291,10 @@ func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndValidated(t *testing.T) {
 							t.Errorf("failed to fetch proof of part %d", i)
 						}
 						part, err := cur.GetPart(i)
-						if err != nil {
+						if err != nil || part == nil {
 							t.Errorf("failed to fetch part %d", i)
 						}
-						if !want.Equal(part.GetProof()) {
-							t.Errorf("proof of part does not equal proof provided by snapshot")
-						}
-						if !part.Verify() {
+						if part != nil && !part.Verify(want) {
 							t.Errorf("failed to verify content of part %d", i)
 						}
 					}

--- a/go/backend/index/snapshot_test.go
+++ b/go/backend/index/snapshot_test.go
@@ -286,13 +286,10 @@ func TestIndexSnapshot_MyIndexSnapshotCanBeCreatedAndValidated(t *testing.T) {
 					t.Errorf("failed to fetch proof of part %d", i)
 				}
 				part, err := cur.GetPart(i)
-				if err != nil {
+				if err != nil || part == nil {
 					t.Errorf("failed to fetch part %d", i)
 				}
-				if !want.Equal(part.GetProof()) {
-					t.Errorf("proof of part does not equal proof provided by snapshot")
-				}
-				if !part.Verify() {
+				if part != nil && !part.Verify(want) {
 					t.Errorf("failed to verify content of part %d", i)
 				}
 			}

--- a/go/backend/snapshot.go
+++ b/go/backend/snapshot.go
@@ -48,10 +48,8 @@ type Snapshot interface {
 
 // Part is a chunk of data of a data structure's snapshot.
 type Part interface {
-	// GetProof returns the proof certifying the content of this part.
-	GetProof() Proof
-	// Verify tests that the owned proof is valid for the contained data.
-	Verify() bool
+	// Verify tests that the given proof is valid for the contained data.
+	Verify(proof Proof) bool
 	// ToBytes serializes this part such that it can be transfered through IO.
 	ToBytes() []byte
 }

--- a/go/backend/store/snapshot_test.go
+++ b/go/backend/store/snapshot_test.go
@@ -301,13 +301,10 @@ func TestStoreSnapshot_MyStoreSnapshotCanBeCreatedAndValidated(t *testing.T) {
 					t.Errorf("failed to fetch proof of part %d", i)
 				}
 				part, err := cur.GetPart(i)
-				if err != nil {
+				if err != nil || part == nil {
 					t.Errorf("failed to fetch part %d", i)
 				}
-				if !want.Equal(part.GetProof()) {
-					t.Errorf("proof of part does not equal proof provided by snapshot")
-				}
-				if !part.Verify() {
+				if part != nil && !part.Verify(want) {
 					t.Errorf("failed to verify content of part %d", i)
 				}
 			}


### PR DESCRIPTION
Removes proofs from individual parts as suggested by @hkalina.

This change simplifies the code and reduces the amount of data to be transferred during state syncs by ~1%.