### PR TITLE
Add snapshotable requirement to Index interface

### DIFF
--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -1,10 +1,11 @@
 package cache
 
 import (
+	"unsafe"
+
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/common"
-	"unsafe"
 )
 
 // Index wraps another index and a cache
@@ -77,31 +78,16 @@ func (m *Index[K, I]) GetProof() (backend.Proof, error) {
 }
 
 func (m *Index[K, I]) CreateSnapshot() (backend.Snapshot, error) {
-	snapshotable, ok := m.wrapped.(backend.Snapshotable)
-	if !ok {
-		return nil, index.ErrNotSnapshotable
-	}
-
-	return snapshotable.CreateSnapshot()
+	return m.wrapped.CreateSnapshot()
 }
 
 func (m *Index[K, I]) Restore(data backend.SnapshotData) error {
-	snapshotable, ok := m.wrapped.(backend.Snapshotable)
-	if !ok {
-		return index.ErrNotSnapshotable
-	}
-
 	m.cache.Clear()
-	return snapshotable.Restore(data)
+	return m.wrapped.Restore(data)
 }
 
 func (m *Index[K, I]) GetSnapshotVerifier(data []byte) (backend.SnapshotVerifier, error) {
-	snapshotable, ok := m.wrapped.(backend.Snapshotable)
-	if !ok {
-		return nil, index.ErrNotSnapshotable
-	}
-
-	return snapshotable.GetSnapshotVerifier(data)
+	return m.wrapped.GetSnapshotVerifier(data)
 }
 
 // GetMemoryFootprint provides the size of the index in memory in bytes

--- a/go/backend/index/index.go
+++ b/go/backend/index/index.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"errors"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -32,11 +34,9 @@ type Index[K comparable, I common.Identifier] interface {
 	common.FlushAndCloser
 
 	// Snapshotable indexes.
-	// TODO: snapshot is not implemented by all indexes
-	//backend.Snapshotable
+	backend.Snapshotable
 }
 
 var (
-	ErrNotFound        = errors.New("index: key not found")
-	ErrNotSnapshotable = errors.New("index: not snapshotable")
+	ErrNotFound = errors.New("index: key not found")
 )

--- a/go/backend/index/indexarray.go
+++ b/go/backend/index/indexarray.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
@@ -107,6 +108,22 @@ func (m *Array[K, I]) Close() error {
 	}
 
 	return resErr
+}
+
+func (s *Array[K, I]) GetProof() (backend.Proof, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *Array[K, I]) CreateSnapshot() (backend.Snapshot, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *Array[K, I]) Restore(data backend.SnapshotData) error {
+	return backend.ErrSnapshotNotSupported
+}
+
+func (s *Array[K, I]) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {
+	return nil, backend.ErrSnapshotNotSupported
 }
 
 // GetMemoryFootprint provides the size of the index in memory in bytes

--- a/go/backend/index/ldb/leveldb.go
+++ b/go/backend/index/ldb/leveldb.go
@@ -2,12 +2,14 @@ package ldb
 
 import (
 	"fmt"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/indexhash"
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
-	"unsafe"
 )
 
 const (
@@ -140,6 +142,22 @@ func (m *Index[K, I]) Flush() error {
 
 func (m *Index[K, I]) Close() error {
 	return m.Flush()
+}
+
+func (s *Index[K, I]) GetProof() (backend.Proof, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *Index[K, I]) CreateSnapshot() (backend.Snapshot, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *Index[K, I]) Restore(data backend.SnapshotData) error {
+	return backend.ErrSnapshotNotSupported
+}
+
+func (s *Index[K, I]) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {
+	return nil, backend.ErrSnapshotNotSupported
 }
 
 // convertKey translates the Index representation of the key into a database key.

--- a/go/backend/index/memory/linearhashindex.go
+++ b/go/backend/index/memory/linearhashindex.go
@@ -1,10 +1,12 @@
 package memory
 
 import (
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/index"
 	"github.com/Fantom-foundation/Carmen/go/backend/index/indexhash"
 	"github.com/Fantom-foundation/Carmen/go/common"
-	"unsafe"
 )
 
 // LinearHashIndex is an in-memory implementation of index.Index.
@@ -74,6 +76,22 @@ func (m *LinearHashIndex[K, I]) Flush() error {
 // Close closes the storage and clean-ups all possible dirty values.
 func (m *LinearHashIndex[K, I]) Close() error {
 	return nil
+}
+
+func (s *LinearHashIndex[K, I]) GetProof() (backend.Proof, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *LinearHashIndex[K, I]) CreateSnapshot() (backend.Snapshot, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *LinearHashIndex[K, I]) Restore(data backend.SnapshotData) error {
+	return backend.ErrSnapshotNotSupported
+}
+
+func (s *LinearHashIndex[K, I]) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {
+	return nil, backend.ErrSnapshotNotSupported
 }
 
 func (m *LinearHashIndex[K, I]) GetMemoryFootprint() *common.MemoryFootprint {

--- a/go/backend/snapshot.go
+++ b/go/backend/snapshot.go
@@ -1,5 +1,7 @@
 package backend
 
+import "errors"
+
 // Snapshots capture a state of a single or a set of data structures at a
 // moment in time for future reference.
 //
@@ -102,3 +104,6 @@ type Snapshotable interface {
 	// not describing a snapshot format compatible with this data structure.
 	GetSnapshotVerifier(metadata []byte) (SnapshotVerifier, error)
 }
+
+// An error that implementations may return if snapshots are not supported.
+var ErrSnapshotNotSupported = errors.New("this implementation does not support snapshots")


### PR DESCRIPTION
This PR makes the implementation of snapshot support mandatory for all indexes. However, implementations may signal that snapshotting is not supported until all implementations are adopted.