### PR TITLE
Add synchronizing wrapper around state implementations

### DIFF
--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -33,10 +33,10 @@ type CppState struct {
 func newCppState(impl C.enum_StateImpl, params Parameters) (State, error) {
 	dir := C.CString(params.Directory)
 	defer C.free(unsafe.Pointer(dir))
-	return &CppState{
+	return wrapIntoSyncedState(&CppState{
 		state:     C.Carmen_OpenState(C.C_Schema(params.Schema), impl, C.enum_StateImpl(params.Archive), dir, C.int(len(params.Directory))),
 		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
-	}, nil
+	}), nil
 }
 
 func NewCppInMemoryState(params Parameters) (State, error) {

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -54,8 +54,8 @@ type GoSchema interface {
 	runPostRestoreTasks() error
 }
 
-func NewGoState(schema GoSchema, archive archive.Archive, cleanup []func()) *GoState {
-	return &GoState{
+func NewGoState(schema GoSchema, archive archive.Archive, cleanup []func()) State {
+	return wrapIntoSyncedState(&GoState{
 		schema,
 		cleanup,
 		archive,
@@ -63,7 +63,7 @@ func NewGoState(schema GoSchema, archive archive.Archive, cleanup []func()) *GoS
 		nil,
 		nil,
 		nil,
-	}
+	})
 }
 
 var emptyCodeHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -277,7 +277,7 @@ func TestFailingStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}
-	goSchema := state.(*GoState).GoSchema.(*GoSchema1)
+	goSchema := state.(*syncedState).state.(*GoState).GoSchema.(*GoSchema1)
 	goSchema.balancesStore = failingStore[uint32, common.Balance]{goSchema.balancesStore}
 	goSchema.noncesStore = failingStore[uint32, common.Nonce]{goSchema.noncesStore}
 	goSchema.valuesStore = failingStore[uint32, common.Value]{goSchema.valuesStore}
@@ -307,7 +307,7 @@ func TestFailingIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create in-memory state; %s", err)
 	}
-	goSchema := state.(*GoState).GoSchema.(*GoSchema1)
+	goSchema := state.(*syncedState).state.(*GoState).GoSchema.(*GoSchema1)
 	goSchema.addressIndex = failingIndex[common.Address, uint32]{goSchema.addressIndex}
 
 	_, err = state.GetBalance(address1)
@@ -335,7 +335,7 @@ func TestGetMemoryFootprint(t *testing.T) {
 			}
 			defer state.Close()
 
-			memoryFootprint := state.(*GoState).GetMemoryFootprint()
+			memoryFootprint := state.GetMemoryFootprint()
 			str, err := memoryFootprint.ToString("state")
 			if err != nil {
 				t.Fatalf("failed to get state memory footprint; %s", err)

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -1,0 +1,164 @@
+package state
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// syncedState wraps a state implemententation with a lock restricting the
+// number of concurrent access to one for the underlying state.
+type syncedState struct {
+	state directUpdateState
+	mu    sync.Mutex
+}
+
+// wrapIntoSyncedState wraps the given state into a synchronizied state
+// ensuring mutual exclusive access to the underlying state.
+func wrapIntoSyncedState(state directUpdateState) directUpdateState {
+	if _, ok := state.(*syncedState); ok {
+		return state
+	}
+	return &syncedState{
+		state: state,
+	}
+}
+
+func (s *syncedState) Exists(address common.Address) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.Exists(address)
+}
+
+func (s *syncedState) GetBalance(address common.Address) (common.Balance, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetBalance(address)
+}
+
+func (s *syncedState) GetNonce(address common.Address) (common.Nonce, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetNonce(address)
+}
+
+func (s *syncedState) GetStorage(address common.Address, key common.Key) (common.Value, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetStorage(address, key)
+}
+
+func (s *syncedState) GetCode(address common.Address) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetCode(address)
+}
+
+func (s *syncedState) GetCodeSize(address common.Address) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetCodeSize(address)
+}
+
+func (s *syncedState) GetCodeHash(address common.Address) (common.Hash, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetCodeHash(address)
+}
+
+func (s *syncedState) Apply(block uint64, update common.Update) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.Apply(block, update)
+}
+
+func (s *syncedState) GetHash() (common.Hash, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetHash()
+}
+
+func (s *syncedState) Flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.Flush()
+}
+
+func (s *syncedState) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.Close()
+}
+
+func (s *syncedState) GetMemoryFootprint() *common.MemoryFootprint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetMemoryFootprint()
+}
+
+func (s *syncedState) GetArchiveState(block uint64) (State, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetArchiveState(block)
+}
+
+func (s *syncedState) GetProof() (backend.Proof, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetProof()
+}
+
+func (s *syncedState) CreateSnapshot() (backend.Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.CreateSnapshot()
+}
+
+func (s *syncedState) Restore(data backend.SnapshotData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.Restore(data)
+}
+
+func (s *syncedState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.GetSnapshotVerifier(metadata)
+}
+
+func (s *syncedState) createAccount(address common.Address) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.createAccount(address)
+}
+
+func (s *syncedState) deleteAccount(address common.Address) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.deleteAccount(address)
+}
+
+func (s *syncedState) setBalance(address common.Address, balance common.Balance) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.setBalance(address, balance)
+}
+
+func (s *syncedState) setNonce(address common.Address, nonce common.Nonce) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.setNonce(address, nonce)
+}
+
+func (s *syncedState) setStorage(address common.Address, key common.Key, value common.Value) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.setStorage(address, key, value)
+}
+
+func (s *syncedState) setCode(address common.Address, code []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.setCode(address, code)
+}


### PR DESCRIPTION
This PR introduces a synchronization layer around any Carmen DB implementation enforcing mutual exclusion of DB operations.