### PR TITLE
Add support for retrieving the size of an index

### DIFF
--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -19,6 +19,11 @@ func NewIndex[K comparable, I common.Identifier](wrapped index.Index[K, I], cach
 	return &Index[K, I]{wrapped, common.NewCache[K, I](cacheCapacity)}
 }
 
+// Size returns the number of registered keys.
+func (m *Index[K, I]) Size() I {
+	return m.wrapped.Size()
+}
+
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *Index[K, I]) GetOrAdd(key K) (idx I, err error) {
 	idx, exists := m.cache.Get(key)

--- a/go/backend/index/file/file.go
+++ b/go/backend/index/file/file.go
@@ -3,6 +3,10 @@ package file
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
+	"unsafe"
+
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/array"
 	"github.com/Fantom-foundation/Carmen/go/backend/array/pagedarray"
@@ -10,9 +14,6 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/backend/index/indexhash"
 	"github.com/Fantom-foundation/Carmen/go/backend/pagepool"
 	"github.com/Fantom-foundation/Carmen/go/common"
-	"io"
-	"os"
-	"unsafe"
 )
 
 const (
@@ -120,6 +121,11 @@ func NewParamIndex[K comparable, I common.Identifier](
 	}
 
 	return
+}
+
+// Size returns the number of registered keys.
+func (m *Index[K, I]) Size() I {
+	return m.maxIndex
 }
 
 // GetOrAdd returns an index mapping for the key, or creates the new index.

--- a/go/backend/index/index.go
+++ b/go/backend/index/index.go
@@ -14,6 +14,9 @@ import (
 // be hashed and compared. The type I is the type used for the
 // ordinal numbers.
 type Index[K comparable, I common.Identifier] interface {
+	// Get the number of elements in this index, which corresponds to the
+	// identifier that will be assigned to the next key to be registered.
+	Size() I
 
 	// GetOrAdd returns an index mapping for the key, or creates the new index
 	GetOrAdd(key K) (I, error)

--- a/go/backend/index/indexarray.go
+++ b/go/backend/index/indexarray.go
@@ -25,6 +25,14 @@ func (m *Array[K, I]) Add(index Index[K, I]) {
 	m.indexes = append(m.indexes, index)
 }
 
+// Size returns the number of registered keys.
+func (m *Array[K, I]) Size() I {
+	if len(m.indexes) == 0 {
+		return I(0)
+	}
+	return m.indexes[0].Size()
+}
+
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *Array[K, I]) GetOrAdd(key K) (I, error) {
 	var res I

--- a/go/backend/index/ldb/leveldb.go
+++ b/go/backend/index/ldb/leveldb.go
@@ -69,6 +69,11 @@ func NewIndex[K comparable, I common.Identifier](
 	return p, nil
 }
 
+// Size returns the number of registered keys.
+func (m *Index[K, I]) Size() I {
+	return m.lastIndex
+}
+
 // GetOrAdd returns an index mapping for the key, or creates the new index
 func (m *Index[K, I]) GetOrAdd(key K) (idx I, err error) {
 	var val []byte

--- a/go/backend/index/memory/linearhashindex.go
+++ b/go/backend/index/memory/linearhashindex.go
@@ -17,7 +17,7 @@ type LinearHashIndex[K comparable, I common.Identifier] struct {
 	indexSerializer common.Serializer[I]
 	hashIndex       *indexhash.IndexHash[K]
 
-	maxIndex I // max index to fast compute nex item
+	maxIndex I // max index to fast compute next item
 }
 
 // NewLinearHashIndex constructs a new Index instance.
@@ -35,6 +35,11 @@ func NewLinearHashParamsIndex[K comparable, I common.Identifier](numBuckets int,
 		hashIndex:     indexhash.NewIndexHash[K](keySerializer),
 	}
 	return &memory
+}
+
+// Size returns the number of registered keys.
+func (m *LinearHashIndex[K, I]) Size() I {
+	return m.maxIndex
 }
 
 // GetOrAdd returns an index mapping for the key, or creates the new index.

--- a/go/backend/index/memory/memory.go
+++ b/go/backend/index/memory/memory.go
@@ -33,6 +33,11 @@ func NewIndex[K comparable, I common.Identifier](serializer common.Serializer[K]
 	return &memory
 }
 
+// Size returns the number of registered keys.
+func (m *Index[K, I]) Size() I {
+	return I(len(m.data))
+}
+
 // GetOrAdd returns an index mapping for the key, or creates the new index.
 func (m *Index[K, I]) GetOrAdd(key K) (I, error) {
 	idx, exists := m.data[key]


### PR DESCRIPTION
Adds a `Size()` method to the `Index` interface to retrieve the number of indexed keys. This is very cheap since every index is already internally maintaining such a counter in one or the other form.