### PR TITLE
Add hashing and forest infrastructure

### DIFF
--- a/go/state/s4/forest.go
+++ b/go/state/s4/forest.go
@@ -1,0 +1,600 @@
+package s4
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"reflect"
+	"sort"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/stock"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/file"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/memory"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/shadow"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+type StorageMode bool
+
+const (
+	// Archive is the mode of an archive or a read-only state on the disk.
+	// All nodes written to disk will be finalized and never updated again.
+	Archive StorageMode = true
+	// Live is the mode of an archive in which the state on the disk can be
+	// modified through destructive updates.
+	Live StorageMode = false
+)
+
+func (m StorageMode) String() string {
+	switch m {
+	case Archive:
+		return "Archive"
+	case Live:
+		return "Live"
+	default:
+		return "?"
+	}
+}
+
+// Forest is a utility node managing nodes for one or more Tries.
+// It provides the common foundation for the Live and Archive Tries.
+type Forest struct {
+	// The stock containers managing individual node types.
+	branches   stock.Stock[uint64, BranchNode]
+	extensions stock.Stock[uint64, ExtensionNode]
+	accounts   stock.Stock[uint64, AccountNode]
+	values     stock.Stock[uint64, ValueNode]
+
+	// Indicates whether all values in the stock should be considered
+	// frozen, and thus immutable as required for the archive case or
+	// mutable, as for the live-db-only case.
+	storageMode StorageMode
+
+	// A unified cache for all node types.
+	nodeCache *common.Cache[NodeId, Node]
+
+	// The set of dirty nodes. Nodes are dirty if there in-memory
+	// state does not match their on-disk content.
+	dirty map[NodeId]struct{}
+
+	// The hasher used to compute state hashes.
+	hasher Hasher
+
+	// A store for hashes.
+	hashes      HashStore
+	dirtyHashes map[NodeId]struct{}
+}
+
+// The number of elements to retain in the node cache.
+const cacheCapacity = 10_000_000
+
+func OpenInMemoryForest(directory string, mode StorageMode) (*Forest, error) {
+	success := false
+	branches, err := memory.OpenStock[uint64, BranchNode](BranchNodeEncoder{}, directory+"/branches")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			branches.Close()
+		}
+	}()
+	extensions, err := memory.OpenStock[uint64, ExtensionNode](ExtensionNodeEncoder{}, directory+"/extensions")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			extensions.Close()
+		}
+	}()
+	accounts, err := memory.OpenStock[uint64, AccountNode](AccountNodeEncoder{}, directory+"/accounts")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			accounts.Close()
+		}
+	}()
+	values, err := memory.OpenStock[uint64, ValueNode](ValueNodeEncoder{}, directory+"/values")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			values.Close()
+		}
+	}()
+	hashes, err := OpenInMemoryHashStore(directory + "/hashes")
+	if err != nil {
+		return nil, err
+	}
+	success = true
+	return makeForest(directory, branches, extensions, accounts, values, hashes, mode)
+}
+
+func OpenFileForest(directory string, mode StorageMode) (*Forest, error) {
+	success := false
+	branches, err := file.OpenStock[uint64, BranchNode](BranchNodeEncoder{}, directory+"/branches")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			branches.Close()
+		}
+	}()
+	extensions, err := file.OpenStock[uint64, ExtensionNode](ExtensionNodeEncoder{}, directory+"/extensions")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			extensions.Close()
+		}
+	}()
+	accounts, err := file.OpenStock[uint64, AccountNode](AccountNodeEncoder{}, directory+"/accounts")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			accounts.Close()
+		}
+	}()
+	values, err := file.OpenStock[uint64, ValueNode](ValueNodeEncoder{}, directory+"/values")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !success {
+			values.Close()
+		}
+	}()
+	hashes, err := OpenFileBasedHashStore(directory + "/hashes")
+	if err != nil {
+		return nil, err
+	}
+	success = true
+	return makeForest(directory, branches, extensions, accounts, values, hashes, mode)
+}
+
+func OpenFileShadowForest(directory string, mode StorageMode) (*Forest, error) {
+	branchesA, err := file.OpenStock[uint64, BranchNode](BranchNodeEncoder{}, directory+"/A/branches")
+	if err != nil {
+		return nil, err
+	}
+	extensionsA, err := file.OpenStock[uint64, ExtensionNode](ExtensionNodeEncoder{}, directory+"/A/extensions")
+	if err != nil {
+		return nil, err
+	}
+	accountsA, err := file.OpenStock[uint64, AccountNode](AccountNodeEncoder{}, directory+"/A/accounts")
+	if err != nil {
+		return nil, err
+	}
+	valuesA, err := file.OpenStock[uint64, ValueNode](ValueNodeEncoder{}, directory+"/A/values")
+	if err != nil {
+		return nil, err
+	}
+	hashes, err := OpenFileBasedHashStore(directory + "/hashes")
+	if err != nil {
+		return nil, err
+	}
+	branchesB, err := memory.OpenStock[uint64, BranchNode](BranchNodeEncoder{}, directory+"/B/branches")
+	if err != nil {
+		return nil, err
+	}
+	extensionsB, err := memory.OpenStock[uint64, ExtensionNode](ExtensionNodeEncoder{}, directory+"/B/extensions")
+	if err != nil {
+		return nil, err
+	}
+	accountsB, err := memory.OpenStock[uint64, AccountNode](AccountNodeEncoder{}, directory+"/B/accounts")
+	if err != nil {
+		return nil, err
+	}
+	valuesB, err := memory.OpenStock[uint64, ValueNode](ValueNodeEncoder{}, directory+"/B/values")
+	if err != nil {
+		return nil, err
+	}
+	branches := shadow.MakeShadowStock(branchesA, branchesB)
+	extensions := shadow.MakeShadowStock(extensionsA, extensionsB)
+	accounts := shadow.MakeShadowStock(accountsA, accountsB)
+	values := shadow.MakeShadowStock(valuesA, valuesB)
+	return makeForest(directory, branches, extensions, accounts, values, hashes, mode)
+}
+
+func makeForest(
+	directory string,
+	branches stock.Stock[uint64, BranchNode],
+	extensions stock.Stock[uint64, ExtensionNode],
+	accounts stock.Stock[uint64, AccountNode],
+	values stock.Stock[uint64, ValueNode],
+	hashes HashStore,
+	mode StorageMode,
+) (*Forest, error) {
+	return &Forest{
+		branches:    branches,
+		extensions:  extensions,
+		accounts:    accounts,
+		values:      values,
+		storageMode: mode,
+		nodeCache:   common.NewCache[NodeId, Node](cacheCapacity),
+		dirty:       map[NodeId]struct{}{},
+		hasher:      &DirectHasher{},
+		hashes:      hashes,
+		dirtyHashes: map[NodeId]struct{}{},
+	}, nil
+}
+
+func (s *Forest) GetAccountInfo(rootId NodeId, addr common.Address) (AccountInfo, bool, error) {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return AccountInfo{}, false, err
+	}
+	path := AddressToNibbles(addr)
+	return root.GetAccount(s, addr, path[:])
+}
+
+func (s *Forest) SetAccountInfo(rootId NodeId, addr common.Address, info AccountInfo) (NodeId, error) {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return NodeId(0), err
+	}
+	path := AddressToNibbles(addr)
+	newRoot, _, err := root.SetAccount(s, rootId, addr, path[:], info)
+	if err != nil {
+		return NodeId(0), err
+	}
+	return newRoot, nil
+}
+
+func (s *Forest) GetValue(rootId NodeId, addr common.Address, key common.Key) (common.Value, error) {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return common.Value{}, err
+	}
+	path := AddressToNibbles(addr)
+	value, _, err := root.GetSlot(s, addr, path[:], key)
+	return value, err
+}
+
+func (s *Forest) SetValue(rootId NodeId, addr common.Address, key common.Key, value common.Value) (NodeId, error) {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return NodeId(0), err
+	}
+	path := AddressToNibbles(addr)
+	newRoot, _, err := root.SetSlot(s, rootId, addr, path[:], key, value)
+	if err != nil {
+		return NodeId(0), err
+	}
+	return newRoot, nil
+}
+
+func (s *Forest) ClearStorage(rootId NodeId, addr common.Address) error {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return err
+	}
+	path := AddressToNibbles(addr)
+	_, _, err = root.ClearStorage(s, rootId, addr, path[:])
+	return err
+}
+
+func (s *Forest) GetHashFor(id NodeId) (common.Hash, error) {
+	// The empty node is forced to have the empty hash.
+	if id.IsEmpty() {
+		return common.Hash{}, nil
+	}
+	// Non-dirty hashes can be taken from the store.
+	if _, dirty := s.dirtyHashes[id]; !dirty {
+		return s.hashes.Get(id)
+	}
+
+	// Dirty hashes need to be re-freshed.
+	node, err := s.getNode(id)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	hash, err := s.hasher.GetHash(node, s)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if err := s.hashes.Set(id, hash); err != nil {
+		return hash, err
+	}
+	delete(s.dirtyHashes, id)
+	return hash, nil
+}
+
+func (f *Forest) Freeze(id NodeId) error {
+	if f.storageMode != Archive {
+		return fmt.Errorf("node-freezing only supported in archive mode")
+	}
+	root, err := f.getNode(id)
+	if err != nil {
+		return err
+	}
+	return root.Freeze(f)
+}
+
+func (s *Forest) Flush() error {
+	// Flush dirty keys in order (to avoid excessive seeking).
+	ids := make([]NodeId, len(s.dirty))
+	for id := range s.dirty {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	var errs = []error{}
+	for _, id := range ids {
+		node, present := s.nodeCache.Get(id)
+		if present {
+			if err := s.flush(id, node); err != nil {
+				errs = append(errs, err)
+			}
+		} else {
+			errs = append(errs, fmt.Errorf("missing dirty node %v in node cache", id))
+		}
+	}
+
+	// Update hashes for dirty nodes.
+	dirty := make([]NodeId, len(s.dirty))
+	for id := range s.dirty {
+		dirty = append(dirty, id)
+	}
+	for _, id := range dirty {
+		if _, err := s.GetHashFor(id); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(
+		errors.Join(errs...),
+		s.accounts.Flush(),
+		s.branches.Flush(),
+		s.extensions.Flush(),
+		s.values.Flush(),
+		s.hashes.Flush(),
+	)
+}
+
+func (s *Forest) Close() error {
+	return errors.Join(
+		s.Flush(),
+		s.accounts.Close(),
+		s.branches.Close(),
+		s.extensions.Close(),
+		s.values.Close(),
+		s.hashes.Close(),
+	)
+}
+
+// GetMemoryFootprint provides sizes of individual components of the state in the memory
+func (s *Forest) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
+	mf.AddChild("accounts", s.accounts.GetMemoryFootprint())
+	mf.AddChild("branches", s.branches.GetMemoryFootprint())
+	mf.AddChild("extensions", s.extensions.GetMemoryFootprint())
+	mf.AddChild("values", s.values.GetMemoryFootprint())
+	mf.AddChild("cache", s.nodeCache.GetDynamicMemoryFootprint(func(node Node) uintptr {
+		if _, ok := node.(*AccountNode); ok {
+			return unsafe.Sizeof(AccountNode{})
+		}
+		if _, ok := node.(*BranchNode); ok {
+			return unsafe.Sizeof(BranchNode{})
+		}
+		if _, ok := node.(EmptyNode); ok {
+			return unsafe.Sizeof(EmptyNode{})
+		}
+		if _, ok := node.(*ExtensionNode); ok {
+			return unsafe.Sizeof(ExtensionNode{})
+		}
+		if _, ok := node.(*ValueNode); ok {
+			return unsafe.Sizeof(ValueNode{})
+		}
+		panic(fmt.Sprintf("unexpected node type: %v", reflect.TypeOf(node)))
+	}))
+	mf.AddChild("hashes", s.hashes.GetMemoryFootprint())
+	mf.AddChild("dirtyHashes", common.NewMemoryFootprint(uintptr(len(s.dirtyHashes))*unsafe.Sizeof(NodeId(0))))
+	return mf
+}
+
+// Dump prints the content of the Trie to the console. Mainly intended for debugging.
+func (s *Forest) Dump(rootId NodeId) {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		fmt.Printf("Failed to fetch root: %v", err)
+	} else {
+		root.Dump(s, rootId, "")
+	}
+}
+
+// Check verifies internal invariants of the Trie instance. If the trie is
+// self-consistent, nil is returned and the Trie is read to be accessed. If
+// errors are detected, the Trie is to be considered in an invalid state and
+// the behaviour of all other operations is undefined.
+func (s *Forest) Check(rootId NodeId) error {
+	root, err := s.getNode(rootId)
+	if err != nil {
+		return err
+	}
+	return root.Check(s, make([]Nibble, 0, common.AddressSize*2))
+}
+
+// -- NodeManager interface --
+
+func (s *Forest) getNode(id NodeId) (Node, error) {
+	// Start by checking the node cache.
+	res, found := s.nodeCache.Get(id)
+	if found {
+		return res, nil
+	}
+
+	// Load the node from peristent storage.
+	var node Node
+	var err error
+	if id.IsValue() {
+		value, e := s.values.Get(id.Index())
+		node, err = &value, e
+	} else if id.IsAccount() {
+		value, e := s.accounts.Get(id.Index())
+		node, err = &value, e
+	} else if id.IsBranch() {
+		value, e := s.branches.Get(id.Index())
+		node, err = &value, e
+	} else if id.IsExtension() {
+		value, e := s.extensions.Get(id.Index())
+		node, err = &value, e
+	} else if id.IsEmpty() {
+		node = EmptyNode{}
+	} else {
+		err = fmt.Errorf("unknown node ID: %v", id)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if node == nil {
+		return nil, fmt.Errorf("no node with ID %d in storage", id)
+	}
+
+	// Everything that is loaded from an archive is to be considered
+	// frozen, and thus immutable.
+	if s.storageMode == Archive {
+		node.MarkFrozen()
+	}
+
+	if err := s.addToCache(id, node); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+func (s *Forest) addToCache(id NodeId, node Node) error {
+	if evictedId, evictedNode, evicted := s.nodeCache.Set(id, node); evicted {
+		// TODO: perform flush asynchroniously.
+		if err := s.flush(evictedId, evictedNode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Forest) flush(id NodeId, node Node) error {
+	// Note: flushing nodes in Archive mode will implicitly freeze them,
+	// since after the reload they will be considered frozen. This may
+	// cause temporary states between updates to be accidentially frozen,
+	// leaving unreferenced nodes in the archive, but it is not causing
+	// correctness issues. However, if the node-cache size is sufficiently
+	// large, such cases should be rare. Nevertheless, a warning is
+	// printed here to get informed if this changes in the future.
+	if s.storageMode == Archive && !node.IsFrozen() {
+		log.Printf("WARNING: non-frozen node flushed to disk causing implicit freeze")
+	}
+
+	if _, dirty := s.dirty[id]; !dirty {
+		return nil
+	}
+	delete(s.dirty, id)
+	if id.IsValue() {
+		return s.values.Set(id.Index(), *node.(*ValueNode))
+	} else if id.IsAccount() {
+		return s.accounts.Set(id.Index(), *node.(*AccountNode))
+	} else if id.IsBranch() {
+		return s.branches.Set(id.Index(), *node.(*BranchNode))
+	} else if id.IsExtension() {
+		return s.extensions.Set(id.Index(), *node.(*ExtensionNode))
+	} else if id.IsEmpty() {
+		return nil
+	} else {
+		return fmt.Errorf("unknown node ID: %v", id)
+	}
+}
+
+func (s *Forest) createAccount() (NodeId, *AccountNode, error) {
+	i, err := s.accounts.New()
+	if err != nil {
+		return 0, nil, err
+	}
+	id := AccountId(i)
+	node := new(AccountNode)
+	if err := s.addToCache(id, node); err != nil {
+		return 0, nil, err
+	}
+	return id, node, err
+}
+
+func (s *Forest) createBranch() (NodeId, *BranchNode, error) {
+	i, err := s.branches.New()
+	if err != nil {
+		return 0, nil, err
+	}
+	id := BranchId(i)
+	node := new(BranchNode)
+	if err := s.addToCache(id, node); err != nil {
+		return 0, nil, err
+	}
+	return id, node, err
+}
+
+func (s *Forest) createExtension() (NodeId, *ExtensionNode, error) {
+	i, err := s.extensions.New()
+	if err != nil {
+		return 0, nil, err
+	}
+	id := ExtensionId(i)
+	node := new(ExtensionNode)
+	if err := s.addToCache(id, node); err != nil {
+		return 0, nil, err
+	}
+	return id, node, err
+}
+
+func (s *Forest) createValue() (NodeId, *ValueNode, error) {
+	i, err := s.values.New()
+	if err != nil {
+		return 0, nil, err
+	}
+	id := ValueId(i)
+	node := new(ValueNode)
+	if err := s.addToCache(id, node); err != nil {
+		return 0, nil, err
+	}
+	return id, node, err
+}
+
+func (s *Forest) update(id NodeId, node Node) error {
+	// all needed here is to register the modfied node as dirty
+	s.dirty[id] = struct{}{}
+	// ... and to invalidate the nodes hash.
+	s.invalidateHash(id)
+	return nil
+}
+
+func (s *Forest) invalidateHash(id NodeId) {
+	// by adding it to the dirty hashes set the hash will be
+	// re-evaluated the next time.
+	if !id.IsEmpty() {
+		s.dirtyHashes[id] = struct{}{}
+	}
+}
+
+func (s *Forest) release(id NodeId) error {
+	s.nodeCache.Remove(id)
+	delete(s.dirty, id)
+	delete(s.dirtyHashes, id)
+	if id.IsAccount() {
+		return s.accounts.Delete(id.Index())
+	}
+	if id.IsBranch() {
+		return s.branches.Delete(id.Index())
+	}
+	if id.IsExtension() {
+		return s.extensions.Delete(id.Index())
+	}
+	if id.IsValue() {
+		return s.values.Delete(id.Index())
+	}
+	return fmt.Errorf("unable to release node %v", id)
+}

--- a/go/state/s4/forest_test.go
+++ b/go/state/s4/forest_test.go
@@ -1,0 +1,247 @@
+package s4
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+var configurations = []struct {
+	name    string
+	factory func(directory string, mode StorageMode) (*Forest, error)
+}{
+	{"InMemory", OpenInMemoryForest},
+	{"FileBased", OpenFileForest},
+	{"FileShadow", OpenFileShadowForest},
+}
+
+func TestForest_OpenAndClose(t *testing.T) {
+	for _, config := range configurations {
+		for _, mode := range []StorageMode{Live, Archive} {
+			t.Run(fmt.Sprintf("%s-%s", config.name, mode), func(t *testing.T) {
+				forest, err := config.factory(t.TempDir(), mode)
+				if err != nil {
+					t.Fatalf("failed to open forest: %v", err)
+				}
+				if err := forest.Close(); err != nil {
+					t.Fatalf("failed to close forest: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestForest_ClosedAndReOpened(t *testing.T) {
+	for _, config := range configurations {
+		for _, mode := range []StorageMode{Live, Archive} {
+			t.Run(fmt.Sprintf("%s-%s", config.name, mode), func(t *testing.T) {
+				directory := t.TempDir()
+
+				forest, err := config.factory(directory, mode)
+				if err != nil {
+					t.Fatalf("failed to open forest: %v", err)
+				}
+
+				addr := common.Address{1}
+				info := AccountInfo{Nonce: common.Nonce{12}}
+
+				root := EmptyId()
+				root, err = forest.SetAccountInfo(root, addr, info)
+				if err != nil {
+					t.Fatalf("failed to set account info: %v", err)
+				}
+
+				if err := forest.Close(); err != nil {
+					t.Fatalf("failed to close forest: %v", err)
+				}
+
+				reopened, err := config.factory(directory, mode)
+				if err != nil {
+					t.Fatalf("failed to re-open forest: %v", err)
+				}
+
+				if got, found, err := reopened.GetAccountInfo(root, addr); info != got || !found || err != nil {
+					t.Fatalf("reopened forest does not contain expected value, wanted %v, got %v, found %t, err %v", info, got, found, err)
+				}
+
+				if err := reopened.Close(); err != nil {
+					t.Fatalf("failed to close forest: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestForest_ArchiveInfoCanBeSetAndRetrieved(t *testing.T) {
+	for _, config := range configurations {
+		for _, mode := range []StorageMode{Live, Archive} {
+			t.Run(fmt.Sprintf("%s-%s", config.name, mode), func(t *testing.T) {
+				forest, err := config.factory(t.TempDir(), mode)
+				if err != nil {
+					t.Fatalf("failed to open forest: %v", err)
+				}
+
+				addr := common.Address{1}
+				info0 := AccountInfo{}
+				info1 := AccountInfo{Nonce: common.Nonce{12}}
+
+				root := EmptyId()
+				if info, found, err := forest.GetAccountInfo(root, addr); info != info0 || found || err != nil {
+					t.Errorf("empty tree should not contain any info, wanted (%v,%t), got (%v,%t), err %v", info0, false, info, true, err)
+				}
+
+				root, err = forest.SetAccountInfo(root, addr, info1)
+				if err != nil {
+					t.Fatalf("failed to set account info: %v", err)
+				}
+
+				if info, found, err := forest.GetAccountInfo(root, addr); info != info1 || !found || err != nil {
+					t.Errorf("empty tree should not contain any info, wanted (%v,%t), got (%v,%t), err %v", info1, true, info, true, err)
+				}
+
+				if err := forest.Close(); err != nil {
+					t.Fatalf("failed to close forest: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestForest_ValueCanBeSetAndRetrieved(t *testing.T) {
+	for _, config := range configurations {
+		for _, mode := range []StorageMode{Live, Archive} {
+			t.Run(fmt.Sprintf("%s-%s", config.name, mode), func(t *testing.T) {
+				forest, err := config.factory(t.TempDir(), mode)
+				if err != nil {
+					t.Fatalf("failed to open forest: %v", err)
+				}
+
+				addr := common.Address{1}
+				info := AccountInfo{Nonce: common.Nonce{12}}
+				key := common.Key{12}
+				value0 := common.Value{}
+				value1 := common.Value{1}
+
+				// Initially, the value is zero.
+				root := EmptyId()
+				if value, err := forest.GetValue(root, addr, key); value != value0 || err != nil {
+					t.Errorf("empty tree should not contain any info, wanted %v, got %v, err %v", value0, value, err)
+				}
+
+				// Setting it without an account does nto have an effect.
+				if newRoot, err := forest.SetValue(root, addr, key, value1); newRoot != root || err != nil {
+					t.Errorf("setting a value without an account should not change the root, wanted %v, got %v, err %v", root, newRoot, err)
+				}
+
+				// Setting the value of an existing account should have an effect.
+				root, err = forest.SetAccountInfo(root, addr, info)
+				if err != nil {
+					t.Fatalf("failed to create an account: %v", err)
+				}
+
+				if root, err = forest.SetValue(root, addr, key, value1); err != nil {
+					t.Errorf("setting a value failed: %v", err)
+				}
+
+				if value, err := forest.GetValue(root, addr, key); value != value1 || err != nil {
+					t.Errorf("value should be contained now, wanted %v, got %v, err %v", value1, value, err)
+				}
+
+				if err := forest.Check(root); err != nil {
+					t.Errorf("inconsistent trie: %v", err)
+				}
+
+				if err := forest.Close(); err != nil {
+					t.Fatalf("failed to close forest: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestForest_InLiveModeHistoryIsOverridden(t *testing.T) {
+	for _, config := range configurations {
+		t.Run(config.name, func(t *testing.T) {
+			forest, err := config.factory(t.TempDir(), Live)
+			if err != nil {
+				t.Fatalf("failed to open forest: %v", err)
+			}
+
+			addr := common.Address{1}
+			info1 := AccountInfo{Nonce: common.Nonce{12}}
+			info2 := AccountInfo{Nonce: common.Nonce{14}}
+
+			// Initially, the value is zero.
+			root0 := EmptyId()
+
+			// Update the account info in two steps.
+			root1, err := forest.SetAccountInfo(root0, addr, info1)
+			if err != nil {
+				t.Fatalf("failed to create an account: %v", err)
+			}
+
+			root2, err := forest.SetAccountInfo(root1, addr, info2)
+			if err != nil {
+				t.Fatalf("failed to create an account: %v", err)
+			}
+
+			// The second update should have not introduced a new root.
+			if root1 != root2 {
+				t.Errorf("expeted same root, got %v and %v", root1, root2)
+			}
+			if info, found, err := forest.GetAccountInfo(root1, addr); info != info2 || !found || err != nil {
+				t.Errorf("invalid version information, wanted %v, got %v, found %t, err %v", info2, info, found, err)
+			}
+		})
+	}
+}
+
+func TestForest_InArchiveModeHistoryIsPreserved(t *testing.T) {
+	for _, config := range configurations {
+		t.Run(config.name, func(t *testing.T) {
+			forest, err := config.factory(t.TempDir(), Archive)
+			if err != nil {
+				t.Fatalf("failed to open forest: %v", err)
+			}
+
+			addr := common.Address{1}
+			info1 := AccountInfo{Nonce: common.Nonce{12}}
+			info2 := AccountInfo{Nonce: common.Nonce{14}}
+
+			// Initially, the value is zero.
+			root0 := EmptyId()
+			if err := forest.Freeze(root0); err != nil {
+				t.Errorf("failed to freeze root0: %v", err)
+			}
+
+			// Update the account info in two steps.
+			root1, err := forest.SetAccountInfo(root0, addr, info1)
+			if err != nil {
+				t.Fatalf("failed to create an account: %v", err)
+			}
+			if err := forest.Freeze(root1); err != nil {
+				t.Errorf("failed to freeze root1: %v", err)
+			}
+
+			root2, err := forest.SetAccountInfo(root1, addr, info2)
+			if err != nil {
+				t.Fatalf("failed to create an account: %v", err)
+			}
+			if err := forest.Freeze(root2); err != nil {
+				t.Errorf("failed to freeze root2: %v", err)
+			}
+
+			// All versions should still be accessable.
+			if info, found, err := forest.GetAccountInfo(root1, addr); info != info1 || !found || err != nil {
+				t.Errorf("invalid version information, wanted %v, got %v, found %t, err %v", info1, info, found, err)
+			}
+			if info, found, err := forest.GetAccountInfo(root1, addr); info != info1 || !found || err != nil {
+				t.Errorf("invalid version information, wanted %v, got %v, found %t, err %v", info1, info, found, err)
+			}
+			if info, found, err := forest.GetAccountInfo(root2, addr); info != info2 || !found || err != nil {
+				t.Errorf("invalid version information, wanted %v, got %v, found %t, err %v", info2, info, found, err)
+			}
+		})
+	}
+}

--- a/go/state/s4/hash_store.go
+++ b/go/state/s4/hash_store.go
@@ -1,0 +1,307 @@
+package s4
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/utils"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// HashStore is an interface for a component capable of storing hashes for
+// nodes on secondary storage.
+type HashStore interface {
+	// Get retrieves the hash of a node retained in this store. Returns the
+	// zero-hash if the hash has not been set before.
+	Get(NodeId) (common.Hash, error)
+	// Set updates the retained hash for a given node.
+	Set(NodeId, common.Hash) error
+
+	common.FlushAndCloser
+	common.MemoryFootprintProvider
+}
+
+// ----------------------------------------------------------------------------
+//                          In-Memory Hash Store
+// ----------------------------------------------------------------------------
+
+// inMemoryHashStore retains all hashes in an in-memory map and only syncs its
+// content with the file system during open, flush, and close operations. It is
+// mainly intended for debugging and unit testing since its memory consumption
+// is linear in the number of retained nodes.
+type inMemoryHashStore struct {
+	hashes   map[NodeId]common.Hash
+	filename string
+}
+
+// OpenInMemoryHashStore opens a HashStore backed by a file and retaining all
+// hashes in an in-memory map. It is mainly intended for debugging and unit
+// testing since its memory consumption is linear in the number of retained
+// nodes.
+func OpenInMemoryHashStore(directory string) (HashStore, error) {
+	// Create the direcory if needed.
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
+
+	filename := directory + "/hashes.dat"
+	hashes, err := loadHashes(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &inMemoryHashStore{
+		hashes:   hashes,
+		filename: filename,
+	}, nil
+}
+
+func (s *inMemoryHashStore) Get(id NodeId) (common.Hash, error) {
+	return s.hashes[id], nil
+}
+
+func (s *inMemoryHashStore) Set(id NodeId, hash common.Hash) error {
+	s.hashes[id] = hash
+	return nil
+}
+
+func (s *inMemoryHashStore) Flush() error {
+	return storeHashes(s.filename, s.hashes)
+}
+
+func (s *inMemoryHashStore) Close() error {
+	return s.Flush()
+}
+
+func (s *inMemoryHashStore) GetMemoryFootprint() *common.MemoryFootprint {
+	return common.NewMemoryFootprint(uintptr(len(s.hashes)) * (unsafe.Sizeof(NodeId(0)) + common.HashSize))
+}
+
+func loadHashes(file string) (map[NodeId]common.Hash, error) {
+	// If there is no file, initialize and return an empty hash map.
+	if _, err := os.Stat(file); err != nil {
+		return map[NodeId]common.Hash{}, nil
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	reader := bufio.NewReader(f)
+
+	res := map[NodeId]common.Hash{}
+	var id [4]byte
+	var hash common.Hash
+	for {
+		if num, err := reader.Read(id[:]); err != nil {
+			if err == io.EOF {
+				return res, nil
+			}
+			return nil, err
+		} else if num != len(id) {
+			return nil, fmt.Errorf("invalid hash file")
+		}
+		if num, err := reader.Read(hash[:]); err != nil {
+			return nil, err
+		} else if num != len(hash) {
+			return nil, fmt.Errorf("invalid hash file")
+		}
+
+		id := NodeId(binary.BigEndian.Uint32(id[:]))
+		res[id] = hash
+	}
+}
+
+func storeHashes(file string, hashes map[NodeId]common.Hash) error {
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	writer := bufio.NewWriter(f)
+
+	// Simple file format: [<node-id>,<hash>]*
+	var buffer [4]byte
+	for id, hash := range hashes {
+		binary.BigEndian.PutUint32(buffer[:], uint32(id))
+		if _, err := writer.Write(buffer[:]); err != nil {
+			return err
+		}
+		if _, err := writer.Write(hash[:]); err != nil {
+			return err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// ----------------------------------------------------------------------------
+//                          File-Based Hash Store
+// ----------------------------------------------------------------------------
+
+// fileBasedHashStore is a HashStore implementation backed by a file that
+// retains a cache of most recently accessed hashes in memory.
+type fileBasedHashStore struct {
+	cache      *common.Cache[NodeId, common.Hash]
+	dirty      map[NodeId]struct{}
+	branches   *utils.BufferedFile
+	extensions *utils.BufferedFile
+	accounts   *utils.BufferedFile
+	values     *utils.BufferedFile
+}
+
+// OpenFileBasedHashStore opens a HashStore backed by a file and retaining a
+// cache of the most recently accessed hashes in memory. Its memory utilization
+// is thus constant. It is intended to be utilized in production.
+func OpenFileBasedHashStore(directory string) (HashStore, error) {
+	return openFileBasedHashStore(directory, 10_000_000)
+}
+
+// openFileBasedHashStore is the same as OpenFileBasedHashStore but with the
+// option to define the utilized cache size. It is mainly intended to perform
+// unit tests on reduced caches to stress-test the implementation.
+func openFileBasedHashStore(directory string, cacheSize int) (HashStore, error) {
+	// Create the direcory if needed.
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
+	branches, err := utils.OpenBufferedFile(directory + "/branches.dat")
+	if err != nil {
+		return nil, err
+	}
+	extensions, err := utils.OpenBufferedFile(directory + "/extensions.dat")
+	if err != nil {
+		branches.Close()
+		return nil, err
+	}
+	accounts, err := utils.OpenBufferedFile(directory + "/accounts.dat")
+	if err != nil {
+		branches.Close()
+		extensions.Close()
+		return nil, err
+	}
+	values, err := utils.OpenBufferedFile(directory + "/values.dat")
+	if err != nil {
+		branches.Close()
+		extensions.Close()
+		accounts.Close()
+		return nil, err
+	}
+	return &fileBasedHashStore{
+		cache:      common.NewCache[NodeId, common.Hash](cacheSize),
+		dirty:      map[NodeId]struct{}{},
+		branches:   branches,
+		extensions: extensions,
+		accounts:   accounts,
+		values:     values,
+	}, nil
+}
+
+func (s *fileBasedHashStore) Get(id NodeId) (common.Hash, error) {
+	if hash, exists := s.cache.Get(id); exists {
+		return hash, nil
+	}
+	var hash common.Hash
+	var err error
+	if id.IsAccount() {
+		err = s.accounts.Read(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsBranch() {
+		err = s.branches.Read(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsExtension() {
+		err = s.extensions.Read(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsValue() {
+		err = s.values.Read(int64(id.Index())*common.HashSize, hash[:])
+	} else {
+		err = fmt.Errorf("unsupported node ID type: %v", id)
+	}
+	if err != nil {
+		return hash, err
+	}
+	if err := s.set(id, hash); err != nil {
+		return hash, err
+	}
+	return hash, nil
+}
+
+func (s *fileBasedHashStore) Set(id NodeId, hash common.Hash) error {
+	s.dirty[id] = struct{}{}
+	return s.set(id, hash)
+}
+
+func (s *fileBasedHashStore) set(id NodeId, hash common.Hash) error {
+	if evictedId, evictedHash, evicted := s.cache.Set(id, hash); evicted {
+		if err := s.sync(evictedId, evictedHash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *fileBasedHashStore) sync(id NodeId, hash common.Hash) error {
+	// Only write the hash if it is dirty.
+	if _, present := s.dirty[id]; !present {
+		return nil
+	}
+	delete(s.dirty, id)
+	if id.IsAccount() {
+		return s.accounts.Write(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsBranch() {
+		return s.branches.Write(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsExtension() {
+		return s.extensions.Write(int64(id.Index())*common.HashSize, hash[:])
+	} else if id.IsValue() {
+		return s.values.Write(int64(id.Index())*common.HashSize, hash[:])
+	} else {
+		return fmt.Errorf("unsupported node ID type: %v", id)
+	}
+}
+
+func (s *fileBasedHashStore) Flush() error {
+	// Flush dirty hashes in order to reduce random seeking.
+	ids := make([]NodeId, 0, len(s.dirty))
+	for id := range s.dirty {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		hash, present := s.cache.Get(id)
+		if !present {
+			return fmt.Errorf("dirty hash for ID %d not present in cache", id)
+		}
+		if err := s.sync(id, hash); err != nil {
+			return err
+		}
+	}
+	return errors.Join(
+		s.branches.Flush(),
+		s.extensions.Flush(),
+		s.accounts.Flush(),
+		s.values.Flush(),
+	)
+}
+
+func (s *fileBasedHashStore) Close() error {
+	return errors.Join(
+		s.Flush(),
+		s.branches.Close(),
+		s.extensions.Close(),
+		s.accounts.Close(),
+		s.values.Close(),
+	)
+}
+
+func (s *fileBasedHashStore) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
+	mf.AddChild("cache", s.cache.GetMemoryFootprint(unsafe.Sizeof(NodeId(0)+common.HashSize)))
+	mf.AddChild("dirty", common.NewMemoryFootprint(uintptr(len(s.dirty))*unsafe.Sizeof(NodeId(0))))
+	return mf
+}

--- a/go/state/s4/hash_store_test.go
+++ b/go/state/s4/hash_store_test.go
@@ -1,0 +1,51 @@
+package s4
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func TestInMemoryHashStore_SetAndGet(t *testing.T) {
+	const N = 1000
+	store, err := OpenInMemoryHashStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	defer store.Close()
+
+	for i := 0; i < 2*N; i++ {
+		if err := store.Set(ValueId(uint64(i)), common.Hash{byte(i >> 16), byte(i >> 8), byte(i)}); err != nil {
+			t.Fatalf("failed to set hash: %v", err)
+		}
+	}
+
+	for i := 0; i < 2*N; i++ {
+		want := common.Hash{byte(i >> 16), byte(i >> 8), byte(i)}
+		if hash, err := store.Get(ValueId(uint64(i))); err != nil || hash != want {
+			t.Fatalf("fetched invalid hash for %d, got %v, wanted %v, err %v", i, hash, want, err)
+		}
+	}
+}
+
+func TestFileBasedHashStore_SetAndGet(t *testing.T) {
+	const N = 1000
+	store, err := openFileBasedHashStore(t.TempDir(), N)
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	defer store.Close()
+
+	for i := 0; i < 2*N; i++ {
+		if err := store.Set(ValueId(uint64(i)), common.Hash{byte(i >> 16), byte(i >> 8), byte(i)}); err != nil {
+			t.Fatalf("failed to set hash: %v", err)
+		}
+	}
+
+	for i := 0; i < 2*N; i++ {
+		want := common.Hash{byte(i >> 16), byte(i >> 8), byte(i)}
+		if hash, err := store.Get(ValueId(uint64(i))); err != nil || hash != want {
+			t.Fatalf("fetched invalid hash for %d, got %v, wanted %v, err %v", i, hash, want, err)
+		}
+	}
+}

--- a/go/state/s4/hasher.go
+++ b/go/state/s4/hasher.go
@@ -1,0 +1,81 @@
+package s4
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// Hasher is an interface for implementations of MPT node hashing algorithms. It is
+// intended to be one of the differentiator between S4 and derived schemas.
+type Hasher interface {
+	// GetHash requests a hash value for the given node. To compute the node's hash,
+	// implementations may recursively resolve hashes for other nodes using the given
+	// HashSource implementation. Due to its recursive nature, multiple calls to the
+	// function may be nested and/or processed concurrently. Thus, implementations are
+	// required to be reentrant and thread-safe.
+	GetHash(Node, HashSource) (common.Hash, error)
+}
+
+type HashSource interface {
+	GetHashFor(NodeId) (common.Hash, error)
+}
+
+// DirectHasher implements a simple, direct node-value hashing algorithm that combines
+// the content of individual nodes with the hashes of referenced child nodes into a
+// hash for individual nodes.
+type DirectHasher struct{}
+
+// GetHash implements the DirectHasher's hashing algorithm.
+func (h *DirectHasher) GetHash(node Node, source HashSource) (common.Hash, error) {
+	hash := common.Hash{}
+	if _, ok := node.(EmptyNode); ok {
+		return hash, nil
+	}
+	hasher := sha256.New()
+	switch node := node.(type) {
+	case *AccountNode:
+		hasher.Write([]byte{'A'})
+		hasher.Write(node.address[:])
+		hasher.Write(node.info.Balance[:])
+		hasher.Write(node.info.Nonce[:])
+		hasher.Write(node.info.CodeHash[:])
+		if hash, err := source.GetHashFor(node.state); err == nil {
+			hasher.Write(hash[:])
+		} else {
+			return hash, err
+		}
+
+	case *BranchNode:
+		hasher.Write([]byte{'B'})
+		// TODO: compute sub-tree hashes in parallel
+		for _, child := range node.children {
+			if hash, err := source.GetHashFor(child); err == nil {
+				hasher.Write(hash[:])
+			} else {
+				return hash, err
+			}
+		}
+
+	case *ExtensionNode:
+		hasher.Write([]byte{'E'})
+		hasher.Write(node.path.path[:])
+		if hash, err := source.GetHashFor(node.next); err == nil {
+			hasher.Write(hash[:])
+		} else {
+			return hash, err
+		}
+
+	case *ValueNode:
+		hasher.Write([]byte{'V'})
+		hasher.Write(node.key[:])
+		hasher.Write(node.value[:])
+
+	default:
+		return hash, fmt.Errorf("unsupported node type: %v", reflect.TypeOf(node))
+	}
+	hasher.Sum(hash[0:0])
+	return hash, nil
+}


### PR DESCRIPTION
This PR introduces the `Forest` type, organizing MPT nodes into a forest of tries.

It also introduces hashing and hash-storage infrastructure.