### PR TITLE
Mark AbortTransaction as deprecated

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -63,6 +63,8 @@ type StateDB interface {
 
 	BeginTransaction()
 	EndTransaction()
+
+	// Deprecated: not necessary, to be removed
 	AbortTransaction()
 
 	BeginBlock()
@@ -993,6 +995,7 @@ func (s *stateDB) EndTransaction() {
 	s.resetTransactionContext()
 }
 
+// Deprecated: not necessary, to be removed
 func (s *stateDB) AbortTransaction() {
 	// Revert all effects and reset transaction context.
 	s.RevertToSnapshot(0)


### PR DESCRIPTION
Method `AbortTransaction()` of StateDB is never used in Aida of go-opera-norma - except its presence in Aida simulation, where it has a zero probability - it can be removed.

This PR marks it as deprecated for now.