### PR TITLE
Kjezek/bulk insert file index

### DIFF
--- a/go/backend/index/file/benchmark_test.go
+++ b/go/backend/index/file/benchmark_test.go
@@ -1,0 +1,72 @@
+package file
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"math/rand"
+	"testing"
+)
+
+// running all these options takes long, run with a longer timeout, e.g. " -timeout 360m"
+var numItems = []int{1 << 23, 1 << 24, 1 << 25}
+
+// BenchmarkInsertOneByOne inserts many keys in the index key by key.
+func BenchmarkInsertOneByOne(b *testing.B) {
+	for _, items := range numItems {
+		keys := genRandKeys[uint32](items)
+		b.Run(fmt.Sprintf("items %d", items), func(b *testing.B) {
+			idx := createFileIndex[common.SlotIdxKey[uint32], uint32](b, common.SlotIdx32KeySerializer{}, common.Identifier32Serializer{}, common.SlotIdx32KeyHasher{}, common.SlotIdx32KeyComparator{})
+			for i := 0; i < b.N; i++ {
+				for _, key := range keys {
+					if _, err := idx.GetOrAdd(key); err != nil {
+						b.Fatalf("cannot insert key: %s", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBulkInsert performs insert of keys by batches
+func BenchmarkBulkInsert(b *testing.B) {
+	for _, items := range numItems {
+		keys := genRandKeys[uint32](items)
+		b.Run(fmt.Sprintf("items %d", items), func(b *testing.B) {
+			idx := createFileIndex[common.SlotIdxKey[uint32], uint32](b, common.SlotIdx32KeySerializer{}, common.Identifier32Serializer{}, common.SlotIdx32KeyHasher{}, common.SlotIdx32KeyComparator{})
+			for i := 0; i < b.N; i++ {
+				if err := idx.bulkInsert(keys); err != nil {
+					b.Fatalf("cannot insert key: %s", err)
+				}
+			}
+		})
+	}
+
+}
+
+func nextRandKey[I common.Identifier]() common.SlotIdxKey[I] {
+	nextIndex := rand.Uint32()
+	var nextKey common.Key
+	return common.SlotIdxKey[I]{I(nextIndex), nextKey}
+}
+
+func genRandKeys[I common.Identifier](size int) []common.SlotIdxKey[I] {
+	keys := make([]common.SlotIdxKey[I], 0, size)
+	for numItem := 0; numItem < size; numItem++ {
+		keys = append(keys, nextRandKey[I]())
+	}
+	return keys
+}
+
+func createFileIndex[K comparable, I common.Identifier](b *testing.B, keySerializer common.Serializer[K], indexSerializer common.Serializer[I], hasher common.Hasher[K], comparator common.Comparator[K]) *Index[K, I] {
+	idx, err := NewIndex[K, I](b.TempDir(), keySerializer, indexSerializer, hasher, comparator)
+	if err != nil {
+		b.Fatalf("failed to init file index; %s", err)
+	}
+	b.Cleanup(func() {
+		if err := idx.Close(); err != nil {
+			b.Fatalf("cannot close index: %s", err)
+		}
+	})
+
+	return idx
+}

--- a/go/backend/index/file/linearhashmap.go
+++ b/go/backend/index/file/linearhashmap.go
@@ -38,7 +38,7 @@ func NewLinearHashMap[K comparable, V comparable](pageCapacity, numBuckets, size
 
 // Put assigns the value to the input key.
 func (h *LinearHashMap[K, V]) Put(key K, value V) error {
-	bucketId := h.GetBucketId(key)
+	bucketId := h.GetBucketId(&key)
 	bucket := h.pageList(bucketId)
 	beforeSize := bucket.Size()
 
@@ -56,7 +56,7 @@ func (h *LinearHashMap[K, V]) Put(key K, value V) error {
 
 // Get returns value associated to the input key.
 func (h *LinearHashMap[K, V]) Get(key K) (value V, exists bool, err error) {
-	bucketId := h.GetBucketId(key)
+	bucketId := h.GetBucketId(&key)
 	bucket := h.pageList(bucketId)
 	value, exists, err = bucket.Get(key)
 	return
@@ -66,7 +66,7 @@ func (h *LinearHashMap[K, V]) Get(key K) (value V, exists bool, err error) {
 // when the key is not stored yet.
 // It returns true if the key was present, or false otherwise.
 func (h *LinearHashMap[K, V]) GetOrAdd(key K, val V) (value V, exists bool, err error) {
-	bucketId := h.GetBucketId(key)
+	bucketId := h.GetBucketId(&key)
 	bucket := h.pageList(bucketId)
 	value, exists, err = bucket.GetOrAdd(key, val)
 	if err != nil {
@@ -93,7 +93,7 @@ func (h *LinearHashMap[K, V]) ForEach(callback func(K, V)) error {
 
 // Remove deletes the key from the map and returns whether an element was removed.
 func (h *LinearHashMap[K, V]) Remove(key K) (bool, error) {
-	bucketId := h.GetBucketId(key)
+	bucketId := h.GetBucketId(&key)
 	bucket := h.pageList(bucketId)
 	exists, err := bucket.Remove(key)
 	if err != nil {

--- a/go/backend/index/memory/linearhashmap.go
+++ b/go/backend/index/memory/linearhashmap.go
@@ -41,7 +41,7 @@ func NewLinearHashMap[K comparable, V comparable](blockItems, numBuckets int, ha
 
 // Put assigns the value to the input key.
 func (h *LinearHashMap[K, V]) Put(key K, value V) {
-	bucketId := h.GetBucketId(key)
+	bucketId := h.GetBucketId(&key)
 	bucket := h.list[bucketId]
 	beforeSize := bucket.Size()
 
@@ -57,7 +57,7 @@ func (h *LinearHashMap[K, V]) Put(key K, value V) {
 
 // Get returns value associated to the input key.
 func (h *LinearHashMap[K, V]) Get(key K) (value V, exists bool) {
-	bucket := h.GetBucketId(key)
+	bucket := h.GetBucketId(&key)
 	value, exists = h.list[bucket].Get(key)
 	return
 }
@@ -66,7 +66,7 @@ func (h *LinearHashMap[K, V]) Get(key K) (value V, exists bool) {
 // when the key is not stored yet.
 // It returns true if the key was present, or false otherwise.
 func (h *LinearHashMap[K, V]) GetOrAdd(key K, val V) (value V, exists bool) {
-	bucket := h.GetBucketId(key)
+	bucket := h.GetBucketId(&key)
 	value, exists = h.list[bucket].GetOrAdd(key, val)
 	if !exists {
 		h.records += 1
@@ -84,7 +84,7 @@ func (h *LinearHashMap[K, V]) ForEach(callback func(K, V)) {
 
 // Remove deletes the key from the map and returns whether an element was removed.
 func (h *LinearHashMap[K, V]) Remove(key K) bool {
-	bucket := h.GetBucketId(key)
+	bucket := h.GetBucketId(&key)
 	exists := h.list[bucket].Remove(key)
 	if exists {
 		h.records -= 1

--- a/go/common/linearhashbase.go
+++ b/go/common/linearhashbase.go
@@ -19,9 +19,9 @@ func NewLinearHashBase[K comparable, V any](numBuckets int, hasher Hasher[K], co
 }
 
 // GetBucketId compute collision bucket index for the input key and current number of buckets
-func (h *LinearHashBase[K, V]) GetBucketId(key K) uint {
+func (h *LinearHashBase[K, V]) GetBucketId(key *K) uint {
 	// get last bits of hash
-	hashedKey := h.hasher.Hash(&key)
+	hashedKey := h.hasher.Hash(key)
 	m := uint(hashedKey & ((1 << h.bits) - 1))
 	if m < h.numBuckets {
 		return m
@@ -53,7 +53,7 @@ func (h *LinearHashBase[K, V]) SplitEntries(bucketId uint, oldEntries []MapEntry
 	}
 
 	for _, entry := range oldEntries {
-		if h.GetBucketId(entry.Key) == bucketId {
+		if h.GetBucketId(&entry.Key) == bucketId {
 			entriesA = append(entriesA, entry)
 		} else {
 			entriesB = append(entriesB, entry)

--- a/go/common/linearhashbase_test.go
+++ b/go/common/linearhashbase_test.go
@@ -18,17 +18,21 @@ func TestLinearHashBitMask(t *testing.T) {
 func TestLinearHashGetBucketId(t *testing.T) {
 	h := NewLinearHashBase[uint32, uint32](3, directHash{}, Uint32Comparator{})
 
-	if bucket := h.GetBucketId(uint32(0)); bucket != 0 {
+	key0 := uint32(0)
+	if bucket := h.GetBucketId(&key0); bucket != 0 {
 		t.Errorf("wrong bucket: %d", bucket)
 	}
-	if bucket := h.GetBucketId(uint32(1)); bucket != 1 {
+	key1 := uint32(1)
+	if bucket := h.GetBucketId(&key1); bucket != 1 {
 		t.Errorf("wrong bucket: %d", bucket)
 	}
-	if bucket := h.GetBucketId(uint32(2)); bucket != 2 {
+	key2 := uint32(2)
+	if bucket := h.GetBucketId(&key2); bucket != 2 {
 		t.Errorf("wrong bucket: %d", bucket)
 	}
 	// 3 = (bin) 11, unset top bit -> 01
-	if bucket := h.GetBucketId(uint32(3)); bucket != 1 {
+	key3 := uint32(3)
+	if bucket := h.GetBucketId(&key3); bucket != 1 {
 		t.Errorf("wrong bucket: %d", bucket)
 	}
 }


### PR DESCRIPTION
This PR bulk inserts ordered keys in the Index for Snapsync. It turns out that 1GB of keys buffer is a good size, it gains about 75% performance, more space allocation brings only extra 5%.

<img width="490" alt="image" src="https://user-images.githubusercontent.com/7114574/233172199-f164e236-192d-465e-b1c1-bcda87f16a0f.png">


Next expensive operations are (1) hashing and (2) split() of the LinearHash. Can we recover the snapshot with the Hashes (proofs) that come from the snapshot source, instead of computing it again?
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/7114574/233172366-b9a4c58e-9a22-4194-9cc2-8a411e202ba4.png">

