### PR TITLE
Integrate S4 as another configuration in Carmen

### DIFF
--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -33,8 +33,14 @@ type CppState struct {
 func newCppState(impl C.enum_StateImpl, params Parameters) (State, error) {
 	dir := C.CString(params.Directory)
 	defer C.free(unsafe.Pointer(dir))
+
+	state := C.Carmen_OpenState(C.C_Schema(params.Schema), impl, C.enum_StateImpl(params.Archive), dir, C.int(len(params.Directory)))
+	if state == unsafe.Pointer(nil) {
+		return nil, UnsupportedConfiguration(fmt.Sprintf("failed to create C++ state instance for parameters %v", params))
+	}
+
 	return wrapIntoSyncedState(&CppState{
-		state:     C.Carmen_OpenState(C.C_Schema(params.Schema), impl, C.enum_StateImpl(params.Archive), dir, C.int(len(params.Directory))),
+		state:     state,
 		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
 	}), nil
 }

--- a/go/state/cpp_state_test.go
+++ b/go/state/cpp_state_test.go
@@ -8,13 +8,7 @@ import (
 )
 
 func TestAccountsAreInitiallyUnknown(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		account_state, _ := state.Exists(address1)
 		if account_state != false {
 			t.Errorf("Initial account is not unknown, got %v", account_state)
@@ -23,13 +17,7 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 }
 
 func TestAccountsCanBeCreated(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		state.createAccount(address1)
 		account_state, _ := state.Exists(address1)
 		if account_state != true {
@@ -39,13 +27,7 @@ func TestAccountsCanBeCreated(t *testing.T) {
 }
 
 func TestAccountsCanBeDeleted(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		state.createAccount(address1)
 		state.deleteAccount(address1)
 		account_state, _ := state.Exists(address1)
@@ -56,13 +38,7 @@ func TestAccountsCanBeDeleted(t *testing.T) {
 }
 
 func TestReadUninitializedBalance(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		balance, err := state.GetBalance(address1)
 		if err != nil {
 			t.Fatalf("Error fetching balance: %v", err)
@@ -74,14 +50,8 @@ func TestReadUninitializedBalance(t *testing.T) {
 }
 
 func TestWriteAndReadBalance(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
-		err = state.setBalance(address1, balance1)
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
+		err := state.setBalance(address1, balance1)
 		if err != nil {
 			t.Fatalf("Error updating balance: %v", err)
 		}
@@ -96,13 +66,7 @@ func TestWriteAndReadBalance(t *testing.T) {
 }
 
 func TestReadUninitializedNonce(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		nonce, err := state.GetNonce(address1)
 		if err != nil {
 			t.Fatalf("Error fetching nonce: %v", err)
@@ -114,14 +78,8 @@ func TestReadUninitializedNonce(t *testing.T) {
 }
 
 func TestWriteAndReadNonce(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
-		err = state.setNonce(address1, nonce1)
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
+		err := state.setNonce(address1, nonce1)
 		if err != nil {
 			t.Fatalf("Error updating nonce: %v", err)
 		}
@@ -136,13 +94,7 @@ func TestWriteAndReadNonce(t *testing.T) {
 }
 
 func TestReadUninitializedSlot(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		value, err := state.GetStorage(address1, key1)
 		if err != nil {
 			t.Fatalf("Error fetching storage slot: %v", err)
@@ -154,14 +106,8 @@ func TestReadUninitializedSlot(t *testing.T) {
 }
 
 func TestWriteAndReadSlot(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
-		err = state.setStorage(address1, key1, val1)
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
+		err := state.setStorage(address1, key1, val1)
 		if err != nil {
 			t.Fatalf("Error updating storage: %v", err)
 		}
@@ -196,13 +142,7 @@ func getTestCodes() [][]byte {
 }
 
 func TestSetAndGetCode(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		for _, code := range getTestCodes() {
 			err := state.setCode(address1, code)
 			if err != nil {
@@ -227,13 +167,7 @@ func TestSetAndGetCode(t *testing.T) {
 }
 
 func TestSetAndGetCodeHash(t *testing.T) {
-	runForEachCppConfig(t, func(t *testing.T, config *namedStateConfig) {
-		state, err := config.createState(t.TempDir())
-		if err != nil {
-			t.Fatalf("failed to initialize state %s", config.name)
-		}
-		defer state.Close()
-
+	runForEachCppConfig(t, func(t *testing.T, state directUpdateState) {
 		for _, code := range getTestCodes() {
 			err := state.setCode(address1, code)
 			if err != nil {
@@ -263,12 +197,21 @@ func initCppStates() []namedStateConfig {
 	return list
 }
 
-func runForEachCppConfig(t *testing.T, test func(*testing.T, *namedStateConfig)) {
+func runForEachCppConfig(t *testing.T, test func(*testing.T, directUpdateState)) {
 	for _, config := range initCppStates() {
 		config := config
 		t.Run(config.name, func(t *testing.T) {
 			t.Parallel()
-			test(t, &config)
+			state, err := config.createState(t.TempDir())
+			if err != nil {
+				if _, ok := err.(UnsupportedConfiguration); ok {
+					t.Skipf("failed to initialize state %s: %v", config.name, err)
+				} else {
+					t.Fatalf("failed to initialize state %s: %v", config.name, err)
+				}
+			}
+			defer state.Close()
+			test(t, state)
 		})
 	}
 }

--- a/go/state/go_schema4.go
+++ b/go/state/go_schema4.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/state/s4"
+)
+
+// goSchema4 implements a state utilizes an MPT based data structure. However, it is
+// not binary compatible with the Ethereum variant of an MPT.
+type goSchema4 struct {
+	*s4.S4State
+}
+
+func newS4State(params Parameters, state *s4.S4State) (State, error) {
+	arch, archiveCleanup, err := openArchive(params)
+	if err != nil {
+		return nil, err
+	}
+	return NewGoState(&goSchema4{
+		S4State: state,
+	}, arch, []func(){archiveCleanup}), nil
+}
+
+func NewGoMemoryS4State(params Parameters) (State, error) {
+	state, err := s4.OpenGoMemoryState(params.Directory)
+	if err != nil {
+		return nil, err
+	}
+	return newS4State(params, state)
+}
+
+func NewGoFileS4State(params Parameters) (State, error) {
+	state, err := s4.OpenGoFileState(params.Directory)
+	if err != nil {
+		return nil, err
+	}
+	return newS4State(params, state)
+}
+
+func (s *goSchema4) createAccount(address common.Address) error {
+	return s.CreateAccount(address)
+}
+
+func (s *goSchema4) deleteAccount(address common.Address) error {
+	return s.DeleteAccount(address)
+}
+
+func (s *goSchema4) setBalance(address common.Address, balance common.Balance) error {
+	return s.SetBalance(address, balance)
+}
+
+func (s *goSchema4) setNonce(address common.Address, nonce common.Nonce) error {
+	return s.SetNonce(address, nonce)
+}
+
+func (s *goSchema4) setStorage(address common.Address, key common.Key, value common.Value) error {
+	return s.SetStorage(address, key, value)
+}
+
+func (s *goSchema4) setCode(address common.Address, code []byte) error {
+	return s.SetCode(address, code)
+}
+
+func (s *goSchema4) getSnapshotableComponents() []backend.Snapshotable {
+	return s.GetSnapshotableComponents()
+}
+
+func (s *goSchema4) runPostRestoreTasks() error {
+	return s.RunPostRestoreTasks()
+}


### PR DESCRIPTION
This introduces S4 as another configuration option in Carmen.

For it to be properly tested, a few generalizations to the test infrastructure have been required. In particular, it is now supported that a factory may return an `UnsupportedConfiguration` to indicate that a given combination of parameters is currently not supported/implemented.