### PR TITLE
make indexes to fit new changes in snapshotable interface

### DIFF
--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -80,7 +79,7 @@ func (m *Index[K, I]) GetProof() (backend.Proof, error) {
 func (m *Index[K, I]) CreateSnapshot() (backend.Snapshot, error) {
 	snapshotable, ok := m.wrapped.(backend.Snapshotable)
 	if !ok {
-		return nil, fmt.Errorf("wrapped index is not snapshotable")
+		return nil, index.ErrNotSnapshotable
 	}
 
 	return snapshotable.CreateSnapshot()
@@ -89,11 +88,20 @@ func (m *Index[K, I]) CreateSnapshot() (backend.Snapshot, error) {
 func (m *Index[K, I]) Restore(data backend.SnapshotData) error {
 	snapshotable, ok := m.wrapped.(backend.Snapshotable)
 	if !ok {
-		return fmt.Errorf("wrapped index is not snapshotable")
+		return index.ErrNotSnapshotable
 	}
 
 	m.cache.Clear()
 	return snapshotable.Restore(data)
+}
+
+func (m *Index[K, I]) GetSnapshotVerifier(data []byte) (backend.SnapshotVerifier, error) {
+	snapshotable, ok := m.wrapped.(backend.Snapshotable)
+	if !ok {
+		return nil, index.ErrNotSnapshotable
+	}
+
+	return snapshotable.GetSnapshotVerifier(data)
 }
 
 // GetMemoryFootprint provides the size of the index in memory in bytes

--- a/go/backend/index/file/file.go
+++ b/go/backend/index/file/file.go
@@ -279,6 +279,10 @@ func (m *Index[K, I]) Restore(data backend.SnapshotData) error {
 	return nil
 }
 
+func (m *Index[K, I]) GetSnapshotVerifier([]byte) (backend.SnapshotVerifier, error) {
+	return index.CreateIndexSnapshotVerifier[K](m.keySerializer), nil
+}
+
 type indexSnapshotSource[K comparable, I common.Identifier] struct {
 	index   *Index[K, I] // The index this snapshot is based on.
 	numKeys int          // The number of keys at the time the snapshot was created.

--- a/go/backend/index/index.go
+++ b/go/backend/index/index.go
@@ -37,5 +37,6 @@ type Index[K comparable, I common.Identifier] interface {
 }
 
 var (
-	ErrNotFound = errors.New("index: key not found")
+	ErrNotFound        = errors.New("index: key not found")
+	ErrNotSnapshotable = errors.New("index: not snapshotable")
 )

--- a/go/backend/index/index_test.go
+++ b/go/backend/index/index_test.go
@@ -170,6 +170,10 @@ func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndRestored(t *testing.T) {
 				}
 
 				snapshot, err := original.CreateSnapshot()
+				if err == index.ErrNotSnapshotable {
+					t.Skip(fmt.Sprintf("%v", err))
+				}
+
 				if err != nil {
 					t.Errorf("failed to create snapshot: %v", err)
 					return
@@ -227,6 +231,10 @@ func TestIndexSnapshot_IndexCrosscheckSnapshotCanBeCreatedAndRestored(t *testing
 				}
 
 				snapshot, err := original.CreateSnapshot()
+				if err == index.ErrNotSnapshotable {
+					t.Skip(fmt.Sprintf("%v", err))
+				}
+
 				if err != nil {
 					t.Errorf("failed to create snapshot: %v", err)
 					return
@@ -248,6 +256,10 @@ func TestIndexSnapshot_IndexCrosscheckSnapshotCanBeCreatedAndRestored(t *testing
 					}
 
 					if err := recovered.Restore(snapshot.GetData()); err != nil {
+						if err == index.ErrNotSnapshotable {
+							t.Skip(fmt.Sprintf("%v", err))
+						}
+
 						t.Errorf("failed to sync to %s snapshot: %v", recoveredName, err)
 						return
 					}
@@ -289,6 +301,10 @@ func TestIndexSnapshot_IndexSnapshotIsShieldedFromMutations(t *testing.T) {
 			}
 
 			snapshot, err := original.CreateSnapshot()
+			if err == index.ErrNotSnapshotable {
+				t.Skip(fmt.Sprintf("%v", err))
+			}
+
 			if err != nil {
 				t.Errorf("failed to create snapshot: %v", err)
 				return
@@ -339,7 +355,7 @@ func TestIndexSnapshot_IndexSnapshotRestoreClearsPreviousVersion(t *testing.T) {
 			fillIndex(t, originalIndex, 20)
 
 			snapshot, err := original.CreateSnapshot()
-			if fmt.Sprintf("%v", err) == "wrapped index is not snapshotable" {
+			if err == index.ErrNotSnapshotable {
 				t.Skip(fmt.Sprintf("%v", err))
 			}
 
@@ -389,6 +405,10 @@ func TestIndexSnapshot_IndexSnapshotCanBeCreatedAndValidated(t *testing.T) {
 				fillIndex(t, originalIndex, size)
 
 				snapshot, err := original.CreateSnapshot()
+				if err == index.ErrNotSnapshotable {
+					t.Skip(fmt.Sprintf("%v", err))
+				}
+
 				if err != nil {
 					t.Errorf("failed to create snapshot: %v", err)
 					return


### PR DESCRIPTION
This PR adds a method from snapshotable interface, which was added later, and thus the indexes stopped conforming to the interface. This PR fixes that.  