### PR TITLE
Handle releasing of new snapshot while an old still exist

### DIFF
--- a/go/backend/hashtree/reduction.go
+++ b/go/backend/hashtree/reduction.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
-// ReduceHashes computes the hash of a tee with the given branching factor
+// ReduceHashes computes the hash of a tree with the given branching factor
 // and numPages hashes on the leaf level. Hashes for leaves are fetched on
 // demand through the source function.
 func ReduceHashes(branchingFactor int, numPages int, source func(int) (common.Hash, error)) (common.Hash, error) {

--- a/go/backend/memsnap/snapshot.go
+++ b/go/backend/memsnap/snapshot.go
@@ -86,6 +86,9 @@ func (s *SnapshotSource) ReleasePreviousSnapshot() {
 
 // Release the snapshot data
 func (s *SnapshotSource) Release() error {
+	if s.prevSource != nil {
+		return fmt.Errorf("unable to release snapshot - older snapshot must be released first")
+	}
 	s.nextSource.ReleasePreviousSnapshot()
 	return nil
 }

--- a/go/backend/store/store_test.go
+++ b/go/backend/store/store_test.go
@@ -277,6 +277,7 @@ func TestStoreSnapshotRecovery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create snapshot; %s", err)
 			}
+			defer snapshot1.Release()
 			snapshot1data := snapshot1.GetData()
 
 			store2 := factory.getStore(t.TempDir())
@@ -329,7 +330,9 @@ func TestStoreSnapshotPartsNum(t *testing.T) {
 					t.Errorf("unexpected amount of snapshot parts: %d (expected %d) i=%d", snapshot.GetNumParts(), expectedPagesCount, i)
 				}
 
-				_ = snapshot.Release()
+				if err := snapshot.Release(); err != nil {
+					t.Fatalf("failed to release snapshot; %s", err)
+				}
 			}
 		})
 	}
@@ -377,6 +380,10 @@ func TestStoreSnapshotRecoveryOverriding(t *testing.T) {
 			err = store2.Restore(snapshot1data)
 			if err != nil {
 				t.Fatalf("failed to recover snapshot; %s", err)
+			}
+
+			if err := snapshot1.Release(); err != nil {
+				t.Errorf("failed to release a snapshot; %s", err)
 			}
 
 			for i := 0; i < PoolSize*2; i++ {


### PR DESCRIPTION
Releasing a snapshot, which has a predecessors should fail (or merge them - which is not supported nor needed now)
