### PR TITLE
Fix file hashtree reset - remove only relevant files

### DIFF
--- a/go/backend/hashtree/htfile/hashtree.go
+++ b/go/backend/hashtree/htfile/hashtree.go
@@ -51,17 +51,17 @@ func NewHashTree(path string, branchingFactor int, pageProvider hashtree.PagePro
 
 // Reset removes the hashtree content
 func (ht *HashTree) Reset() error {
-	files, err := os.ReadDir(ht.path)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		err = os.Remove(fmt.Sprintf("%s/%s", ht.path, file.Name()))
+	ht.dirtyPages = map[int]bool{}
+	for layerId := 0; ; layerId++ {
+		file := ht.layerFile(layerId)
+		err := os.Remove(file)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // the last layer was deleted - success
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
 }
 
 // parentOf provides an index of a parent node, by the child index


### PR DESCRIPTION
File hashtree supposed to have its own directory, deleting all the content on reset.
It seems it is not longer true, at least for some test cases - changed to delete relevant (layers) files only.