### PR TITLE
Add benchmark for basic MPT operations

### DIFF
--- a/go/state/mpt/state_test.go
+++ b/go/state/mpt/state_test.go
@@ -1,0 +1,41 @@
+package mpt
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func BenchmarkStorageChanges(b *testing.B) {
+	for _, config := range allMptConfigs {
+		for _, withHashing := range []bool{false, true} {
+			mode := "just_update"
+			if withHashing {
+				mode = "with_hashing"
+			}
+			b.Run(fmt.Sprintf("%s/%s", config.Name, mode), func(b *testing.B) {
+				state, err := OpenGoMemoryState(b.TempDir(), config)
+				if err != nil {
+					b.Fail()
+				}
+
+				address := common.Address{}
+				state.SetNonce(address, common.ToNonce(12))
+
+				key := common.Key{}
+				value := common.Value{}
+
+				for i := 0; i < b.N; i++ {
+					binary.BigEndian.PutUint64(key[:], uint64(i%1024))
+					binary.BigEndian.PutUint64(value[:], uint64(i))
+					state.SetStorage(address, key, value)
+					if withHashing {
+						state.GetHash()
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Adds a benchmark covering MPT state modifications and hashing.

It is intended to guide the tuning of the MPT implementation.

Initial results:
```
cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
BenchmarkStorageChanges/S4/just_update-4         	 1537586	     701.7 ns/op
BenchmarkStorageChanges/S4/with_hashing-4        	  105638	     10928 ns/op
BenchmarkStorageChanges/S5/just_update-4         	  320035	      3416 ns/op
BenchmarkStorageChanges/S5/with_hashing-4        	    1359	   1730491 ns/op
```