### PR TITLE
Check branching factor for invalid values to avoid div-by-zero panic

### DIFF
--- a/go/backend/hashtree/reduction.go
+++ b/go/backend/hashtree/reduction.go
@@ -2,6 +2,7 @@ package hashtree
 
 import (
 	"crypto/sha256"
+	"fmt"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
@@ -10,6 +11,9 @@ import (
 // and numPages hashes on the leaf level. Hashes for leaves are fetched on
 // demand through the source function.
 func ReduceHashes(branchingFactor int, numPages int, source func(int) (common.Hash, error)) (common.Hash, error) {
+	if branchingFactor <= 0 {
+		return common.Hash{}, fmt.Errorf("invalid branching factor: %v", branchingFactor)
+	}
 
 	// If there are no pages, the procedure is simple.
 	if numPages <= 0 {

--- a/go/backend/hashtree/reduction_test.go
+++ b/go/backend/hashtree/reduction_test.go
@@ -46,3 +46,16 @@ func TestKnownHashes(t *testing.T) {
 		hashes = append(hashes, getSha256Hash([]byte{byte(i<<4 | i)}))
 	}
 }
+
+func TestInvalidBranchingFactor(t *testing.T) {
+	source := func(i int) (common.Hash, error) {
+		return common.Hash{}, nil
+	}
+	if _, err := ReduceHashes(0, 10, source); err == nil {
+		t.Errorf("branching factor of 0 should fail")
+	}
+
+	if _, err := ReduceHashes(-1, 10, source); err == nil {
+		t.Errorf("branching factor of -1 should fail")
+	}
+}


### PR DESCRIPTION
During testing, a case occurred where the branching factor was 0, which lead to a division-by-zero panic. 

This fix is adding a value check preventing the code from panicking.