### PR TITLE
Add leveldb store snapshotting support

### DIFF
--- a/go/backend/snapshot.go
+++ b/go/backend/snapshot.go
@@ -85,7 +85,7 @@ type SnapshotVerifier interface {
 // Snapshotable is an interface to be implemented by data structure to support
 // integration into the snapshotting infrastructure.
 type Snapshotable interface {
-	// GetProof returns a proof a snapshot would exhibit if it would be created
+	// GetProof returns a proof the snapshot exhibits if it is created
 	// for the current state of the data structure.
 	GetProof() (Proof, error)
 	// CreateSnapshot creates a snapshot of the current state of the data

--- a/go/backend/store/ldb/snapshot.go
+++ b/go/backend/store/ldb/snapshot.go
@@ -1,0 +1,34 @@
+package ldb
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend/hashtree/htldb"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/syndtr/goleveldb/leveldb"
+	"unsafe"
+)
+
+// SnapshotSource is backend.StoreSnapshotSource implementation for leveldb store.
+type SnapshotSource[I common.Identifier, V any] struct {
+	snap  *leveldb.Snapshot
+	store *Store[I, V]
+}
+
+// GetPage provides the content of a snapshot part
+func (s *SnapshotSource[I, V]) GetPage(pageNum int) (data []byte, err error) {
+	return s.store.getPageFromLdbReader(pageNum, s.snap)
+}
+
+// GetHash provides pages hashes for snapshotting
+func (s *SnapshotSource[I, V]) GetHash(pageNum int) (common.Hash, error) {
+	return htldb.GetPageHashFromLdb(s.store.table, pageNum, s.snap)
+}
+
+// Release the snapshot data
+func (s *SnapshotSource[I, V]) Release() error {
+	s.snap.Release()
+	return nil
+}
+
+func (s *SnapshotSource[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
+	return common.NewMemoryFootprint(unsafe.Sizeof(*s))
+}

--- a/go/backend/store/memory/memory.go
+++ b/go/backend/store/memory/memory.go
@@ -102,7 +102,7 @@ func (m *Store[I, V]) GetStateHash() (common.Hash, error) {
 	return m.hashTree.HashRoot()
 }
 
-// GetProof returns a proof a snapshot would exhibit if it would be created
+// GetProof returns a proof the snapshot exhibits if it is created
 // for the current state of the data structure.
 func (m *Store[I, V]) GetProof() (backend.Proof, error) {
 	hash, err := m.GetStateHash()

--- a/go/common/ldb.go
+++ b/go/common/ldb.go
@@ -72,7 +72,53 @@ type LevelDB interface {
 	// not before. Write will not modify content of the batch.
 	Write(batch *leveldb.Batch, wo *opt.WriteOptions) error
 
+	// GetSnapshot returns a latest snapshot of the underlying DB. A snapshot
+	// is a frozen snapshot of a DB state at a particular point in time. The
+	// content of snapshot are guaranteed to be consistent.
+	//
+	// The snapshot must be released after use, by calling Release method.
+	GetSnapshot() (*leveldb.Snapshot, error)
+
 	MemoryFootprintProvider
+}
+
+// LevelDBReader is an interface missing in original LevelDB design.
+// It contains methods common for the LevelDB instance and its Snapshots.
+type LevelDBReader interface {
+	// Get gets the value for the given key. It returns ErrNotFound if the
+	// DB does not contain the key.
+	//
+	// The returned slice is its own copy, it is safe to modify the contents
+	// of the returned slice.
+	// It is safe to modify the contents of the argument after Get returns.
+	Get(key []byte, ro *opt.ReadOptions) (value []byte, err error)
+
+	// Has returns true if the DB does contain the given key.
+	//
+	// It is safe to modify the contents of the argument after Has returns.
+	Has(key []byte, ro *opt.ReadOptions) (bool, error)
+
+	// NewIterator returns an iterator for the latest snapshot of the
+	// underlying DB.
+	// The returned iterator is not safe for concurrent use, but it is safe to use
+	// multiple iterators concurrently, with each in a dedicated goroutine.
+	// It is also safe to use an iterator concurrently with modifying its
+	// underlying DB. The resultant key/value pairs are guaranteed to be
+	// consistent.
+	//
+	// Slice allows slicing the iterator to only contains keys in the given
+	// range. A nil Range.Start is treated as a key before all keys in the
+	// DB. And a nil Range.Limit is treated as a key after all keys in
+	// the DB.
+	//
+	// WARNING: Any slice returned by iterator (e.g. slice returned by calling
+	// Iterator.Key() or Iterator.Key() methods), its content should not be modified
+	// unless noted otherwise.
+	//
+	// The iterator must be released after use, by calling Release method.
+	//
+	// Also read Iterator documentation of the leveldb/iterator package.
+	NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator
 }
 
 // OpenLevelDb opens the LevelDB connection and provides it wrapped in memory-footprint-reporting object.
@@ -114,6 +160,10 @@ func (wrapper *LevelDbMemoryFootprintWrapper) OpenTransaction() (*LevelDbTransac
 type LevelDbTransactionMemoryFootprintWrapper struct {
 	*leveldb.Transaction
 	mf *MemoryFootprint
+}
+
+func (wrapper *LevelDbTransactionMemoryFootprintWrapper) GetSnapshot() (*leveldb.Snapshot, error) {
+	return nil, fmt.Errorf("unable to get snapshot from a transaction")
 }
 
 func (wrapper *LevelDbTransactionMemoryFootprintWrapper) GetMemoryFootprint() *MemoryFootprint {


### PR DESCRIPTION
Snapshotting support for leveldb store with leveldb hashtree.
(if snapshoting is used, there is hard dependency between them, as leveldb snapshots are used)

Made separated from #435 as discussed.