### PR TITLE
Add 4-bit Nibble type and utilities

### DIFF
--- a/go/state/s4/nibble.go
+++ b/go/state/s4/nibble.go
@@ -1,0 +1,66 @@
+package s4
+
+import "github.com/Fantom-foundation/Carmen/go/common"
+
+// Nibble is a 4-bit signed integer in the range 0-F. It is a single letter
+// used to navigate in the MPT structure.
+type Nibble byte
+
+// Rune converts a Nibble in a hexa-decimal rune (0-9a-f).
+func (n Nibble) Rune() rune {
+	if n < 10 {
+		return rune('0' + n)
+	} else if n < 16 {
+		return rune('a' + n - 10)
+	} else {
+		return '?'
+	}
+}
+
+// String converts a Nibble in a hexa-decimal stirng (0-9a-f).
+func (n Nibble) String() string {
+	return string(n.Rune())
+}
+
+// AddressToNibbles converts a common.Address into a fixed-length sequence of
+// Nibbles. Slices of Nibbles are the main format used while navigating MPTs.
+func AddressToNibbles(addr common.Address) [40]Nibble {
+	var res [40]Nibble
+	parseNibbles(res[:], addr[:])
+	return res
+}
+
+// KeyToNibbles converts a common.Key into a fixed-length sequence of Nibbles.
+// Slices of Nibbles are the main format used while navigating MPTs.
+func KeyToNibbles(key common.Key) [64]Nibble {
+	var res [64]Nibble
+	parseNibbles(res[:], key[:])
+	return res
+}
+
+func parseNibbles(dst []Nibble, src []byte) {
+	for i := 0; i < len(src); i++ {
+		dst[2*i] = Nibble(src[i] >> 4)
+		dst[2*i+1] = Nibble(src[i] & 0xF)
+	}
+}
+
+// GetCommonPrefixLength computes the length of the common prefix of the given
+// Nibble-slices.
+func GetCommonPrefixLength(a, b []Nibble) int {
+	lengthA := len(a)
+	if lengthA > len(b) {
+		return GetCommonPrefixLength(b, a)
+	}
+	for i := 0; i < lengthA; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return lengthA
+}
+
+// IsPrefixOf tests whether one Nibble slice is the prefix of another.
+func IsPrefixOf(a, b []Nibble) bool {
+	return len(a) <= len(b) && GetCommonPrefixLength(a, b) == len(a)
+}

--- a/go/state/s4/nibble_test.go
+++ b/go/state/s4/nibble_test.go
@@ -1,0 +1,105 @@
+package s4
+
+import "testing"
+
+func TestNibble_Print(t *testing.T) {
+	tests := []struct {
+		value Nibble
+		print string
+	}{
+		{Nibble(0), "0"},
+		{Nibble(1), "1"},
+		{Nibble(2), "2"},
+		{Nibble(3), "3"},
+		{Nibble(4), "4"},
+		{Nibble(5), "5"},
+		{Nibble(6), "6"},
+		{Nibble(7), "7"},
+		{Nibble(8), "8"},
+		{Nibble(9), "9"},
+		{Nibble(10), "a"},
+		{Nibble(11), "b"},
+		{Nibble(12), "c"},
+		{Nibble(13), "d"},
+		{Nibble(14), "e"},
+		{Nibble(15), "f"},
+		{Nibble(16), "?"},
+		{Nibble(255), "?"},
+	}
+
+	for _, test := range tests {
+		if got, want := test.value.String(), test.print; got != want {
+			t.Errorf("invalid print, got %s, wanted %s", got, want)
+		}
+	}
+}
+
+func TestNibbles_GetCommonPrefix(t *testing.T) {
+	tests := []struct {
+		a, b []byte
+		res  int
+	}{
+		{[]byte{}, []byte{}, 0},
+		{[]byte{}, []byte{1}, 0},
+		{[]byte{1}, []byte{}, 0},
+
+		{[]byte{1}, []byte{1}, 1},
+		{[]byte{1, 2}, []byte{1, 2}, 2},
+		{[]byte{1, 2, 3}, []byte{1, 2, 3}, 3},
+
+		{[]byte{1, 2, 3}, []byte{1, 2, 3, 4, 5}, 3},
+		{[]byte{1, 2, 3, 4, 5}, []byte{1, 2, 3}, 3},
+
+		{[]byte{1, 2, 3}, []byte{1, 3, 2}, 1},
+		{[]byte{1, 2, 3}, []byte{3, 2, 1}, 0},
+	}
+
+	for _, test := range tests {
+		a := make([]Nibble, len(test.a))
+		for i, cur := range test.a {
+			a[i] = Nibble(cur)
+		}
+		b := make([]Nibble, len(test.b))
+		for i, cur := range test.b {
+			b[i] = Nibble(cur)
+		}
+		if got, want := GetCommonPrefixLength(a, b), test.res; got != want {
+			t.Errorf("invalid common prefix length of %v and %v, got %d, wanted %d", a, b, got, want)
+		}
+	}
+}
+
+func TestNibbles_IsPrefixOf(t *testing.T) {
+	tests := []struct {
+		a, b []byte
+		res  bool
+	}{
+		{[]byte{}, []byte{}, true},
+		{[]byte{}, []byte{1}, true},
+		{[]byte{1}, []byte{}, false},
+
+		{[]byte{1}, []byte{1}, true},
+		{[]byte{1, 2}, []byte{1, 2}, true},
+		{[]byte{1, 2, 3}, []byte{1, 2, 3}, true},
+
+		{[]byte{1, 2, 3}, []byte{1, 2, 3, 4, 5}, true},
+		{[]byte{1, 2, 3, 4, 5}, []byte{1, 2, 3}, false},
+
+		{[]byte{1, 2, 3}, []byte{1, 3, 2}, false},
+		{[]byte{1, 2, 3}, []byte{3, 2, 1}, false},
+	}
+
+	for _, test := range tests {
+		a := make([]Nibble, len(test.a))
+		for i, cur := range test.a {
+			a[i] = Nibble(cur)
+		}
+		b := make([]Nibble, len(test.b))
+		for i, cur := range test.b {
+			b[i] = Nibble(cur)
+		}
+		if got, want := IsPrefixOf(a, b), test.res; got != want {
+			t.Errorf("invalid is-prefix-of result for %v and %v, got %t, wanted %t", a, b, got, want)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces a 4-bit token representation and some utilities known in the MPT implementation as a Nibble. It is the smallest unit used in an MPT for navigating the trie.