### PR TITLE
implements hasher that is cached and thread safe

### DIFF
--- a/go/common/cached_hasher.go
+++ b/go/common/cached_hasher.go
@@ -1,0 +1,104 @@
+package common
+
+import (
+	"golang.org/x/crypto/sha3"
+	"hash"
+	"sync"
+)
+
+// CachedHasher allows for hashing input keys.
+// It caches the keys and returns an already cached value
+// when it exists in the cache.
+// If the key is not in the cache, it is hashed, stored in the cache
+// and returned.
+// This structure is safe for concurrent access, except
+// the input hasher of the Hash method is modified (reset) with every
+// hashing, i.e. the caller must make sure the hasher is thread local
+// (i.e. not share across threads)
+type CachedHasher[T comparable] struct {
+	cache      *Cache[T, Hash]
+	serializer Serializer[T]
+	cached     bool
+	lock       *sync.Mutex
+	pool       *hasherPool
+}
+
+// NewCachedHasher creates a new hasher, that will use cache of computed hashes sized to the input capacity.
+// If the capacity is set to zero, or negative, no cache will be used.
+// Input serializer is used to convert the type, which will be hashed, to byte slice.
+func NewCachedHasher[T comparable](cacheCapacity int, serializer Serializer[T]) *CachedHasher[T] {
+	return &CachedHasher[T]{
+		cache:      NewCache[T, Hash](cacheCapacity),
+		serializer: serializer,
+		cached:     cacheCapacity > 0,
+		lock:       &sync.Mutex{},
+		pool:       newHasherPool(),
+	}
+}
+
+// Hash hashes the input type. It uses an internal cache, returning the hash
+// from the cache, if the input type was already used and is retained in the cache.
+// This method is thread safe.
+func (h *CachedHasher[T]) Hash(t T) Hash {
+	if !h.cached {
+		hasher := h.pool.getHasher()
+		defer h.pool.returnHasher(hasher)
+		return GetHash(hasher, h.serializer.ToBytes(t))
+	}
+
+	h.lock.Lock()
+	res, exists := h.cache.Get(t)
+	h.lock.Unlock()
+	if exists {
+		return res
+	}
+
+	hasher := h.pool.getHasher()
+	res = GetHash(hasher, h.serializer.ToBytes(t))
+	h.pool.returnHasher(hasher)
+
+	h.lock.Lock()
+	h.cache.Set(t, res)
+	h.lock.Unlock()
+	return res
+}
+
+// hasherPool is a synchronised pool of hashers. Whenever a hasher is required
+// it is either returned from the pool, or created as new, if no hasher is available in the pool
+type hasherPool struct {
+	pool []hash.Hash
+	lock *sync.Mutex
+}
+
+func newHasherPool() *hasherPool {
+	return &hasherPool{
+		pool: make([]hash.Hash, 0, 100),
+		lock: &sync.Mutex{},
+	}
+}
+
+// getHasher returns a hasher. The hasher is either from the pool,
+// or created as a new one.
+func (p *hasherPool) getHasher() hash.Hash {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	var hasher hash.Hash
+	if len(p.pool) > 0 {
+		hasher = p.pool[len(p.pool)-1]
+		p.pool = p.pool[0 : len(p.pool)-1]
+	} else {
+		hasher = sha3.NewLegacyKeccak256()
+	}
+
+	return hasher
+}
+
+// returnHasher returns the hasher back to the pool. It is not checked if the method was
+// called at most once for the same hasher. It is up to the caller.
+func (p *hasherPool) returnHasher(hasher hash.Hash) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.pool = append(p.pool, hasher)
+}

--- a/go/common/cached_hasher_benchmark_test.go
+++ b/go/common/cached_hasher_benchmark_test.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"encoding/binary"
+	"golang.org/x/exp/rand"
+	"testing"
+)
+
+var hashSink Hash
+
+func BenchmarkHashNoCache(b *testing.B) {
+	hasher := NewCachedHasher[Address](0, AddressSerializer{})
+	for i := 1; i <= b.N; i++ {
+		var addr Address
+		addr[i%20]++
+		hashSink = hasher.Hash(addr)
+	}
+}
+
+func BenchmarkHashNoCacheRunParallel(b *testing.B) {
+	hasher := NewCachedHasher[Address](0, AddressSerializer{})
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var addr Address
+			hashSink = hasher.Hash(addr)
+		}
+	})
+}
+
+func BenchmarkAddressHitLatency(b *testing.B) {
+	b.StopTimer()
+	cacheSize := 1000
+	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
+	addresses := make([]Address, 0, cacheSize)
+	for i := 0; i < cacheSize; i++ {
+		arr := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		var addr Address
+		copy(addr[:], arr)
+		hasher.Hash(addr) // warm-up cache
+		addresses = append(addresses, addr)
+	}
+	b.StartTimer()
+
+	// all addresses will be in the cache (after 'cacheSize' iterations)
+	for i := 1; i <= b.N; i++ {
+		hashSink = hasher.Hash(addresses[i%cacheSize])
+	}
+}
+
+func BenchmarkAddressMissLatency(b *testing.B) {
+	address := Address{}
+	hasher := NewCachedHasher[Address](1024, AddressSerializer{})
+	for i := 1; i <= b.N; i++ {
+		binary.BigEndian.PutUint64(address[:], uint64(i))
+		hashSink = hasher.Hash(address)
+	}
+}
+
+func BenchmarkKeyHitLatency(b *testing.B) {
+	b.StopTimer()
+	cacheSize := 1000
+	hasher := NewCachedHasher[Key](cacheSize, KeySerializer{})
+	keys := make([]Key, 0, cacheSize)
+	for i := 0; i < cacheSize; i++ {
+		arr := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		var key Key
+		copy(key[:], arr)
+		hasher.Hash(key) // warm-up cache
+		keys = append(keys, key)
+	}
+	b.StartTimer()
+
+	// all keys will be in the cache (after 'cacheSize' iterations)
+	for i := 1; i <= b.N; i++ {
+		hashSink = hasher.Hash(keys[i%cacheSize])
+	}
+}
+
+func BenchmarkKeyMissLatency(b *testing.B) {
+	key := Key{}
+	hasher := NewCachedHasher[Key](1024, KeySerializer{})
+	for i := 1; i <= b.N; i++ {
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		hashSink = hasher.Hash(key)
+	}
+}
+
+func BenchmarkAddressesHitsRunParallel(b *testing.B) {
+	b.StopTimer()
+	cacheSize := 1000
+	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
+	addresses := make([]Address, 0, cacheSize)
+	for i := 0; i < b.N; i++ {
+		arr := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
+		var addr Address
+		copy(addr[:], arr)
+		hasher.Hash(addr) // warm-up cache
+		addresses = append(addresses, addr)
+	}
+	b.StartTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		var pos int
+		for pb.Next() {
+			hashSink = hasher.Hash(addresses[pos])
+			pos++
+		}
+	})
+}
+
+func BenchmarkAddressesMissRunParallel(b *testing.B) {
+	hasher := NewCachedHasher[Address](1024, AddressSerializer{})
+	b.RunParallel(func(pb *testing.PB) {
+		pos := rand.Int63()
+		var address Address
+		for pb.Next() {
+			binary.BigEndian.PutUint64(address[:], uint64(pos))
+			hashSink = hasher.Hash(address)
+			pos++
+		}
+	})
+}

--- a/go/common/cached_hasher_test.go
+++ b/go/common/cached_hasher_test.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"golang.org/x/crypto/sha3"
+	"testing"
+)
+
+func TestHashPassThrough(t *testing.T) {
+	cacheSize := 1000
+	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
+	var adr Address
+	for i := 0; i < 2*cacheSize; i++ {
+		if got, want := hasher.Hash(adr), GetHash(sha3.NewLegacyKeccak256(), adr[:]); got != want {
+			t.Errorf("hashes do not match: %v != %v", got, want)
+		}
+		adr[i%20]++
+	}
+}
+
+func TestHashPassThroughRunParallel(t *testing.T) {
+	cacheSize := 100
+	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
+	for i := 0; i < 10_000*cacheSize; i++ {
+		var addr Address
+		go func(addr Address) {
+			if got, want := hasher.Hash(addr), GetHash(sha3.NewLegacyKeccak256(), addr[:]); got != want {
+				t.Errorf("hashes do not match: %v != %v", got, want)
+			}
+		}(addr)
+		addr[i%20]++
+	}
+}
+
+func TestHasherPool(t *testing.T) {
+	pool := newHasherPool()
+
+	hasher := pool.getHasher()
+
+	// hasher created as new - the pool is empty
+	if len(pool.pool) != 0 {
+		t.Errorf("pool is not empty: %d", len(pool.pool))
+	}
+
+	// hasher returned to the pool
+	pool.returnHasher(hasher)
+
+	if len(pool.pool) != 1 {
+		t.Errorf("pool is empty: %d", len(pool.pool))
+	}
+
+	if pool.pool[0] != hasher {
+		t.Errorf("hasher not the same as the one in the pool")
+	}
+
+	// get again from the pool
+	hasher2 := pool.getHasher()
+
+	if hasher2 != hasher {
+		t.Errorf("hasher not the same as the one in the pool")
+	}
+
+	// hasher returned - the pool is empty
+
+	if len(pool.pool) != 0 {
+		t.Errorf("pool capacity should change: %d", len(pool.pool))
+	}
+}


### PR DESCRIPTION
This PR implements a Hasher that is thread safe and cached. 
It re-uses LRU cache and the Hashing method we already had, i.e. its implementation should be straigforward. 

Bench results are: 

```
BenchmarkHashNoCache
BenchmarkHashNoCache-8                 	 1873776	       732.1 ns/op
BenchmarkHashNoCacheReuseHasher
BenchmarkHashNoCacheReuseHasher-8      	 2187704	       540.4 ns/op
BenchmarkHashNoCacheRunParallel
BenchmarkHashNoCacheRunParallel-8      	 3172207	       377.7 ns/op
BenchmarkAllFitInCache
BenchmarkAllFitInCache-8               	33636057	        31.22 ns/op
BenchmarkHalfFitInCache
BenchmarkHalfFitInCache-8              	31985748	        33.01 ns/op
BenchmarkHalfFitInCacheRunParallel
BenchmarkHalfFitInCacheRunParallel-8   	 7234662	       163.4 ns/op
```