### PR TITLE
Simplify schema configuration parameters

### DIFF
--- a/cpp/state/BUILD
+++ b/cpp/state/BUILD
@@ -68,12 +68,24 @@ cc_test(
 )
 
 cc_library(
+    name = "configuration",
+    hdrs = ["configuration.h"],
+    visibility = [
+        "//state:__subpackages__",
+    ],
+    deps = [
+        "//common:type",
+    ],
+)
+
+cc_library(
     name = "configurations",
     hdrs = ["configurations.h"],
     visibility = [
         "//state:__subpackages__",
     ],
     deps = [
+        ":configuration",
         "//archive",
         "//backend/depot/file:depot",
         "//backend/depot/leveldb:depot",

--- a/cpp/state/configuration.h
+++ b/cpp/state/configuration.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "common/type.h"
+
+namespace carmen {
+
+// A configuration defines the implementation types of various primitives to be
+// combined by schemas to instantiate a state.
+template <template <typename K, typename V> class IndexType,
+          template <typename K, typename V> class StoreType,
+          template <typename K> class DepotType,
+          template <typename K, typename V> class MultiMapType,
+          typename ArchiveType>
+struct Configuration {
+  template <Trivial K, Trivial V>
+  using Index = IndexType<K, V>;
+
+  template <Trivial K, Trivial V>
+  using Store = StoreType<K, V>;
+
+  template <Trivial K>
+  using Depot = DepotType<K>;
+
+  template <Trivial K, Trivial V>
+  using MultiMap = MultiMapType<K, V>;
+
+  using Archive = ArchiveType;
+};
+
+}  // namespace carmen

--- a/cpp/state/configurations.h
+++ b/cpp/state/configurations.h
@@ -12,18 +12,11 @@
 #include "backend/store/file/store.h"
 #include "backend/store/leveldb/store.h"
 #include "backend/store/memory/store.h"
+#include "state/configuration.h"
 
 namespace carmen {
 
 constexpr const std::size_t kPageSize = 1 << 12;  // 4 KiB
-
-#define Schema                                                    \
-  template <template <typename K, typename V> class IndexType,    \
-            template <typename K, typename V> class StoreType,    \
-            template <typename K> class DepotType,                \
-            template <typename K, typename V> class MultiMapType, \
-            typename ArchiveType>                                 \
-  class
 
 // ----------------------------------------------------------------------------
 //                         In-Memory Configuration
@@ -41,9 +34,9 @@ using InMemoryDepot = backend::depot::InMemoryDepot<K>;
 template <typename K, typename V>
 using InMemoryMultiMap = backend::multimap::InMemoryMultiMap<K, V>;
 
-template <Schema State, Archive Archive>
-using InMemoryState = State<InMemoryIndex, InMemoryStore, InMemoryDepot,
-                            InMemoryMultiMap, Archive>;
+template <Archive Archive>
+using InMemoryConfig = Configuration<InMemoryIndex, InMemoryStore,
+                                     InMemoryDepot, InMemoryMultiMap, Archive>;
 
 // ----------------------------------------------------------------------------
 //                         File-Based Configuration
@@ -60,9 +53,10 @@ using FileBasedStore =
 template <typename K>
 using FileBasedDepot = backend::depot::FileDepot<K>;
 
-template <Schema State, Archive Archive>
-using FileBasedState = State<FileBasedIndex, FileBasedStore, FileBasedDepot,
-                             InMemoryMultiMap, Archive>;
+template <Archive Archive>
+using FileBasedConfig =
+    Configuration<FileBasedIndex, FileBasedStore, FileBasedDepot,
+                  InMemoryMultiMap, Archive>;
 
 // ----------------------------------------------------------------------------
 //                         LevelDB-Based Configuration
@@ -78,10 +72,9 @@ using LevelDbBasedStore = backend::store::LevelDbStore<K, V, kPageSize>;
 template <typename K>
 using LevelDbBasedDepot = backend::depot::LevelDbDepot<K>;
 
-template <Schema State, Archive Archive>
-using LevelDbBasedState = State<LevelDbBasedIndex, LevelDbBasedStore,
-                                LevelDbBasedDepot, InMemoryMultiMap, Archive>;
-
-#undef Schema
+template <Archive Archive>
+using LevelDbBasedConfig =
+    Configuration<LevelDbBasedIndex, LevelDbBasedStore, LevelDbBasedDepot,
+                  InMemoryMultiMap, Archive>;
 
 }  // namespace carmen

--- a/cpp/state/s1/state.h
+++ b/cpp/state/s1/state.h
@@ -25,18 +25,15 @@ namespace carmen::s1 {
 // This implementation of the state can be parameterized by the implementation
 // of index and store types, which are instantiated internally to form the
 // data infrastructure required to maintain all necessary information.
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
+template <typename Config>
 class State {
  public:
+  using Archive = typename Config::Archive;
+
   // The types used for internal indexing.
   using AddressId = std::uint32_t;
   using KeyId = std::uint32_t;
   using SlotId = std::uint32_t;
-  using Archive = ArchiveType;
 
   // Identifies a single slot by its address/key values.
   struct Slot {
@@ -105,7 +102,7 @@ class State {
 
   // Retrieves a pointer to the owned archive or nullptr, if no archive is
   // maintained.
-  ArchiveType* GetArchive() { return archive_.get(); }
+  Archive* GetArchive() { return archive_.get(); }
 
   // Obtains a state hash providing a unique cryptographic fingerprint of the
   // entire maintained state.
@@ -123,49 +120,59 @@ class State {
   MemoryFootprint GetMemoryFootprint() const;
 
  protected:
+  template <typename K, typename V>
+  using Index = typename Config::template Index<K, V>;
+
+  template <typename K, typename V>
+  using Store = typename Config::template Store<K, V>;
+
+  template <typename K>
+  using Depot = typename Config::template Depot<K>;
+
+  template <typename K, typename V>
+  using MultiMap = typename Config::template MultiMap<K, V>;
+
   // Make the state constructor protected to prevent direct instantiation. The
   // state should be created by calling the static Open method. This allows
   // the state to be mocked in tests.
-  State(IndexType<Address, AddressId> address_index,
-        IndexType<Key, KeyId> key_index, IndexType<Slot, SlotId> slot_index,
-        StoreType<AddressId, Balance> balances,
-        StoreType<AddressId, Nonce> nonces,
-        StoreType<SlotId, Value> value_store,
-        StoreType<AddressId, AccountState> account_states,
-        DepotType<AddressId> codes, StoreType<AddressId, Hash> code_hashes,
-        MultiMapType<AddressId, SlotId> address_to_slots,
-        std::unique_ptr<ArchiveType> archive);
+  State(Index<Address, AddressId> address_index, Index<Key, KeyId> key_index,
+        Index<Slot, SlotId> slot_index, Store<AddressId, Balance> balances,
+        Store<AddressId, Nonce> nonces, Store<SlotId, Value> value_store,
+        Store<AddressId, AccountState> account_states, Depot<AddressId> codes,
+        Store<AddressId, Hash> code_hashes,
+        MultiMap<AddressId, SlotId> address_to_slots,
+        std::unique_ptr<Archive> archive);
 
   absl::Status ClearAccount(AddressId addr_id);
 
   // Indexes for mapping address, keys, and slots to dense, numeric IDs.
-  IndexType<Address, AddressId> address_index_;
-  IndexType<Key, KeyId> key_index_;
-  IndexType<Slot, SlotId> slot_index_;
+  Index<Address, AddressId> address_index_;
+  Index<Key, KeyId> key_index_;
+  Index<Slot, SlotId> slot_index_;
 
   // A store retaining the current balance of all accounts.
-  StoreType<AddressId, Balance> balances_;
+  Store<AddressId, Balance> balances_;
 
   // A store retaining the current nonces of all accounts.
-  StoreType<AddressId, Nonce> nonces_;
+  Store<AddressId, Nonce> nonces_;
 
   // The store retaining all values for the covered storage slots.
-  StoreType<SlotId, Value> value_store_;
+  Store<SlotId, Value> value_store_;
 
   // The store retaining account state information.
-  StoreType<AddressId, AccountState> account_states_;
+  Store<AddressId, AccountState> account_states_;
 
   // The code depot to retain account contracts.
-  DepotType<AddressId> codes_;
+  Depot<AddressId> codes_;
 
   // A store to retain code hashes.
-  StoreType<AddressId, Hash> code_hashes_;
+  Store<AddressId, Hash> code_hashes_;
 
   // A map associating accounts to its slots.
-  MultiMapType<AddressId, SlotId> address_to_slots_;
+  MultiMap<AddressId, SlotId> address_to_slots_;
 
   // A pointer to the optionally included archive.
-  std::unique_ptr<ArchiveType> archive_;
+  std::unique_ptr<Archive> archive_;
 
   // A constant for the hash of the empty code.
   static const Hash kEmptyCodeHash;
@@ -173,54 +180,42 @@ class State {
 
 // ----------------------------- Definitions ----------------------------------
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-const Hash State<IndexType, StoreType, DepotType, MultiMapType,
-                 ArchiveType>::kEmptyCodeHash = GetKeccak256Hash({});
+template <typename Config>
+const Hash State<Config>::kEmptyCodeHash = GetKeccak256Hash({});
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<
-    State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Open(
+template <typename Config>
+absl::StatusOr<State<Config>> State<Config>::Open(
     const std::filesystem::path& dir, bool with_archive) {
   backend::Context context;
-  ASSIGN_OR_RETURN(auto address_index, (IndexType<Address, AddressId>::Open(
+  ASSIGN_OR_RETURN(auto address_index, (Index<Address, AddressId>::Open(
                                            context, dir / "addresses")));
   ASSIGN_OR_RETURN(auto key_index,
-                   (IndexType<Key, KeyId>::Open(context, dir / "keys")));
+                   (Index<Key, KeyId>::Open(context, dir / "keys")));
   ASSIGN_OR_RETURN(auto slot_index,
-                   (IndexType<Slot, SlotId>::Open(context, dir / "slots")));
+                   (Index<Slot, SlotId>::Open(context, dir / "slots")));
 
-  ASSIGN_OR_RETURN(auto balances, (StoreType<AddressId, Balance>::Open(
+  ASSIGN_OR_RETURN(auto balances, (Store<AddressId, Balance>::Open(
                                       context, dir / "balances")));
-  ASSIGN_OR_RETURN(auto nonces, (StoreType<AddressId, Nonce>::Open(
-                                    context, dir / "nonces")));
+  ASSIGN_OR_RETURN(auto nonces,
+                   (Store<AddressId, Nonce>::Open(context, dir / "nonces")));
   ASSIGN_OR_RETURN(auto values,
-                   (StoreType<SlotId, Value>::Open(context, dir / "values")));
-  ASSIGN_OR_RETURN(auto account_state,
-                   (StoreType<AddressId, AccountState>::Open(
-                       context, dir / "account_states")));
-  ASSIGN_OR_RETURN(auto code_hashes, (StoreType<AddressId, Hash>::Open(
+                   (Store<SlotId, Value>::Open(context, dir / "values")));
+  ASSIGN_OR_RETURN(auto account_state, (Store<AddressId, AccountState>::Open(
+                                           context, dir / "account_states")));
+  ASSIGN_OR_RETURN(auto code_hashes, (Store<AddressId, Hash>::Open(
                                          context, dir / "code_hashes")));
 
   ASSIGN_OR_RETURN(auto codes,
-                   (DepotType<AddressId>::Open(context, dir / "codes")));
+                   (Depot<AddressId>::Open(context, dir / "codes")));
 
-  ASSIGN_OR_RETURN(auto address_to_slots,
-                   (MultiMapType<AddressId, SlotId>::Open(
-                       context, dir / "address_to_slots")));
+  ASSIGN_OR_RETURN(
+      auto address_to_slots,
+      (MultiMap<AddressId, SlotId>::Open(context, dir / "address_to_slots")));
 
-  std::unique_ptr<ArchiveType> archive;
+  std::unique_ptr<Archive> archive;
   if (with_archive) {
-    ASSIGN_OR_RETURN(auto instance, ArchiveType::Open(dir / "archive"));
-    archive = std::make_unique<ArchiveType>(std::move(instance));
+    ASSIGN_OR_RETURN(auto instance, Archive::Open(dir / "archive"));
+    archive = std::make_unique<Archive>(std::move(instance));
   }
 
   return State(std::move(address_index), std::move(key_index),
@@ -230,20 +225,17 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Open(
                std::move(archive));
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::State(
-    IndexType<Address, AddressId> address_index,
-    IndexType<Key, KeyId> key_index, IndexType<Slot, SlotId> slot_index,
-    StoreType<AddressId, Balance> balances, StoreType<AddressId, Nonce> nonces,
-    StoreType<SlotId, Value> value_store,
-    StoreType<AddressId, AccountState> account_states,
-    DepotType<AddressId> codes, StoreType<AddressId, Hash> code_hashes,
-    MultiMapType<AddressId, SlotId> address_to_slots,
-    std::unique_ptr<ArchiveType> archive)
+template <typename Config>
+State<Config>::State(Index<Address, AddressId> address_index,
+                     Index<Key, KeyId> key_index,
+                     Index<Slot, SlotId> slot_index,
+                     Store<AddressId, Balance> balances,
+                     Store<AddressId, Nonce> nonces,
+                     Store<SlotId, Value> value_store,
+                     Store<AddressId, AccountState> account_states,
+                     Depot<AddressId> codes, Store<AddressId, Hash> code_hashes,
+                     MultiMap<AddressId, SlotId> address_to_slots,
+                     std::unique_ptr<Archive> archive)
     : address_index_(std::move(address_index)),
       key_index_(std::move(key_index)),
       slot_index_(std::move(slot_index)),
@@ -256,26 +248,16 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::State(
       address_to_slots_(std::move(address_to_slots)),
       archive_(std::move(archive)) {}
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::CreateAccount(const Address& address) {
+template <typename Config>
+absl::Status State<Config>::CreateAccount(const Address& address) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   RETURN_IF_ERROR(account_states_.Set(addr_id.first, AccountState::kExists));
   return ClearAccount(addr_id.first);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<AccountState>
-State<IndexType, StoreType, DepotType, MultiMapType,
-      ArchiveType>::GetAccountState(const Address& address) const {
+template <typename Config>
+absl::StatusOr<AccountState> State<Config>::GetAccountState(
+    const Address& address) const {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return AccountState::kUnknown;
@@ -284,13 +266,8 @@ State<IndexType, StoreType, DepotType, MultiMapType,
   return account_states_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::DeleteAccount(const Address& address) {
+template <typename Config>
+absl::Status State<Config>::DeleteAccount(const Address& address) {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return absl::OkStatus();
@@ -300,13 +277,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return ClearAccount(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::ClearAccount(AddressId addr_id) {
+template <typename Config>
+absl::Status State<Config>::ClearAccount(AddressId addr_id) {
   // Reset slots associated to account.
   absl::Status reset_status;
   RETURN_IF_ERROR(address_to_slots_.ForEach(addr_id, [&](SlotId slot_id) {
@@ -317,13 +289,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return address_to_slots_.Erase(addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Balance>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetBalance(
+template <typename Config>
+absl::StatusOr<Balance> State<Config>::GetBalance(
     const Address& address) const {
   constexpr static const Balance kZero{};
   auto addr_id = address_index_.Get(address);
@@ -334,26 +301,14 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetBalance(
   return balances_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetBalance(const Address& address,
-                                            Balance value) {
+template <typename Config>
+absl::Status State<Config>::SetBalance(const Address& address, Balance value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   return balances_.Set(addr_id.first, value);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Nonce>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetNonce(
-    const Address& address) const {
+template <typename Config>
+absl::StatusOr<Nonce> State<Config>::GetNonce(const Address& address) const {
   constexpr static const Nonce kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -363,26 +318,15 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetNonce(
   return nonces_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetNonce(const Address& address, Nonce value) {
+template <typename Config>
+absl::Status State<Config>::SetNonce(const Address& address, Nonce value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   return nonces_.Set(addr_id.first, value);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Value>
-State<IndexType, StoreType, DepotType, MultiMapType,
-      ArchiveType>::GetStorageValue(const Address& address,
-                                    const Key& key) const {
+template <typename Config>
+absl::StatusOr<Value> State<Config>::GetStorageValue(const Address& address,
+                                                     const Key& key) const {
   constexpr static const Value kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -403,15 +347,10 @@ State<IndexType, StoreType, DepotType, MultiMapType,
   return value_store_.Get(*slot_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetStorageValue(const Address& address,
-                                                 const Key& key,
-                                                 const Value& value) {
+template <typename Config>
+absl::Status State<Config>::SetStorageValue(const Address& address,
+                                            const Key& key,
+                                            const Value& value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   ASSIGN_OR_RETURN(auto key_id, key_index_.GetOrAdd(key));
   Slot slot{addr_id.first, key_id.first};
@@ -426,13 +365,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Code> State<IndexType, StoreType, DepotType, MultiMapType,
-                           ArchiveType>::GetCode(const Address& address) const {
+template <typename Config>
+absl::StatusOr<Code> State<Config>::GetCode(const Address& address) const {
   constexpr static const std::span<const std::byte> kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -447,27 +381,17 @@ absl::StatusOr<Code> State<IndexType, StoreType, DepotType, MultiMapType,
   return *code;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetCode(const Address& address,
-                                         std::span<const std::byte> code) {
+template <typename Config>
+absl::Status State<Config>::SetCode(const Address& address,
+                                    std::span<const std::byte> code) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   RETURN_IF_ERROR(codes_.Set(addr_id.first, code));
   return code_hashes_.Set(
       addr_id.first, code.empty() ? kEmptyCodeHash : GetKeccak256Hash(code));
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<std::uint32_t>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeSize(
+template <typename Config>
+absl::StatusOr<std::uint32_t> State<Config>::GetCodeSize(
     const Address& address) const {
   constexpr static const std::uint32_t kZero = 0;
   auto addr_id = address_index_.Get(address);
@@ -483,14 +407,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeSize(
   return *size;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Hash>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeHash(
-    const Address& address) const {
+template <typename Config>
+absl::StatusOr<Hash> State<Config>::GetCodeHash(const Address& address) const {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return kEmptyCodeHash;
@@ -510,13 +428,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeHash(
   return code_hash;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::Apply(BlockId block, const Update& update) {
+template <typename Config>
+absl::Status State<Config>::Apply(BlockId block, const Update& update) {
   // Add updates the current state only.
   RETURN_IF_ERROR(ApplyToState(update));
   // If there is an active archive, the update is also added to its log.
@@ -527,13 +440,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::ApplyToState(const Update& update) {
+template <typename Config>
+absl::Status State<Config>::ApplyToState(const Update& update) {
   // It is important to keep the update order.
   for (auto& addr : update.GetDeletedAccounts()) {
     RETURN_IF_ERROR(DeleteAccount(addr));
@@ -556,13 +464,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Hash>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetHash() {
+template <typename Config>
+absl::StatusOr<Hash> State<Config>::GetHash() {
   ASSIGN_OR_RETURN(auto addr_idx_hash, address_index_.GetHash());
   ASSIGN_OR_RETURN(auto key_idx_hash, key_index_.GetHash());
   ASSIGN_OR_RETURN(auto slot_idx_hash, slot_index_.GetHash());
@@ -576,13 +479,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetHash() {
                        codes_hash);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Flush() {
+template <typename Config>
+absl::Status State<Config>::Flush() {
   RETURN_IF_ERROR(address_index_.Flush());
   RETURN_IF_ERROR(key_index_.Flush());
   RETURN_IF_ERROR(slot_index_.Flush());
@@ -599,13 +497,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Flush() {
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Close() {
+template <typename Config>
+absl::Status State<Config>::Close() {
   RETURN_IF_ERROR(address_index_.Close());
   RETURN_IF_ERROR(key_index_.Close());
   RETURN_IF_ERROR(slot_index_.Close());
@@ -622,13 +515,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Close() {
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-MemoryFootprint State<IndexType, StoreType, DepotType, MultiMapType,
-                      ArchiveType>::GetMemoryFootprint() const {
+template <typename Config>
+MemoryFootprint State<Config>::GetMemoryFootprint() const {
   MemoryFootprint res(*this);
   res.Add("address_index", address_index_.GetMemoryFootprint());
   res.Add("key_index", key_index_.GetMemoryFootprint());

--- a/cpp/state/s1/state_test.cc
+++ b/cpp/state/s1/state_test.cc
@@ -34,9 +34,9 @@ using ::testing::StatusIs;
 using TestArchive = archive::leveldb::LevelDbArchive;
 
 using StateConfigurations =
-    ::testing::Types<InMemoryState<State, TestArchive>,
-                     FileBasedState<State, TestArchive>,
-                     LevelDbBasedState<State, TestArchive>>;
+    ::testing::Types<State<InMemoryConfig<TestArchive>>,
+                     State<FileBasedConfig<TestArchive>>,
+                     State<LevelDbBasedConfig<TestArchive>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Schema_1, StateTest, StateConfigurations);
 
@@ -54,8 +54,10 @@ using MockDepot = backend::depot::MockDepot<K>;
 template <typename K, typename V>
 using MockMultiMap = backend::multimap::MockMultiMap<K, V>;
 
-using MockState =
-    State<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+using MockConfig =
+    Configuration<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+
+using MockState = State<MockConfig>;
 
 // A test fixture for the State class. It provides a State instance with
 // mocked dependencies. The dependencies are exposed through getters.

--- a/cpp/state/s2/state.h
+++ b/cpp/state/s2/state.h
@@ -25,17 +25,14 @@ namespace carmen::s2 {
 // This implementation of the state can be parameterized by the implementation
 // of index and store types, which are instantiated internally to form the
 // data infrastructure required to maintain all necessary information.
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
+template <typename Config>
 class State {
  public:
+  using Archive = typename Config::Archive;
+
   // The types used for internal indexing.
   using AddressId = std::uint32_t;
   using SlotId = std::uint32_t;
-  using Archive = ArchiveType;
 
   static constexpr Schema GetSchema() { return StateFeature::kAddressId; }
 
@@ -88,7 +85,7 @@ class State {
 
   // Retrieves a pointer to the owned archive or nullptr, if no archive is
   // maintained.
-  ArchiveType* GetArchive() { return archive_.get(); }
+  Archive* GetArchive() { return archive_.get(); }
 
   // Obtains a state hash providing a unique cryptographic fingerprint of the
   // entire maintained state.
@@ -106,6 +103,18 @@ class State {
   MemoryFootprint GetMemoryFootprint() const;
 
  protected:
+  template <typename K, typename V>
+  using Index = typename Config::template Index<K, V>;
+
+  template <typename K, typename V>
+  using Store = typename Config::template Store<K, V>;
+
+  template <typename K>
+  using Depot = typename Config::template Depot<K>;
+
+  template <typename K, typename V>
+  using MultiMap = typename Config::template MultiMap<K, V>;
+
   // Identifies a single slot by its address/key values.
   struct Slot {
     AddressId address;
@@ -126,45 +135,43 @@ class State {
   // Make the state constructor protected to prevent direct instantiation. The
   // state should be created by calling the static Open method. This allows
   // the state to be mocked in tests.
-  State(IndexType<Address, AddressId> address_index,
-        IndexType<Slot, SlotId> slot_index,
-        StoreType<AddressId, Balance> balances,
-        StoreType<AddressId, Nonce> nonces,
-        StoreType<SlotId, Value> value_store,
-        StoreType<AddressId, AccountState> account_states,
-        DepotType<AddressId> codes, StoreType<AddressId, Hash> code_hashes,
-        MultiMapType<AddressId, SlotId> address_to_slots,
-        std::unique_ptr<ArchiveType> archive);
+  State(Index<Address, AddressId> address_index, Index<Slot, SlotId> slot_index,
+        Store<AddressId, Balance> balances, Store<AddressId, Nonce> nonces,
+        Store<SlotId, Value> value_store,
+        Store<AddressId, AccountState> account_states, Depot<AddressId> codes,
+        Store<AddressId, Hash> code_hashes,
+        MultiMap<AddressId, SlotId> address_to_slots,
+        std::unique_ptr<Archive> archive);
 
   absl::Status ClearAccount(AddressId addr_id);
 
   // Indexes for mapping address and slots to dense, numeric IDs.
-  IndexType<Address, AddressId> address_index_;
-  IndexType<Slot, SlotId> slot_index_;
+  Index<Address, AddressId> address_index_;
+  Index<Slot, SlotId> slot_index_;
 
   // A store retaining the current balance of all accounts.
-  StoreType<AddressId, Balance> balances_;
+  Store<AddressId, Balance> balances_;
 
   // A store retaining the current nonces of all accounts.
-  StoreType<AddressId, Nonce> nonces_;
+  Store<AddressId, Nonce> nonces_;
 
   // The store retaining all values for the covered storage slots.
-  StoreType<SlotId, Value> value_store_;
+  Store<SlotId, Value> value_store_;
 
   // The store retaining account state information.
-  StoreType<AddressId, AccountState> account_states_;
+  Store<AddressId, AccountState> account_states_;
 
   // The code depot to retain account contracts.
-  DepotType<AddressId> codes_;
+  Depot<AddressId> codes_;
 
   // A store to retain code hashes.
-  StoreType<AddressId, Hash> code_hashes_;
+  Store<AddressId, Hash> code_hashes_;
 
   // A map associating accounts to its slots.
-  MultiMapType<AddressId, SlotId> address_to_slots_;
+  MultiMap<AddressId, SlotId> address_to_slots_;
 
   // A pointer to the optionally included archive.
-  std::unique_ptr<ArchiveType> archive_;
+  std::unique_ptr<Archive> archive_;
 
   // A constant for the hash of the empty code.
   static const Hash kEmptyCodeHash;
@@ -172,52 +179,40 @@ class State {
 
 // ----------------------------- Definitions ----------------------------------
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-const Hash State<IndexType, StoreType, DepotType, MultiMapType,
-                 ArchiveType>::kEmptyCodeHash = GetKeccak256Hash({});
+template <typename Config>
+const Hash State<Config>::kEmptyCodeHash = GetKeccak256Hash({});
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<
-    State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Open(
+template <typename Config>
+absl::StatusOr<State<Config>> State<Config>::Open(
     const std::filesystem::path& dir, bool with_archive) {
   backend::Context context;
-  ASSIGN_OR_RETURN(auto address_index, (IndexType<Address, AddressId>::Open(
+  ASSIGN_OR_RETURN(auto address_index, (Index<Address, AddressId>::Open(
                                            context, dir / "addresses")));
   ASSIGN_OR_RETURN(auto slot_index,
-                   (IndexType<Slot, SlotId>::Open(context, dir / "slots")));
+                   (Index<Slot, SlotId>::Open(context, dir / "slots")));
 
-  ASSIGN_OR_RETURN(auto balances, (StoreType<AddressId, Balance>::Open(
+  ASSIGN_OR_RETURN(auto balances, (Store<AddressId, Balance>::Open(
                                       context, dir / "balances")));
-  ASSIGN_OR_RETURN(auto nonces, (StoreType<AddressId, Nonce>::Open(
-                                    context, dir / "nonces")));
+  ASSIGN_OR_RETURN(auto nonces,
+                   (Store<AddressId, Nonce>::Open(context, dir / "nonces")));
   ASSIGN_OR_RETURN(auto values,
-                   (StoreType<SlotId, Value>::Open(context, dir / "values")));
-  ASSIGN_OR_RETURN(auto account_state,
-                   (StoreType<AddressId, AccountState>::Open(
-                       context, dir / "account_states")));
-  ASSIGN_OR_RETURN(auto code_hashes, (StoreType<AddressId, Hash>::Open(
+                   (Store<SlotId, Value>::Open(context, dir / "values")));
+  ASSIGN_OR_RETURN(auto account_state, (Store<AddressId, AccountState>::Open(
+                                           context, dir / "account_states")));
+  ASSIGN_OR_RETURN(auto code_hashes, (Store<AddressId, Hash>::Open(
                                          context, dir / "code_hashes")));
 
   ASSIGN_OR_RETURN(auto codes,
-                   (DepotType<AddressId>::Open(context, dir / "codes")));
+                   (Depot<AddressId>::Open(context, dir / "codes")));
 
-  ASSIGN_OR_RETURN(auto address_to_slots,
-                   (MultiMapType<AddressId, SlotId>::Open(
-                       context, dir / "address_to_slots")));
+  ASSIGN_OR_RETURN(
+      auto address_to_slots,
+      (MultiMap<AddressId, SlotId>::Open(context, dir / "address_to_slots")));
 
-  std::unique_ptr<ArchiveType> archive;
+  std::unique_ptr<Archive> archive;
   if (with_archive) {
-    ASSIGN_OR_RETURN(auto instance, ArchiveType::Open(dir / "archive"));
-    archive = std::make_unique<ArchiveType>(std::move(instance));
+    ASSIGN_OR_RETURN(auto instance, Archive::Open(dir / "archive"));
+    archive = std::make_unique<Archive>(std::move(instance));
   }
 
   return State(std::move(address_index), std::move(slot_index),
@@ -227,19 +222,16 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Open(
                std::move(archive));
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::State(
-    IndexType<Address, AddressId> address_index,
-    IndexType<Slot, SlotId> slot_index, StoreType<AddressId, Balance> balances,
-    StoreType<AddressId, Nonce> nonces, StoreType<SlotId, Value> value_store,
-    StoreType<AddressId, AccountState> account_states,
-    DepotType<AddressId> codes, StoreType<AddressId, Hash> code_hashes,
-    MultiMapType<AddressId, SlotId> address_to_slots,
-    std::unique_ptr<ArchiveType> archive)
+template <typename Config>
+State<Config>::State(Index<Address, AddressId> address_index,
+                     Index<Slot, SlotId> slot_index,
+                     Store<AddressId, Balance> balances,
+                     Store<AddressId, Nonce> nonces,
+                     Store<SlotId, Value> value_store,
+                     Store<AddressId, AccountState> account_states,
+                     Depot<AddressId> codes, Store<AddressId, Hash> code_hashes,
+                     MultiMap<AddressId, SlotId> address_to_slots,
+                     std::unique_ptr<Archive> archive)
     : address_index_(std::move(address_index)),
       slot_index_(std::move(slot_index)),
       balances_(std::move(balances)),
@@ -251,26 +243,16 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::State(
       address_to_slots_(std::move(address_to_slots)),
       archive_(std::move(archive)) {}
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::CreateAccount(const Address& address) {
+template <typename Config>
+absl::Status State<Config>::CreateAccount(const Address& address) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   RETURN_IF_ERROR(account_states_.Set(addr_id.first, AccountState::kExists));
   return ClearAccount(addr_id.first);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<AccountState>
-State<IndexType, StoreType, DepotType, MultiMapType,
-      ArchiveType>::GetAccountState(const Address& address) const {
+template <typename Config>
+absl::StatusOr<AccountState> State<Config>::GetAccountState(
+    const Address& address) const {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return AccountState::kUnknown;
@@ -279,13 +261,8 @@ State<IndexType, StoreType, DepotType, MultiMapType,
   return account_states_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::DeleteAccount(const Address& address) {
+template <typename Config>
+absl::Status State<Config>::DeleteAccount(const Address& address) {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return absl::OkStatus();
@@ -295,13 +272,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return ClearAccount(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::ClearAccount(AddressId addr_id) {
+template <typename Config>
+absl::Status State<Config>::ClearAccount(AddressId addr_id) {
   // Reset slots associated to account.
   absl::Status reset_status;
   RETURN_IF_ERROR(address_to_slots_.ForEach(addr_id, [&](SlotId slot_id) {
@@ -312,13 +284,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return address_to_slots_.Erase(addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Balance>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetBalance(
+template <typename Config>
+absl::StatusOr<Balance> State<Config>::GetBalance(
     const Address& address) const {
   constexpr static const Balance kZero{};
   auto addr_id = address_index_.Get(address);
@@ -329,26 +296,14 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetBalance(
   return balances_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetBalance(const Address& address,
-                                            Balance value) {
+template <typename Config>
+absl::Status State<Config>::SetBalance(const Address& address, Balance value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   return balances_.Set(addr_id.first, value);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Nonce>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetNonce(
-    const Address& address) const {
+template <typename Config>
+absl::StatusOr<Nonce> State<Config>::GetNonce(const Address& address) const {
   constexpr static const Nonce kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -358,26 +313,15 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetNonce(
   return nonces_.Get(*addr_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetNonce(const Address& address, Nonce value) {
+template <typename Config>
+absl::Status State<Config>::SetNonce(const Address& address, Nonce value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   return nonces_.Set(addr_id.first, value);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Value>
-State<IndexType, StoreType, DepotType, MultiMapType,
-      ArchiveType>::GetStorageValue(const Address& address,
-                                    const Key& key) const {
+template <typename Config>
+absl::StatusOr<Value> State<Config>::GetStorageValue(const Address& address,
+                                                     const Key& key) const {
   constexpr static const Value kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -393,15 +337,10 @@ State<IndexType, StoreType, DepotType, MultiMapType,
   return value_store_.Get(*slot_id);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetStorageValue(const Address& address,
-                                                 const Key& key,
-                                                 const Value& value) {
+template <typename Config>
+absl::Status State<Config>::SetStorageValue(const Address& address,
+                                            const Key& key,
+                                            const Value& value) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   Slot slot{addr_id.first, key};
   ASSIGN_OR_RETURN(auto slot_id, slot_index_.GetOrAdd(slot));
@@ -415,13 +354,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Code> State<IndexType, StoreType, DepotType, MultiMapType,
-                           ArchiveType>::GetCode(const Address& address) const {
+template <typename Config>
+absl::StatusOr<Code> State<Config>::GetCode(const Address& address) const {
   constexpr static const std::span<const std::byte> kZero{};
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
@@ -436,27 +370,17 @@ absl::StatusOr<Code> State<IndexType, StoreType, DepotType, MultiMapType,
   return *code;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::SetCode(const Address& address,
-                                         std::span<const std::byte> code) {
+template <typename Config>
+absl::Status State<Config>::SetCode(const Address& address,
+                                    std::span<const std::byte> code) {
   ASSIGN_OR_RETURN(auto addr_id, address_index_.GetOrAdd(address));
   RETURN_IF_ERROR(codes_.Set(addr_id.first, code));
   return code_hashes_.Set(
       addr_id.first, code.empty() ? kEmptyCodeHash : GetKeccak256Hash(code));
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<std::uint32_t>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeSize(
+template <typename Config>
+absl::StatusOr<std::uint32_t> State<Config>::GetCodeSize(
     const Address& address) const {
   constexpr static const std::uint32_t kZero = 0;
   auto addr_id = address_index_.Get(address);
@@ -472,14 +396,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeSize(
   return *size;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Hash>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeHash(
-    const Address& address) const {
+template <typename Config>
+absl::StatusOr<Hash> State<Config>::GetCodeHash(const Address& address) const {
   auto addr_id = address_index_.Get(address);
   if (absl::IsNotFound(addr_id.status())) {
     return kEmptyCodeHash;
@@ -499,13 +417,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetCodeHash(
   return code_hash;
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::Apply(BlockId block, const Update& update) {
+template <typename Config>
+absl::Status State<Config>::Apply(BlockId block, const Update& update) {
   // Add updates the current state only.
   RETURN_IF_ERROR(ApplyToState(update));
   // If there is an active archive, the update is also added to its log.
@@ -516,13 +429,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
-                   ArchiveType>::ApplyToState(const Update& update) {
+template <typename Config>
+absl::Status State<Config>::ApplyToState(const Update& update) {
   // It is important to keep the update order.
   for (auto& addr : update.GetDeletedAccounts()) {
     RETURN_IF_ERROR(DeleteAccount(addr));
@@ -545,13 +453,8 @@ absl::Status State<IndexType, StoreType, DepotType, MultiMapType,
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::StatusOr<Hash>
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetHash() {
+template <typename Config>
+absl::StatusOr<Hash> State<Config>::GetHash() {
   ASSIGN_OR_RETURN(auto addr_idx_hash, address_index_.GetHash());
   ASSIGN_OR_RETURN(auto slot_idx_hash, slot_index_.GetHash());
   ASSIGN_OR_RETURN(auto bal_hash, balances_.GetHash());
@@ -563,13 +466,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::GetHash() {
                        val_store_hash, acc_states_hash, codes_hash);
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Flush() {
+template <typename Config>
+absl::Status State<Config>::Flush() {
   RETURN_IF_ERROR(address_index_.Flush());
   RETURN_IF_ERROR(slot_index_.Flush());
   RETURN_IF_ERROR(account_states_.Flush());
@@ -585,13 +483,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Flush() {
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-absl::Status
-State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Close() {
+template <typename Config>
+absl::Status State<Config>::Close() {
   RETURN_IF_ERROR(address_index_.Close());
   RETURN_IF_ERROR(slot_index_.Close());
   RETURN_IF_ERROR(account_states_.Close());
@@ -607,13 +500,8 @@ State<IndexType, StoreType, DepotType, MultiMapType, ArchiveType>::Close() {
   return absl::OkStatus();
 }
 
-template <template <typename K, typename V> class IndexType,
-          template <typename K, typename V> class StoreType,
-          template <typename K> class DepotType,
-          template <typename K, typename V> class MultiMapType,
-          Archive ArchiveType>
-MemoryFootprint State<IndexType, StoreType, DepotType, MultiMapType,
-                      ArchiveType>::GetMemoryFootprint() const {
+template <typename Config>
+MemoryFootprint State<Config>::GetMemoryFootprint() const {
   MemoryFootprint res(*this);
   res.Add("address_index", address_index_.GetMemoryFootprint());
   res.Add("slot_index", slot_index_.GetMemoryFootprint());

--- a/cpp/state/s2/state_test.cc
+++ b/cpp/state/s2/state_test.cc
@@ -34,9 +34,9 @@ using ::testing::StatusIs;
 using TestArchive = archive::leveldb::LevelDbArchive;
 
 using StateConfigurations =
-    ::testing::Types<InMemoryState<State, TestArchive>,
-                     FileBasedState<State, TestArchive>,
-                     LevelDbBasedState<State, TestArchive>>;
+    ::testing::Types<State<InMemoryConfig<TestArchive>>,
+                     State<FileBasedConfig<TestArchive>>,
+                     State<LevelDbBasedConfig<TestArchive>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Schema_2, StateTest, StateConfigurations);
 
@@ -54,8 +54,10 @@ using MockDepot = backend::depot::MockDepot<K>;
 template <typename K, typename V>
 using MockMultiMap = backend::multimap::MockMultiMap<K, V>;
 
-using MockState =
-    State<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+using MockConfig =
+    Configuration<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+
+using MockState = State<MockConfig>;
 
 // A test fixture for the State class. It provides a State instance with
 // mocked dependencies. The dependencies are exposed through getters.

--- a/cpp/state/s3/state_test.cc
+++ b/cpp/state/s3/state_test.cc
@@ -34,9 +34,9 @@ using ::testing::StatusIs;
 using TestArchive = archive::leveldb::LevelDbArchive;
 
 using StateConfigurations =
-    ::testing::Types<InMemoryState<State, TestArchive>,
-                     FileBasedState<State, TestArchive>,
-                     LevelDbBasedState<State, TestArchive>>;
+    ::testing::Types<State<InMemoryConfig<TestArchive>>,
+                     State<FileBasedConfig<TestArchive>>,
+                     State<LevelDbBasedConfig<TestArchive>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Schema_3, StateTest, StateConfigurations);
 
@@ -54,8 +54,10 @@ using MockDepot = backend::depot::MockDepot<K>;
 template <typename K, typename V>
 using MockMultiMap = backend::multimap::MockMultiMap<K, V>;
 
-using MockState =
-    State<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+using MockConfig =
+    Configuration<MockIndex, MockStore, MockDepot, MockMultiMap, MockArchive>;
+
+using MockState = State<MockConfig>;
 
 // A test fixture for the State class. It provides a State instance with
 // mocked dependencies. The dependencies are exposed through getters.

--- a/cpp/state/state_benchmark.cc
+++ b/cpp/state/state_benchmark.cc
@@ -19,17 +19,17 @@ using Archive = archive::leveldb::LevelDbArchive;
 //    bazel run -c opt //state:state_benchmark
 
 // Defines the list of configurations to be benchmarked.
-BENCHMARK_TYPE_LIST(StateConfigList, (InMemoryState<s1::State, Archive>),
-                    (FileBasedState<s1::State, Archive>),
-                    (LevelDbBasedState<s1::State, Archive>),
+BENCHMARK_TYPE_LIST(StateConfigList, (s1::State<InMemoryConfig<Archive>>),
+                    (s1::State<FileBasedConfig<Archive>>),
+                    (s1::State<LevelDbBasedConfig<Archive>>),
 
-                    (InMemoryState<s2::State, Archive>),
-                    (FileBasedState<s2::State, Archive>),
-                    (LevelDbBasedState<s2::State, Archive>),
+                    (s2::State<InMemoryConfig<Archive>>),
+                    (s2::State<FileBasedConfig<Archive>>),
+                    (s2::State<LevelDbBasedConfig<Archive>>),
 
-                    (InMemoryState<s3::State, Archive>),
-                    (FileBasedState<s3::State, Archive>),
-                    (LevelDbBasedState<s3::State, Archive>));
+                    (s3::State<InMemoryConfig<Archive>>),
+                    (s3::State<FileBasedConfig<Archive>>),
+                    (s3::State<LevelDbBasedConfig<Archive>>));
 
 // Benchmarks the time it takes to open and close a state DB.
 template <typename State>


### PR DESCRIPTION
This PR adds a configuration struct for schemas to eliminate the long list of template parameters schemas used to exhibit. The intent is to reduce code complexity and to make it easier to implement additional schemas using different parameters.