### PR TITLE
All SetNonce calls should register account as empty candidate

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -610,9 +610,8 @@ func (s *stateDB) GetNonce(addr common.Address) uint64 {
 
 func (s *stateDB) SetNonce(addr common.Address, nonce uint64) {
 	s.setNonceInternal(addr, nonce)
-	if s.createAccountIfNotExists(addr) && nonce == 0 {
-		s.addEmptyAccountCandidate(addr)
-	}
+	s.createAccountIfNotExists(addr)
+	s.addEmptyAccountCandidate(addr)
 }
 
 func (s *stateDB) setNonceInternal(addr common.Address, nonce uint64) {


### PR DESCRIPTION
Due to Geth's complex behavior of registering cleared accounts, it is necessary to always register accounts targeted by GetNonce(...) to be checked at the end of a transaction -- like it is done by Geth itself.

Geth's `SetNonce` function is [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/statedb.go#L415-L420)
The update happens [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/state_object.go#L551-L557)
The journal entry always reports the targeted account as dirty [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/journal.go#L196-L198)

This problem may occur in actual block processing. 

This PR includes a test case that re-creates an event sequence where the lack of registering the account as an account to be cleared leads to a wrong account-deletion decision.