### PR TITLE
corrects min size for btree

### DIFF
--- a/go/backend/btree/innernode.go
+++ b/go/backend/btree/innernode.go
@@ -43,7 +43,7 @@ func (m *InnerNode[K]) insert(key K) (right node[K], middle K, split bool) {
 		}
 
 		// check and potentially split this node
-		if len(m.keys) == m.capacity+1 {
+		if len(m.keys) >= m.capacity+1 {
 			right, middle = m.split()
 			split = true
 		}
@@ -413,8 +413,13 @@ func (m InnerNode[K]) checkProperties(treeDepth *int, currentLevel int) error {
 	}
 
 	// check capacity (for non-root leaf)
-	if currentLevel > 0 && m.size() < m.capacity/2 {
+	if currentLevel > 0 && m.size() < (m.capacity-1)/2 {
 		return fmt.Errorf("size below minimal capacity: %d < %d", m.size(), m.capacity/2)
+	}
+
+	// check capacity is not exceeded
+	if m.size() > m.capacity {
+		return fmt.Errorf("size above the maximal capacity: %d > %d", m.size(), m.capacity)
 	}
 
 	return nil

--- a/go/backend/btree/leafnode.go
+++ b/go/backend/btree/leafnode.go
@@ -27,7 +27,7 @@ func (m *LeafNode[K]) insert(key K) (right node[K], middle K, split bool) {
 		m.insertAt(index, key, nil, nil)
 
 		// split when overflow
-		if len(m.keys) == m.capacity+1 {
+		if len(m.keys) >= m.capacity+1 {
 			right, middle = m.split()
 			split = true
 		}
@@ -182,8 +182,13 @@ func (m LeafNode[K]) checkProperties(treeDepth *int, currentLevel int) error {
 	}
 
 	// check capacity (for non-root leaf)
-	if currentLevel > 0 && m.size() < m.capacity/2 {
+	if currentLevel > 0 && m.size() < (m.capacity-1)/2 {
 		return fmt.Errorf("size below minimal capacity: %d < %d", m.size(), m.capacity/2)
+	}
+
+	// check capacity is not exceeded
+	if m.size() > m.capacity {
+		return fmt.Errorf("size above the maximal capacity: %d > %d", m.size(), m.capacity)
 	}
 
 	return nil

--- a/go/backend/btree/node.go
+++ b/go/backend/btree/node.go
@@ -88,5 +88,5 @@ type nodeChecker[K any] interface {
 // isMinSize returns true if the size of the input node is at minimal capacity.
 // Minimal capacity is half of the full capacity rounded up.
 func isMinSize[K any](m node[K], capacity int) bool {
-	return m.size() <= capacity/2
+	return m.size() <= (capacity-1)/2
 }

--- a/go/backend/multimap/btreemem/dbkey.go
+++ b/go/backend/multimap/btreemem/dbkey.go
@@ -8,8 +8,8 @@ import (
 // dbKey is used as a key to the BTree backed Multimap.
 // It concatenates Key-Value pairs into one database (BTree) key.
 type dbKey[K any, V any] struct {
-	k              K
-	v              V
+	key            K
+	value          V
 	maxVal, minVal bool // shortcuts for comparator of [K,V] with max value [K,0xF...F] or min [K,0x0...0]
 }
 
@@ -22,18 +22,18 @@ func newDbKey[K any, V any](k K, v V) dbKey[K, V] {
 // and the value is assumed as a maximal value from the address space
 // i.e. dbKey := [key][0xFF..FF]
 func newDbKeyMaxVal[K any, V any](k K) dbKey[K, V] {
-	return dbKey[K, V]{k: k, maxVal: true, minVal: false}
+	return dbKey[K, V]{key: k, maxVal: true, minVal: false}
 }
 
 // newDbKeyMinVal creates a new key where the input key is used
 // and the value is assumed as a minimal value from the address space
 // i.e. dbKey := [key][0x00..00]
 func newDbKeyMinVal[K any, V any](k K) dbKey[K, V] {
-	return dbKey[K, V]{k: k, maxVal: false, minVal: true}
+	return dbKey[K, V]{key: k, maxVal: false, minVal: true}
 }
 
 func (c dbKey[K, V]) String() string {
-	return fmt.Sprintf("dbKey: %v -> %v", c.k, c.v)
+	return fmt.Sprintf("%v_%v", c.key, c.value)
 }
 
 // dbKeyComparator comparator of DB key, which is composed of a Key-Value pair
@@ -43,7 +43,7 @@ type dbKeyComparator[K any, V any] struct {
 }
 
 func (c dbKeyComparator[K, V]) Compare(a, b *dbKey[K, V]) int {
-	res := c.keyComparator.Compare(&a.k, &b.k)
+	res := c.keyComparator.Compare(&a.key, &b.key)
 	if res == 0 {
 		if b.minVal || a.maxVal {
 			return +1
@@ -51,7 +51,7 @@ func (c dbKeyComparator[K, V]) Compare(a, b *dbKey[K, V]) int {
 		if a.minVal || b.maxVal {
 			return -1
 		}
-		res = c.valueComparator.Compare(&a.v, &b.v)
+		res = c.valueComparator.Compare(&a.value, &b.value)
 	}
 
 	return res

--- a/go/backend/multimap/btreemem/file.go
+++ b/go/backend/multimap/btreemem/file.go
@@ -59,7 +59,7 @@ func (m *MultiMap[K, V]) GetAll(key K) ([]V, error) {
 	it := m.btree.NewIterator(newDbKeyMinVal[K, V](key), newDbKeyMaxVal[K, V](key))
 	values := make([]V, 0, 100)
 	for it.HasNext() {
-		values = append(values, it.Next().v)
+		values = append(values, it.Next().value)
 	}
 	return values, nil
 }


### PR DESCRIPTION
The key change of this PR is calculation of minimal size of BTree node. It used to cause problems when removing and adding elements in the tree

It used to compute the minimal size as `capacity/2`, while the correct way is `(capacity-1)/2`

Example: lets say the capacity is `4`, originally, it calculated the min size to `2`. When there were two sibling nodes at minimal capacity, removal of an element caused `merge` of the siblings with the parent key - i.e. the new node had `2+2+1=5` keys, i.e. above the capacity. Further insertion of keys to this node caused it grew unbound as the keys were added above the capacity, which was not checked. With this update, the merge in this example will happen only when siblings have one key, i.e. the new node will have 3 keys. 

This calculation is consistent with standard definition[1] where the capacity is defined as half of the capacity `t`, and the minimal number of keys is `2t-1`

As an extra precaution, condition to split a node was also updated from `==` to `>=`

[1] [Btree](https://www.cs.utexas.edu/users/djimenez/utsa/cs3343/lecture16.html)
 