### PR TITLE
Add LiveTrie and State interface adapter

### DIFF
--- a/go/state/s4/live_trie.go
+++ b/go/state/s4/live_trie.go
@@ -1,0 +1,177 @@
+package s4
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// LiveTrie retains a single trie encoding state information with destructible
+// updates. Thus, whenever updating some information, the previous state is
+// lost.
+//
+// Its main role is to adapt the maintain a root node and to provide a single-
+// trie view on a forest.
+type LiveTrie struct {
+	// The node structure of the trie.
+	forest *Forest
+	// The root node of the trie.
+	root NodeId
+	// The file name for storing trie metadata.
+	metadatafile string
+}
+
+// OpenInMemoryLiveTrie loads trie information from the given directory and
+// creates a LiveTrie instance retaining all information in memory. If the
+// directory is empty, an empty trie is created.
+func OpenInMemoryLiveTrie(directory string) (*LiveTrie, error) {
+	forest, err := OpenInMemoryForest(directory, Live)
+	if err != nil {
+		return nil, err
+	}
+	return makeTrie(directory, forest)
+}
+
+// OpenInMemoryLiveTrie loads trie information from the given directory and
+// creates a LiveTrie instance using a fixed-size cache for retaining nodes in
+// memory, backed by a file-based storage automatically kept in sync. If the
+// directory is empty, an empty trie is created.
+func OpenFileLiveTrie(directory string) (*LiveTrie, error) {
+	forest, err := OpenFileForest(directory, Live)
+	if err != nil {
+		return nil, err
+	}
+	return makeTrie(directory, forest)
+}
+
+func makeTrie(
+	directory string,
+	forest *Forest,
+) (*LiveTrie, error) {
+	// Parse metadata file.
+	metadatafile := directory + "/meta.json"
+	metadata, err := readMetadata(metadatafile)
+	if err != nil {
+		return nil, err
+	}
+	return &LiveTrie{
+		root:         metadata.RootNode,
+		metadatafile: metadatafile,
+		forest:       forest,
+	}, nil
+}
+
+// getTrieView creates a live trie based on an existing Forest instance.
+func getTrieView(root NodeId, forest *Forest) *LiveTrie {
+	return &LiveTrie{
+		root:   root,
+		forest: forest,
+	}
+}
+
+func (s *LiveTrie) GetAccountInfo(addr common.Address) (AccountInfo, bool, error) {
+	return s.forest.GetAccountInfo(s.root, addr)
+}
+
+func (s *LiveTrie) SetAccountInfo(addr common.Address, info AccountInfo) error {
+	newRoot, err := s.forest.SetAccountInfo(s.root, addr, info)
+	if err != nil {
+		return err
+	}
+	s.root = newRoot
+	return nil
+}
+
+func (s *LiveTrie) GetValue(addr common.Address, key common.Key) (common.Value, error) {
+	return s.forest.GetValue(s.root, addr, key)
+}
+
+func (s *LiveTrie) SetValue(addr common.Address, key common.Key, value common.Value) error {
+	newRoot, err := s.forest.SetValue(s.root, addr, key, value)
+	if err != nil {
+		return err
+	}
+	s.root = newRoot
+	return nil
+}
+
+func (s *LiveTrie) ClearStorage(addr common.Address) error {
+	return s.forest.ClearStorage(s.root, addr)
+}
+
+func (s *LiveTrie) GetHash() (common.Hash, error) {
+	return s.forest.GetHashFor(s.root)
+}
+
+func (s *LiveTrie) Flush() error {
+	// Update on-disk meta-data.
+	metadata, err := json.Marshal(metadata{
+		RootNode: s.root,
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(s.metadatafile, metadata, 0600); err != nil {
+		return err
+	}
+	return s.forest.Flush()
+}
+
+func (s *LiveTrie) Close() error {
+	return errors.Join(
+		s.Flush(),
+		s.forest.Close(),
+	)
+}
+
+// GetMemoryFootprint provides sizes of individual components of the state in the memory
+func (s *LiveTrie) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
+	mf.AddChild("forest", s.forest.GetMemoryFootprint())
+	return mf
+}
+
+// Dump prints the content of the Trie to the console. Mainly intended for debugging.
+func (s *LiveTrie) Dump() {
+	s.forest.Dump(s.root)
+}
+
+// Check verifies internal invariants of the Trie instance. If the trie is
+// self-consistent, nil is returned and the Trie is read to be accessed. If
+// errors are detected, the Trie is to be considered in an invalid state and
+// the behaviour of all other operations is undefined.
+func (s *LiveTrie) Check() error {
+	return s.forest.Check(s.root)
+}
+
+// -- LiveTrie metadata --
+
+// metadata is the helper type to read and write metadata from/to the disk.
+type metadata struct {
+	RootNode NodeId
+}
+
+// readMetadata parses the content of the given file if it exists or returns
+// a default-initialized metadata struct if there is no such file.
+func readMetadata(filename string) (metadata, error) {
+
+	// If there is no file, initialize and return default metadata.
+	if _, err := os.Stat(filename); err != nil {
+		return metadata{}, nil
+	}
+
+	// If the file exists, parse it and return its content.
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return metadata{}, err
+	}
+
+	var meta metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, err
+	}
+	return meta, nil
+}

--- a/go/state/s4/live_trie_test.go
+++ b/go/state/s4/live_trie_test.go
@@ -1,0 +1,453 @@
+package s4
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func TestLiveTrie_EmptyTrieIsConsistent(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	if err := trie.Check(); err != nil {
+		t.Fatalf("empty try has consistency problems: %v", err)
+	}
+}
+
+func TestLiveTrie_NonExistingAccountsHaveEmptyInfo(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	if err := trie.Check(); err != nil {
+		t.Fatalf("empty try has consistency problems: %v", err)
+	}
+
+	addr1 := common.Address{1}
+	if info, exists, err := trie.GetAccountInfo(addr1); err != nil || exists || info != (AccountInfo{}) {
+		t.Errorf("failed to get default account infor from empty state, got %v, exists %v, err: %v", info, exists, err)
+	}
+}
+
+func TestLiveTrie_SetAndGetSingleAccountInformationWorks(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	if err := trie.Check(); err != nil {
+		t.Fatalf("empty try has consistency problems: %v", err)
+	}
+
+	addr := common.Address{1}
+	info := AccountInfo{
+		Nonce:    common.Nonce{1},
+		Balance:  common.Balance{2},
+		CodeHash: common.Hash{3},
+	}
+
+	if err := trie.SetAccountInfo(addr, info); err != nil {
+		t.Errorf("failed to set info of account: %v", err)
+	}
+
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Errorf("trie corrupted after insert: %v", err)
+	}
+
+	if recovered, exists, err := trie.GetAccountInfo(addr); err != nil || !exists || recovered != info {
+		t.Errorf("failed to recover account information, wanted %v, got %v, exists %v, err %v", info, recovered, exists, err)
+	}
+
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Errorf("trie corrupted after read: %v", err)
+	}
+}
+
+func TestLiveTrie_SetAndGetMultipleAccountInformationWorks(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	if err := trie.Check(); err != nil {
+		t.Fatalf("empty try has consistency problems: %v", err)
+	}
+
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+	addr3 := common.Address{0, 0, 0, 0, 0, 0, 3}
+
+	if err := trie.SetAccountInfo(addr1, AccountInfo{Nonce: common.Nonce{1}}); err != nil {
+		t.Errorf("failed to set info of account: %v", err)
+	}
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Errorf("trie corrupted after insert: %v", err)
+	}
+
+	if err := trie.SetAccountInfo(addr2, AccountInfo{Nonce: common.Nonce{2}}); err != nil {
+		t.Errorf("failed to set info of account: %v", err)
+	}
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Errorf("trie corrupted after insert: %v", err)
+	}
+
+	if err := trie.SetAccountInfo(addr3, AccountInfo{Nonce: common.Nonce{3}}); err != nil {
+		t.Errorf("failed to set info of account: %v", err)
+	}
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Errorf("trie corrupted after insert: %v", err)
+	}
+}
+
+func TestLiveTrie_NonExistingValueHasZeroValue(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	addr := common.Address{1}
+	key := common.Key{1}
+
+	// If the account does not exist, the result should be empty.
+	if value, err := trie.GetValue(addr, key); value != (common.Value{}) || err != nil {
+		t.Errorf("expected value of non-existing account to be empty, got %v, err: %v", value, err)
+	}
+
+	// Also, if the account exists, the result should be empty.
+	if err := trie.SetAccountInfo(addr, AccountInfo{Nonce: common.Nonce{1}}); err != nil {
+		t.Fatalf("failed to create an account")
+	}
+	if value, err := trie.GetValue(addr, key); value != (common.Value{}) || err != nil {
+		t.Errorf("expected value of uninitialized slot to be empty, got %v, err: %v", value, err)
+	}
+}
+
+func TestLiveTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	addr := common.Address{1}
+	key := common.Key{1}
+	value := common.Value{1}
+
+	// If the account does not exist, the write has no effect.
+	if err := trie.SetValue(addr, key, value); err != nil {
+		t.Errorf("writing to non-existing account failed: %v", err)
+	}
+	if got, err := trie.GetValue(addr, key); got != (common.Value{}) || err != nil {
+		t.Errorf("wanted %v, got %v", common.Value{}, got)
+	}
+
+	// Create the account.
+	if err := trie.SetAccountInfo(addr, AccountInfo{Nonce: common.Nonce{1}}); err != nil {
+		t.Fatalf("failed to create account for test: %v", err)
+	}
+	if err := trie.SetValue(addr, key, value); err != nil {
+		t.Errorf("writing to existing account failed: %v", err)
+	}
+	if got, err := trie.GetValue(addr, key); value != got || err != nil {
+		t.Errorf("wanted %v, got %v", value, got)
+	}
+}
+
+func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
+	trie1, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	trie2, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+
+	hash1, err := trie1.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of empty trie: %v", err)
+	}
+	hash2, err := trie2.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of empty trie: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("Expected empty tries to have same hash, got %v and %v", hash1, hash2)
+	}
+
+	info1 := AccountInfo{Nonce: common.ToNonce(1)}
+	info2 := AccountInfo{Nonce: common.ToNonce(2)}
+	trie1.SetAccountInfo(common.Address{1}, info1)
+	trie2.SetAccountInfo(common.Address{2}, info2)
+
+	hash1, err = trie1.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of non-empty trie: %v", err)
+	}
+	hash2, err = trie2.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of non-empty trie: %v", err)
+	}
+	if hash1 == hash2 {
+		t.Errorf("Expected different tries to have different hashes, got %v and %v", hash1, hash2)
+	}
+
+	// Update tries to contain same data.
+	trie1.SetAccountInfo(common.Address{2}, info2)
+	trie2.SetAccountInfo(common.Address{1}, info1)
+
+	hash1, err = trie1.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of non-empty trie: %v", err)
+	}
+	hash2, err = trie2.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of non-empty trie: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("Expected equal tries to have same hashes, got %v and %v", hash1, hash2)
+	}
+}
+
+func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+
+	info1 := AccountInfo{Nonce: common.ToNonce(1)}
+	info2 := AccountInfo{Nonce: common.ToNonce(2)}
+	trie.SetAccountInfo(common.Address{1}, info1)
+	trie.SetAccountInfo(common.Address{2}, info2)
+
+	hash1, err := trie.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of empty trie: %v", err)
+	}
+
+	// The next update does not change anything in the root node, but the hash should
+	// still be updated.
+	trie.SetAccountInfo(common.Address{1}, info2)
+
+	hash2, err := trie.GetHash()
+	if err != nil {
+		t.Errorf("failed to fetch hash of empty trie: %v", err)
+	}
+	if hash1 == hash2 {
+		t.Errorf("Nested modification should have caused a change in hashes, got %v and %v", hash1, hash2)
+	}
+}
+
+func TestLiveTrie_InsertLotsOfData(t *testing.T) {
+	t.Parallel()
+	const N = 100
+
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	address := getTestAddresses(N)
+	keys := getTestKeys(N)
+
+	// Fill the tree.
+	for i, addr := range address {
+		if err := trie.SetAccountInfo(addr, AccountInfo{Nonce: common.ToNonce(uint64(i) + 1)}); err != nil {
+			t.Fatalf("failed to insert account: %v", err)
+		}
+		if err := trie.Check(); err != nil {
+			trie.Dump()
+			t.Fatalf("trie inconsistent after account insert:\n%v", err)
+		}
+
+		for i, key := range keys {
+			if err := trie.SetValue(addr, key, common.Value{byte(i)}); err != nil {
+				t.Fatalf("failed to insert value: %v", err)
+			}
+			if err := trie.Check(); err != nil {
+				trie.Dump()
+				t.Fatalf("trie inconsistent after value insert:\n%v", err)
+			}
+		}
+	}
+
+	// Check its content.
+	for i, addr := range address {
+		if info, _, err := trie.GetAccountInfo(addr); int(info.Nonce.ToUint64()) != i+1 || err != nil {
+			t.Fatalf("wrong value, wanted %v, got %v, err %v", i+1, int(info.Nonce.ToUint64()), err)
+		}
+		for i, key := range keys {
+			if value, err := trie.GetValue(addr, key); value[0] != byte(i) || err != nil {
+				t.Fatalf("wrong value, wanted %v, got %v, err %v", byte(i), value[0], err)
+			}
+		}
+	}
+
+	// Delete all accounts.
+	for _, addr := range address {
+		if err := trie.SetAccountInfo(addr, AccountInfo{}); err != nil {
+			t.Fatalf("failed to delete account: %v", err)
+		}
+		if err := trie.Check(); err != nil {
+			trie.Dump()
+			t.Fatalf("trie inconsistent after account deletion:\n%v\nDeleted account: %v", err, addr)
+		}
+	}
+}
+
+func TestLiveTrie_InsertLotsOfValues(t *testing.T) {
+	t.Parallel()
+	const N = 10000
+
+	trie, err := OpenInMemoryLiveTrie(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+
+	addr := common.Address{}
+	keys := getTestKeys(N)
+
+	// Fill a single account.
+	if err := trie.SetAccountInfo(addr, AccountInfo{Nonce: common.ToNonce(1)}); err != nil {
+		t.Fatalf("failed to insert account: %v", err)
+	}
+	if err := trie.Check(); err != nil {
+		trie.Dump()
+		t.Fatalf("trie inconsistent after account insert:\n%v", err)
+	}
+
+	for i, key := range keys {
+		if err := trie.SetValue(addr, key, common.Value{byte(i)}); err != nil {
+			t.Fatalf("failed to insert value: %v", err)
+		}
+		if err := trie.Check(); err != nil {
+			trie.Dump()
+			t.Fatalf("trie inconsistent after value insert:\n%v", err)
+		}
+	}
+
+	// Check its content.
+	for i, key := range keys {
+		if value, err := trie.GetValue(addr, key); value[0] != byte(i) || err != nil {
+			t.Fatalf("wrong value, wanted %v, got %v, err %v", byte(i), value[0], err)
+		}
+	}
+
+	// Delete all values.
+	for _, key := range keys {
+		if err := trie.SetValue(addr, key, common.Value{}); err != nil {
+			t.Fatalf("failed to delete value: %v", err)
+		}
+		if err := trie.Check(); err != nil {
+			trie.Dump()
+			t.Fatalf("trie inconsistent after value deletion:\n%v\nDeleted value: %v", err, key)
+		}
+	}
+}
+
+func getTestAddresses(number int) []common.Address {
+	res := make([]common.Address, number)
+	for i := range res {
+		j := i * i
+		res[i][0] = byte(j)
+		res[i][1] = byte(j >> 8)
+		res[i][2] = byte(j >> 16)
+		res[i][3] = byte(j >> 24)
+	}
+	rand.Seed(0)
+	rand.Shuffle(len(res), func(i, j int) {
+		res[i], res[j] = res[j], res[i]
+	})
+	return res
+}
+
+func getTestKeys(number int) []common.Key {
+	res := make([]common.Key, number)
+	for i := range res {
+		j := i * i
+		res[i][0] = byte(j)
+		res[i][1] = byte(j >> 8)
+		res[i][2] = byte(j >> 16)
+		res[i][3] = byte(j >> 24)
+	}
+	rand.Seed(0)
+	rand.Shuffle(len(res), func(i, j int) {
+		res[i], res[j] = res[j], res[i]
+	})
+	return res
+}
+
+func benchmarkValueInsertion(trie *LiveTrie, b *testing.B) {
+	accounts := getTestAddresses(100)
+	keys := getTestKeys(100)
+
+	info := AccountInfo{Nonce: common.ToNonce(1)}
+	val1 := common.Value{1}
+	for i := 0; i < b.N; i++ {
+		for _, account := range accounts {
+			if err := trie.SetAccountInfo(account, info); err != nil {
+				b.Fatalf("failed to create account %v: %v", account, err)
+			}
+			for _, key := range keys {
+				if err := trie.SetValue(account, key, val1); err != nil {
+					b.Fatalf("insertion failed: %v", err)
+				}
+			}
+		}
+		for _, account := range accounts {
+			for _, key := range keys {
+				if value, err := trie.GetValue(account, key); value != val1 || err != nil {
+					b.Fatalf("invalid element in trie, wanted %v, got %v, err %v", val1, value, err)
+				}
+			}
+		}
+		for _, account := range accounts {
+			for _, key := range keys {
+				if err := trie.SetValue(account, key, common.Value{}); err != nil {
+					b.Fatalf("deletion failed: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkValueInsertionInMemoryTrie(b *testing.B) {
+	b.StopTimer()
+	trie, err := OpenInMemoryLiveTrie(b.TempDir())
+	if err != nil {
+		b.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+	b.StartTimer()
+	benchmarkValueInsertion(trie, b)
+	b.StopTimer()
+}
+
+func BenchmarkValueInsertionInFileTrie(b *testing.B) {
+	b.StopTimer()
+	trie, err := OpenFileLiveTrie(b.TempDir())
+	if err != nil {
+		b.Fatalf("failed to open trie: %v", err)
+	}
+	defer trie.Close()
+	b.StartTimer()
+	benchmarkValueInsertion(trie, b)
+	b.StopTimer()
+}

--- a/go/state/s4/state.go
+++ b/go/state/s4/state.go
@@ -1,0 +1,311 @@
+package s4
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"hash"
+	"io"
+	"os"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"golang.org/x/crypto/sha3"
+)
+
+// S4State implementation of a state utilizes an MPT based data structure. While
+// functionally equivalent to the Ethereum State MPT, hashes are computed using
+// a distinct algorithm.
+//
+// The main role of the S4State is to provide an adapter between a LiveTrie and
+// Carmen's State interface. Also, it retains an index of contract codes.
+type S4State struct {
+	trie     *LiveTrie
+	code     map[common.Hash][]byte
+	codefile string
+	hasher   hash.Hash
+}
+
+var emptyCodeHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})
+
+func newS4State(directory string, trie *LiveTrie) (*S4State, error) {
+	codefile := directory + "/codes.json"
+	codes, err := readCodes(codefile)
+	if err != nil {
+		return nil, err
+	}
+	return &S4State{
+		trie:     trie,
+		code:     codes,
+		codefile: codefile,
+	}, nil
+}
+
+// OpenGoMemoryState loads state information from the given directory and
+// creates a Trie entirly retained in memory.
+func OpenGoMemoryState(directory string) (*S4State, error) {
+	trie, err := OpenInMemoryLiveTrie(directory)
+	if err != nil {
+		return nil, err
+	}
+	return newS4State(directory, trie)
+}
+
+func OpenGoFileState(directory string) (*S4State, error) {
+	trie, err := OpenFileLiveTrie(directory)
+	if err != nil {
+		return nil, err
+	}
+	return newS4State(directory, trie)
+}
+
+func (s *S4State) CreateAccount(address common.Address) (err error) {
+	_, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return err
+	}
+	if exists {
+		// For existing accounts, only clear the storage, preserve the rest.
+		return s.trie.ClearStorage(address)
+	}
+	// Create account with hash of empty code.
+	return s.trie.SetAccountInfo(address, AccountInfo{
+		CodeHash: emptyCodeHash,
+	})
+}
+
+func (s *S4State) Exists(address common.Address) (bool, error) {
+	_, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+func (s *S4State) DeleteAccount(address common.Address) error {
+	return s.trie.SetAccountInfo(address, AccountInfo{})
+}
+
+func (s *S4State) GetBalance(address common.Address) (balance common.Balance, err error) {
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if !exists || err != nil {
+		return common.Balance{}, err
+	}
+	return info.Balance, nil
+}
+
+func (s *S4State) SetBalance(address common.Address, balance common.Balance) (err error) {
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return err
+	}
+	if info.Balance == balance {
+		return nil
+	}
+	info.Balance = balance
+	if !exists {
+		info.CodeHash = emptyCodeHash
+	}
+	return s.trie.SetAccountInfo(address, info)
+}
+
+func (s *S4State) GetNonce(address common.Address) (nonce common.Nonce, err error) {
+	info, _, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return common.Nonce{}, err
+	}
+	return info.Nonce, nil
+}
+
+func (s *S4State) SetNonce(address common.Address, nonce common.Nonce) (err error) {
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return err
+	}
+	if info.Nonce == nonce {
+		return nil
+	}
+	info.Nonce = nonce
+	if !exists {
+		info.CodeHash = emptyCodeHash
+	}
+	return s.trie.SetAccountInfo(address, info)
+}
+
+func (s *S4State) GetStorage(address common.Address, key common.Key) (value common.Value, err error) {
+	return s.trie.GetValue(address, key)
+}
+
+func (s *S4State) SetStorage(address common.Address, key common.Key, value common.Value) error {
+	return s.trie.SetValue(address, key, value)
+}
+
+func (s *S4State) GetCode(address common.Address) (value []byte, err error) {
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	return s.code[info.CodeHash], nil
+}
+
+func (s *S4State) GetCodeSize(address common.Address) (size int, err error) {
+	code, err := s.GetCode(address)
+	if err != nil {
+		return 0, err
+	}
+	return len(code), err
+}
+
+func (s *S4State) SetCode(address common.Address, code []byte) (err error) {
+	var codeHash common.Hash
+	if s.hasher == nil {
+		s.hasher = sha3.NewLegacyKeccak256()
+	}
+	codeHash = common.GetHash(s.hasher, code)
+
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if err != nil {
+		return err
+	}
+	if !exists && len(code) == 0 {
+		return nil
+	}
+	if info.CodeHash == codeHash {
+		return nil
+	}
+	info.CodeHash = codeHash
+	s.code[codeHash] = code
+	return s.trie.SetAccountInfo(address, info)
+}
+
+func (s *S4State) GetCodeHash(address common.Address) (hash common.Hash, err error) {
+	info, exists, err := s.trie.GetAccountInfo(address)
+	if !exists || err != nil {
+		return emptyCodeHash, err
+	}
+	return info.CodeHash, nil
+}
+
+func (s *S4State) GetHash() (hash common.Hash, err error) {
+	return s.trie.GetHash()
+}
+
+func (s *S4State) Flush() error {
+	// Flush codes and state trie.
+	return errors.Join(
+		writeCodes(s.code, s.codefile),
+		s.trie.Flush(),
+	)
+}
+
+func (s *S4State) Close() (lastErr error) {
+	return errors.Join(
+		s.Flush(),
+		s.trie.Close(),
+	)
+}
+
+func (s *S4State) GetSnapshotableComponents() []backend.Snapshotable {
+	//panic("not implemented")
+	return nil
+}
+
+func (s *S4State) RunPostRestoreTasks() error {
+	//panic("not implemented")
+	return nil
+}
+
+// GetMemoryFootprint provides sizes of individual components of the state in the memory
+func (s *S4State) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
+	mf.AddChild("trie", s.trie.GetMemoryFootprint())
+	// TODO: add code store
+	return mf
+}
+
+var errCorruptedCodeFile = errors.New("invalid encoding of code file")
+
+// readCodes parses the content of the given file if it exists or returns
+// a an empty code collection if there is no such file.
+func readCodes(filename string) (map[common.Hash][]byte, error) {
+
+	// If there is no file, initialize and return an empty code collection.
+	if _, err := os.Stat(filename); err != nil {
+		return map[common.Hash][]byte{}, nil
+	}
+
+	// If the file exists, parse it and return its content.
+	res := map[common.Hash][]byte{}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	reader := bufio.NewReader(file)
+
+	// The format is simple: [<key>, <length>, <code>]*
+	var hash common.Hash
+	var length [4]byte
+	for {
+		if num, err := reader.Read(hash[:]); err != nil {
+			if err == io.EOF {
+				return res, nil
+			}
+			return nil, err
+		} else if num != len(hash) {
+			return nil, errCorruptedCodeFile
+		}
+		if num, err := reader.Read(length[:]); err != nil {
+			return nil, err
+		} else if num != len(length) {
+			return nil, errCorruptedCodeFile
+		}
+
+		size := binary.BigEndian.Uint32(length[:])
+		code := make([]byte, size)
+		if num, err := reader.Read(code[:]); err != nil {
+			return nil, err
+		} else if num != len(code) {
+			return nil, errCorruptedCodeFile
+		}
+
+		res[hash] = code
+	}
+}
+
+// writeCodes write the given map of codes to the given file.
+func writeCodes(codes map[common.Hash][]byte, filename string) (err error) {
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+	writer := bufio.NewWriter(file)
+
+	// The format is simple: [<key>, <length>, <code>]*
+	for key, code := range codes {
+		if _, err := writer.Write(key[:]); err != nil {
+			return err
+		}
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(code)))
+		if _, err := writer.Write(length[:]); err != nil {
+			return err
+		}
+		if _, err := writer.Write(code); err != nil {
+			return err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return err
+	}
+	return err
+}


### PR DESCRIPTION
This PR adds a single-trie (LiveTrie) wrapper around the `Forest` implementation and an adapter for the `state.State` interface.