### PR TITLE
import hashes of the index from the snapshot proof instead of recompu…

### DIFF
--- a/go/backend/index/snapshot.go
+++ b/go/backend/index/snapshot.go
@@ -46,6 +46,14 @@ func (p *IndexProof) ToBytes() []byte {
 	return res
 }
 
+func (p *IndexProof) GetBeforeHash() common.Hash {
+	return p.before
+}
+
+func (p *IndexProof) GetAfterHash() common.Hash {
+	return p.after
+}
+
 // ----------------------------------- Part -----------------------------------
 
 // maxBytesPerPart the approximate size aimed for per part.


### PR DESCRIPTION
This PR uses snapshot Proofs to recover the index snapshot instead of computing the hashes on restoration. 

Insert Performance after this PR - +5% for 1GB cache
<img width="416" alt="image" src="https://user-images.githubusercontent.com/7114574/233418495-d4a9a1aa-c9f4-44f6-b950-f376c16bb785.png">

before this PR:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/7114574/233419335-9f7a0a58-dd05-4708-81d8-66481ead87d6.png">
