### PR TITLE
Fix storing long keys into leveldb index

### DIFF
--- a/go/common/scheme.go
+++ b/go/common/scheme.go
@@ -45,9 +45,9 @@ const (
 	AccountHashArchiveKey TableSpace = '7'
 )
 
-// DbKey expects max size of the 32B key plus at most two bytes
+// DbKey expects max size of the 36B key plus at most two bytes
 // for the table prefix (e.g. balance, nonce, slot, ...) and the domain (e.g. data, hash, ...)
-type DbKey [34]byte
+type DbKey [38]byte
 
 func (d DbKey) ToBytes() []byte {
 	return d[:]


### PR DESCRIPTION
Leveldb index does not store long keys correctly because of length limit of DbKey type - this PR fixes and test-cover the longest key we use in schema2/schema3.

This should fix issue https://github.com/Fantom-foundation/Carmen/issues/447