### PR TITLE
Add code depot support in state snapshotting

### DIFF
--- a/go/state/go_schema1.go
+++ b/go/state/go_schema1.go
@@ -324,6 +324,10 @@ func (s *GoSchema1) getSnapshotableComponents() []backend.Snapshotable {
 	return nil // = snapshotting not supported
 }
 
+func (s *GoSchema1) runPostRestoreTasks() error {
+	return backend.ErrSnapshotNotSupported
+}
+
 // GetMemoryFootprint provides sizes of individual components of the state in the memory
 func (s *GoSchema1) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(0)

--- a/go/state/go_schema2.go
+++ b/go/state/go_schema2.go
@@ -308,6 +308,10 @@ func (s *GoSchema2) getSnapshotableComponents() []backend.Snapshotable {
 	return nil // = snapshotting not supported
 }
 
+func (s *GoSchema2) runPostRestoreTasks() error {
+	return backend.ErrSnapshotNotSupported
+}
+
 // GetMemoryFootprint provides sizes of individual components of the state in the memory
 func (s *GoSchema2) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(0)

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -48,6 +48,10 @@ type GoSchema interface {
 	// getSnapshotableComponents lists all components required to back-up or restore
 	// for snapshotting this schema. Returns nil if snapshotting is not supported.
 	getSnapshotableComponents() []backend.Snapshotable
+
+	// Called after synching to a new state, requisting the schema to update cached
+	// values or tables not covered by the snapshot synchronization.
+	runPostRestoreTasks() error
 }
 
 func NewGoState(schema GoSchema, archive archive.Archive, cleanup []func()) *GoState {
@@ -253,7 +257,7 @@ func (s *GoState) Restore(data backend.SnapshotData) error {
 			return err
 		}
 	}
-	return nil
+	return s.GoSchema.runPostRestoreTasks()
 }
 
 func (s *GoState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"golang.org/x/crypto/sha3"
 )
 
 type namedStateConfig struct {
@@ -543,7 +544,7 @@ func TestPersistentState(t *testing.T) {
 func fillStateForSnapshotting(state directUpdateState) {
 	state.setBalance(address1, common.Balance{12})
 	state.setNonce(address2, common.Nonce{14})
-	//state.setCode(address3, []byte{0, 8, 15})   // TODO: enable once depots are supported
+	state.setCode(address3, []byte{0, 8, 15})
 	state.setStorage(address1, key1, val1)
 }
 
@@ -594,7 +595,6 @@ func TestSnapshotCanBeCreatedAndRestored(t *testing.T) {
 				}
 			}
 
-			/* TODO: enable once depot snapshotting is supported
 			code := []byte{0, 8, 15}
 			if got, err := recovered.GetCode(address3); err != nil || !bytes.Equal(got, code) {
 				if err != nil {
@@ -603,7 +603,15 @@ func TestSnapshotCanBeCreatedAndRestored(t *testing.T) {
 					t.Errorf("failed to recover code for account %v - wanted %v, got %v", address1, code, got)
 				}
 			}
-			*/
+
+			codeHash := common.GetHash(sha3.NewLegacyKeccak256(), code)
+			if got, err := recovered.GetCodeHash(address3); err != nil || got != codeHash {
+				if err != nil {
+					t.Errorf("failed to fetch code hash for account %v: %v", address1, err)
+				} else {
+					t.Errorf("failed to recover code hash for account %v - wanted %v, got %v", address1, codeHash, got)
+				}
+			}
 
 			if got, err := recovered.GetStorage(address1, key1); err != nil || got != val1 {
 				if err != nil {


### PR DESCRIPTION
Enables coverage for the code depot in the state snapshot code and fixes the syncing of code hashes not covered by the snapshot.