### PR TITLE
Make all SetState operations changing a value be an account touch

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -697,13 +697,11 @@ func (s *stateDB) GetState(addr common.Address, key common.Key) common.Value {
 }
 
 func (s *stateDB) SetState(addr common.Address, key common.Key, value common.Value) {
-	isImplicitlyCreated := s.createAccountIfNotExists(addr)
+	s.createAccountIfNotExists(addr)
 	if value == s.GetState(addr, key) {
 		return
 	}
-	if isImplicitlyCreated {
-		s.addEmptyAccountCandidate(addr)
-	}
+	s.addEmptyAccountCandidate(addr)
 
 	sid := slotId{addr, key}
 	if entry, exists := s.data.Get(sid); exists {


### PR DESCRIPTION
In Geth, all `SetState` calls changing the value of a slot cause the targeted account to be in the `emptyCandidate` list. Carmen used to include the targeted account only if the account was implicitly created by the `SetState` call. However, there are operation sequences where this can lead to the wrong result, as demonstrated in included test case.