### PR TITLE
Mark long-running state tests to be able to run in parallel

### DIFF
--- a/go/state/cpp_state_test.go
+++ b/go/state/cpp_state_test.go
@@ -8,189 +8,171 @@ import (
 )
 
 func TestAccountsAreInitiallyUnknown(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			account_state, _ := state.Exists(address1)
-			if account_state != false {
-				t.Errorf("Initial account is not unknown, got %v", account_state)
-			}
-		})
-	}
+		account_state, _ := state.Exists(address1)
+		if account_state != false {
+			t.Errorf("Initial account is not unknown, got %v", account_state)
+		}
+	})
 }
 
 func TestAccountsCanBeCreated(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			state.createAccount(address1)
-			account_state, _ := state.Exists(address1)
-			if account_state != true {
-				t.Errorf("Created account does not exist, got %v", account_state)
-			}
-		})
-	}
+		state.createAccount(address1)
+		account_state, _ := state.Exists(address1)
+		if account_state != true {
+			t.Errorf("Created account does not exist, got %v", account_state)
+		}
+	})
 }
 
 func TestAccountsCanBeDeleted(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			state.createAccount(address1)
-			state.deleteAccount(address1)
-			account_state, _ := state.Exists(address1)
-			if account_state != false {
-				t.Errorf("Deleted account is not deleted, got %v", account_state)
-			}
-		})
-	}
+		state.createAccount(address1)
+		state.deleteAccount(address1)
+		account_state, _ := state.Exists(address1)
+		if account_state != false {
+			t.Errorf("Deleted account is not deleted, got %v", account_state)
+		}
+	})
 }
 
 func TestReadUninitializedBalance(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			balance, err := state.GetBalance(address1)
-			if err != nil {
-				t.Fatalf("Error fetching balance: %v", err)
-			}
-			if (balance != common.Balance{}) {
-				t.Errorf("Initial balance is not zero, got %v", balance)
-			}
-		})
-	}
+		balance, err := state.GetBalance(address1)
+		if err != nil {
+			t.Fatalf("Error fetching balance: %v", err)
+		}
+		if (balance != common.Balance{}) {
+			t.Errorf("Initial balance is not zero, got %v", balance)
+		}
+	})
 }
 
 func TestWriteAndReadBalance(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			err = state.setBalance(address1, balance1)
-			if err != nil {
-				t.Fatalf("Error updating balance: %v", err)
-			}
-			balance, err := state.GetBalance(address1)
-			if err != nil {
-				t.Fatalf("Error fetching balance: %v", err)
-			}
-			if balance != balance1 {
-				t.Errorf("Invalid balance read, got %v, wanted %v", balance, balance1)
-			}
-		})
-	}
+		err = state.setBalance(address1, balance1)
+		if err != nil {
+			t.Fatalf("Error updating balance: %v", err)
+		}
+		balance, err := state.GetBalance(address1)
+		if err != nil {
+			t.Fatalf("Error fetching balance: %v", err)
+		}
+		if balance != balance1 {
+			t.Errorf("Invalid balance read, got %v, wanted %v", balance, balance1)
+		}
+	})
 }
 
 func TestReadUninitializedNonce(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			nonce, err := state.GetNonce(address1)
-			if err != nil {
-				t.Fatalf("Error fetching nonce: %v", err)
-			}
-			if (nonce != common.Nonce{}) {
-				t.Errorf("Initial nonce is not zero, got %v", nonce)
-			}
-		})
-	}
+		nonce, err := state.GetNonce(address1)
+		if err != nil {
+			t.Fatalf("Error fetching nonce: %v", err)
+		}
+		if (nonce != common.Nonce{}) {
+			t.Errorf("Initial nonce is not zero, got %v", nonce)
+		}
+	})
 }
 
 func TestWriteAndReadNonce(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			err = state.setNonce(address1, nonce1)
-			if err != nil {
-				t.Fatalf("Error updating nonce: %v", err)
-			}
-			nonce, err := state.GetNonce(address1)
-			if err != nil {
-				t.Fatalf("Error fetching nonce: %v", err)
-			}
-			if nonce != nonce1 {
-				t.Errorf("Invalid nonce read, got %v, wanted %v", nonce, nonce1)
-			}
-		})
-	}
+		err = state.setNonce(address1, nonce1)
+		if err != nil {
+			t.Fatalf("Error updating nonce: %v", err)
+		}
+		nonce, err := state.GetNonce(address1)
+		if err != nil {
+			t.Fatalf("Error fetching nonce: %v", err)
+		}
+		if nonce != nonce1 {
+			t.Errorf("Invalid nonce read, got %v, wanted %v", nonce, nonce1)
+		}
+	})
 }
 
 func TestReadUninitializedSlot(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			value, err := state.GetStorage(address1, key1)
-			if err != nil {
-				t.Fatalf("Error fetching storage slot: %v", err)
-			}
-			if (value != common.Value{}) {
-				t.Errorf("Initial value is not zero, got %v", value)
-			}
-		})
-	}
+		value, err := state.GetStorage(address1, key1)
+		if err != nil {
+			t.Fatalf("Error fetching storage slot: %v", err)
+		}
+		if (value != common.Value{}) {
+			t.Errorf("Initial value is not zero, got %v", value)
+		}
+	})
 }
 
 func TestWriteAndReadSlot(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			err = state.setStorage(address1, key1, val1)
-			if err != nil {
-				t.Fatalf("Error updating storage: %v", err)
-			}
-			value, err := state.GetStorage(address1, key1)
-			if err != nil {
-				t.Fatalf("Error fetching storage slot: %v", err)
-			}
-			if value != val1 {
-				t.Errorf("Invalid value read, got %v, wanted %v", value, val1)
-			}
-		})
-	}
+		err = state.setStorage(address1, key1, val1)
+		if err != nil {
+			t.Fatalf("Error updating storage: %v", err)
+		}
+		value, err := state.GetStorage(address1, key1)
+		if err != nil {
+			t.Fatalf("Error fetching storage slot: %v", err)
+		}
+		if value != val1 {
+			t.Errorf("Invalid value read, got %v, wanted %v", value, val1)
+		}
+	})
 }
 
 func getTestCodeOfLength(size int) []byte {
@@ -214,63 +196,59 @@ func getTestCodes() [][]byte {
 }
 
 func TestSetAndGetCode(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			for _, code := range getTestCodes() {
-				err := state.setCode(address1, code)
-				if err != nil {
-					t.Fatalf("Error setting code: %v", err)
-				}
-				value, err := state.GetCode(address1)
-				if err != nil {
-					t.Fatalf("Error fetching code: %v", err)
-				}
-				if !bytes.Equal(code, value) {
-					t.Errorf("Invalid value read, got %v, wanted %v", value, code)
-				}
-				size, err := state.GetCodeSize(address1)
-				if err != nil {
-					t.Fatalf("Error fetching code size: %v", err)
-				}
-				if size != len(code) {
-					t.Errorf("Invalid value size read, got %v, wanted %v", size, len(code))
-				}
+		for _, code := range getTestCodes() {
+			err := state.setCode(address1, code)
+			if err != nil {
+				t.Fatalf("Error setting code: %v", err)
 			}
-		})
-	}
+			value, err := state.GetCode(address1)
+			if err != nil {
+				t.Fatalf("Error fetching code: %v", err)
+			}
+			if !bytes.Equal(code, value) {
+				t.Errorf("Invalid value read, got %v, wanted %v", value, code)
+			}
+			size, err := state.GetCodeSize(address1)
+			if err != nil {
+				t.Fatalf("Error fetching code size: %v", err)
+			}
+			if size != len(code) {
+				t.Errorf("Invalid value size read, got %v, wanted %v", size, len(code))
+			}
+		}
+	})
 }
 
 func TestSetAndGetCodeHash(t *testing.T) {
-	for _, config := range initCppStates() {
-		t.Run(config.name, func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s", config.name)
-			}
-			defer state.Close()
+	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
+		state, err := config.createState(t.TempDir())
+		if err != nil {
+			t.Fatalf("failed to initialize state %s", config.name)
+		}
+		defer state.Close()
 
-			for _, code := range getTestCodes() {
-				err := state.setCode(address1, code)
-				if err != nil {
-					t.Fatalf("Error setting code: %v", err)
-				}
-				hash, err := state.GetCodeHash(address1)
-				if err != nil {
-					t.Fatalf("Error fetching code: %v", err)
-				}
-				want := common.GetKeccak256Hash(code)
-				if hash != want {
-					t.Errorf("Invalid code hash, got %v, wanted %v", hash, want)
-				}
+		for _, code := range getTestCodes() {
+			err := state.setCode(address1, code)
+			if err != nil {
+				t.Fatalf("Error setting code: %v", err)
 			}
-		})
-	}
+			hash, err := state.GetCodeHash(address1)
+			if err != nil {
+				t.Fatalf("Error fetching code: %v", err)
+			}
+			want := common.GetKeccak256Hash(code)
+			if hash != want {
+				t.Errorf("Invalid code hash, got %v, wanted %v", hash, want)
+			}
+		}
+	})
 }
 
 func initCppStates() []namedStateConfig {
@@ -283,4 +261,14 @@ func initCppStates() []namedStateConfig {
 		}...)
 	}
 	return list
+}
+
+func runForEachCppConfig(t *testing.T, test func(*testing.T, *namedStateConfig)) {
+	for _, config := range initCppStates() {
+		config := config
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+			test(t, &config)
+		})
+	}
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -2884,7 +2884,10 @@ func TestCarmenThereCanBeMultipleBulkLoadPhases(t *testing.T) {
 func TestCarmenThereCanBeMultipleBulkLoadPhasesOnRealState(t *testing.T) {
 	for _, config := range initStates() {
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				state, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -2909,7 +2912,10 @@ func TestCarmenThereCanBeMultipleBulkLoadPhasesOnRealState(t *testing.T) {
 func TestCarmenBulkLoadsCanBeInterleavedWithRegularUpdates(t *testing.T) {
 	for _, config := range initStates() {
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				state, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -2971,7 +2977,9 @@ func testCarmenStateDbHashAfterModification(t *testing.T, mod func(s StateDB)) {
 	}
 	for i := 0; i < 3; i++ {
 		for _, config := range initStates() {
+			config := config
 			t.Run(fmt.Sprintf("%v/run=%d", config.name, i), func(t *testing.T) {
+				t.Parallel()
 				state, err := config.createState(t.TempDir())
 				if err != nil {
 					t.Fatalf("failed to initialize state %s", config.name)
@@ -3087,7 +3095,10 @@ func TestPersistentStateDB(t *testing.T) {
 			continue
 		}
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				s, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -3267,7 +3278,10 @@ func toKey(key uint64) common.Key {
 func TestStateDBArchive(t *testing.T) {
 	for _, config := range initStates() {
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				s, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -3325,7 +3339,10 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 	const M = 100 // number of updates per goroutine
 	for _, config := range initStates() {
 		for _, archiveType := range []ArchiveType{NoArchive /*LevelDbArchive, SqliteArchive*/} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				state, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -53,7 +53,9 @@ func initStates() []namedStateConfig {
 
 func testEachConfiguration(t *testing.T, test func(t *testing.T, config *namedStateConfig, s directUpdateState)) {
 	for _, config := range initStates() {
+		config := config
 		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
 			state, err := config.createState(t.TempDir())
 			if err != nil {
 				t.Fatalf("failed to initialize state %s", config.name)
@@ -402,7 +404,10 @@ func TestDeleteAccountClearsStorage(t *testing.T) {
 func TestArchive(t *testing.T) {
 	for _, config := range initStates() {
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			config := config
+			archiveType := archiveType
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 				dir := t.TempDir()
 				s, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -513,7 +518,10 @@ func TestPersistentState(t *testing.T) {
 			continue
 		}
 		for _, archiveType := range []ArchiveType{LevelDbArchive, SqliteArchive} {
+			archiveType := archiveType
+			config := config
 			t.Run(fmt.Sprintf("%s-%s", config.name, archiveType), func(t *testing.T) {
+				t.Parallel()
 
 				dir := t.TempDir()
 				s, err := config.createStateWithArchive(dir, archiveType)


### PR DESCRIPTION
Running those tests in parallel reduces the execution time of tests from ~200s to ~50s.