### PR TITLE
All code updates are potential empty account registrations

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -753,9 +753,7 @@ func (s *stateDB) GetCode(addr common.Address) []byte {
 func (s *stateDB) SetCode(addr common.Address, code []byte) {
 	s.createAccountIfNotExists(addr)
 	s.setCodeInternal(addr, code)
-	if len(code) == 0 {
-		s.addEmptyAccountCandidate(addr)
-	}
+	s.addEmptyAccountCandidate(addr)
 }
 
 func (s *stateDB) setCodeInternal(addr common.Address, code []byte) {


### PR DESCRIPTION
Due to Geth's complex behavior of registering cleared accounts, it is necessary to always register accounts targeted by SetCode(...) to be checked at the end of a transaction -- like it is done by Geth itself.

Geth's `SetCode` function is [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/statedb.go#L422-L427)
The update happens [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/state_object.go#L535-L543)
The journal entry always reports the targeted account as dirty [here](https://github.com/Fantom-foundation/go-ethereum-substate/blob/main/core/state/journal.go#L204-L206)

This problem may occur in actual block processing. 

This PR includes a test case that re-creates an event sequence where the lack of registering the account as an account to be cleared leads to a wrong account-deletion decision.