### PR TITLE
Remove the hardcoded clang dependency

### DIFF
--- a/.github/workflows/cpp-osx.yml
+++ b/.github/workflows/cpp-osx.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/cpp-osx.yml'
       - 'cpp/**'
 
+env:
+  CC: clang
+  CXX: clang++
+
 jobs:
 
   build:

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/cpp-tests.yml'
       - 'cpp/**'
 
+env:
+  CC: clang
+  CXX: clang++
+
 jobs:
   tests-check:
     name: Tests Check

--- a/cpp/.bazelrc
+++ b/cpp/.bazelrc
@@ -1,10 +1,8 @@
-build --repo_env=CC=clang
 build --cxxopt=-std=c++20
 build --cxxopt=-Wpedantic
 build --cxxopt=-Wall
 build --cxxopt=-Wextra
 build --cxxopt=-Wno-gcc-compat
-build --cxxopt=-Werror
 
 # A configuration running all code using an address sanitizer
 # To run, add --config=asan to bazel command.

--- a/cpp/backend/index/file/stable_hash.h
+++ b/cpp/backend/index/file/stable_hash.h
@@ -46,7 +46,7 @@ class StableHashState {
 
   // The fall-back support for types implementing the Absl hashing interface.
   template <typename T>
-  static std::size_t hash(const T& value) {
+  requires(!std::is_integral_v<T>) static std::size_t hash(const T& value) {
     return AbslHashValue(internal::StableHashState(), value).state_;
   }
 

--- a/go/lib/build_libcarmen.sh
+++ b/go/lib/build_libcarmen.sh
@@ -13,6 +13,10 @@ set -e
 
 cd "$(dirname $0)/../../cpp"
 
+# Use clang compiler unless overruled.
+export CC=${CC:-clang}
+export CXX=${CXX:-clang++}
+
 if bazel version &> /dev/null
 then
     echo "- C++ build environment:"


### PR DESCRIPTION
This change removes the hard-coded utilization of the command `clang` as the compiler for C and C++ code. This allows users to override the used compiler using the CC environment variable. If not set, the system default compiler is used.

The change also removes `--Werror` as this introduces a tool chain dependency.

This fixes #458