### PR TITLE
Add support for tracking Logs in StateDB

### DIFF
--- a/go/common/log.go
+++ b/go/common/log.go
@@ -1,0 +1,17 @@
+package common
+
+// Log summarizes a log message recorded during the execution of a contract.
+// This should be approximating ethereum's definition: t.ly/dVL7
+type Log struct {
+	// -- payload --
+	// Address of the contract that generated the event.
+	Address Address
+	// List of topics the log message should be tagged by.
+	Topics []Hash
+	// The actual log message.
+	Data []byte
+
+	// -- metadata --
+	// The hash of the transaction producing this log message.
+	TxHash Hash
+}


### PR DESCRIPTION
This PR introduces log-tracking support into Carmen's StateDB implementation. 

With this change, the log messages reported during a transaction can be tracked during the processing of the transactions of a block and collected for forwarding them into a log store at the end of the block.