### PR TITLE
Reduce runtime of Live-Trie tests by reducing problem size

### DIFF
--- a/go/state/s4/live_trie_test.go
+++ b/go/state/s4/live_trie_test.go
@@ -290,7 +290,7 @@ func TestLiveTrie_InsertLotsOfData(t *testing.T) {
 		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
-			const N = 100
+			const N = 50
 
 			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
 			if err != nil {
@@ -353,7 +353,7 @@ func TestLiveTrie_InsertLotsOfValues(t *testing.T) {
 		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
-			const N = 10000
+			const N = 1000
 
 			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
 			if err != nil {


### PR DESCRIPTION
This should reduce the CI test time and reduce time-out failures.