### PR TITLE
Suicide must register the deleted account as empty candidate

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -500,6 +500,7 @@ func (s *stateDB) Suicide(addr common.Address) bool {
 	}
 
 	s.setAccountState(addr, kSuicided)
+	s.addEmptyAccountCandidate(addr) // < the account may be reserected and still be empty
 
 	s.resetBalance(addr)
 	deleteListLength := len(s.accountsToDelete)


### PR DESCRIPTION
There are operation sequences, like the one in the test case, where this is relevant.