### PR TITLE
Update google test, benchmark, and absl library

### DIFF
--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -3,23 +3,23 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "ca2d683a5ed38d0c9a5c5ab6a2ab67bc5ce8772444133029b2bfc5c3bf05db2f",
-    strip_prefix = "googletest-15460959cbbfa20e66ef0b5ab497367e47fc0a04",
-    urls = ["https://github.com/google/googletest/archive/15460959cbbfa20e66ef0b5ab497367e47fc0a04.zip"],
+    sha256 = "983a7f2f4cc2a4d75d94ee06300c46a657291fba965e355d11ab3b6965a7b0e5",
+    strip_prefix = "googletest-b796f7d44681514f58a683a3a71ff17c94edb0c1",
+    urls = ["https://github.com/google/googletest/archive/b796f7d44681514f58a683a3a71ff17c94edb0c1.zip"],
 )
 
 http_archive(
     name = "com_github_google_benchmark",
-    sha256 = "e0e6a0f2a5e8971198e5d382507bfe8e4be504797d75bb7aec44b5ea368fa100",
-    strip_prefix = "benchmark-1.7.0",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.7.0.zip"],
+    sha256 = "aeec52381284ec3752505a220d36096954c869da4573c2e1df3642d2f0a4aac6",
+    strip_prefix = "benchmark-1.7.1",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.7.1.zip"],
 )
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "41618cbfe85c498034914f4b7a0d84c5703e515c060fbddb7b9396848dc2c029",
-    strip_prefix = "abseil-cpp-eda52d053e6400d9411b1f46a1a17a959d4db11f",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/eda52d053e6400d9411b1f46a1a17a959d4db11f.zip"],
+    sha256 = "f7c2cb2c5accdcbbbd5c0c59f241a988c0b1da2a3b7134b823c0bd613b1a6880",
+    strip_prefix = "abseil-cpp-b971ac5250ea8de900eae9f95e06548d14cd95fe",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/b971ac5250ea8de900eae9f95e06548d14cd95fe.zip"],
 )
 
 http_archive(

--- a/cpp/archive/sqlite/archive.cc
+++ b/cpp/archive/sqlite/archive.cc
@@ -796,42 +796,49 @@ class Archive {
   // Prepared statemetns for logging new data to the archive.
   absl::Mutex mutation_lock_;
 
-  std::unique_ptr<SqlStatement> add_block_stmt_ GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> add_block_stmt_ ABSL_GUARDED_BY(mutation_lock_);
 
   absl::Mutex get_block_hash_lock_;
   std::unique_ptr<SqlStatement> get_block_hash_stmt_
-      GUARDED_BY(get_block_hash_lock_);
+      ABSL_GUARDED_BY(get_block_hash_lock_);
 
   absl::Mutex get_block_height_lock_;
   std::unique_ptr<SqlStatement> get_block_height_stmt_
-      GUARDED_BY(get_block_height_lock_);
+      ABSL_GUARDED_BY(get_block_height_lock_);
 
   absl::Mutex get_account_hash_lock_;
   std::unique_ptr<SqlStatement> add_account_hash_stmt_
-      GUARDED_BY(mutation_lock_);
+      ABSL_GUARDED_BY(mutation_lock_);
   std::unique_ptr<SqlStatement> get_account_hash_stmt_
-      GUARDED_BY(get_account_hash_lock_);
+      ABSL_GUARDED_BY(get_account_hash_lock_);
 
   absl::Mutex get_status_lock_;
-  std::unique_ptr<SqlStatement> create_account_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> delete_account_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> get_status_stmt_ GUARDED_BY(get_status_lock_);
+  std::unique_ptr<SqlStatement> create_account_stmt_
+      ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> delete_account_stmt_
+      ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> get_status_stmt_
+      ABSL_GUARDED_BY(get_status_lock_);
 
   absl::Mutex get_balance_lock_;
-  std::unique_ptr<SqlStatement> add_balance_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> get_balance_stmt_ GUARDED_BY(get_balance_lock_);
+  std::unique_ptr<SqlStatement> add_balance_stmt_
+      ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> get_balance_stmt_
+      ABSL_GUARDED_BY(get_balance_lock_);
 
   absl::Mutex get_code_lock_;
-  std::unique_ptr<SqlStatement> add_code_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> get_code_stmt_ GUARDED_BY(get_code_lock_);
+  std::unique_ptr<SqlStatement> add_code_stmt_ ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> get_code_stmt_ ABSL_GUARDED_BY(get_code_lock_);
 
   absl::Mutex get_nonce_lock_;
-  std::unique_ptr<SqlStatement> add_nonce_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> get_nonce_stmt_ GUARDED_BY(get_nonce_lock_);
+  std::unique_ptr<SqlStatement> add_nonce_stmt_ ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> get_nonce_stmt_
+      ABSL_GUARDED_BY(get_nonce_lock_);
 
   absl::Mutex get_value_lock_;
-  std::unique_ptr<SqlStatement> add_value_stmt_ GUARDED_BY(mutation_lock_);
-  std::unique_ptr<SqlStatement> get_value_stmt_ GUARDED_BY(get_value_lock_);
+  std::unique_ptr<SqlStatement> add_value_stmt_ ABSL_GUARDED_BY(mutation_lock_);
+  std::unique_ptr<SqlStatement> get_value_stmt_
+      ABSL_GUARDED_BY(get_value_lock_);
 };
 
 }  // namespace internal


### PR DESCRIPTION
The libraries are updated to reduce produced compiler warnings with alternative compilers.