### PR TITLE
Add benchmark for RLP encoding

### DIFF
--- a/go/state/mpt/rlp/rlp_test.go
+++ b/go/state/mpt/rlp/rlp_test.go
@@ -177,3 +177,45 @@ func TestEncoding_BigInt(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkListEncoding(b *testing.B) {
+	example := &List{
+		[]Item{
+			&String{[]byte("hello")},
+			&String{[]byte("world")},
+			&List{
+				[]Item{
+					&String{[]byte("nested")},
+					&String{[]byte("content")},
+				},
+			},
+			// Some 'hashes'
+			&String{make([]byte, 32)},
+			&String{make([]byte, 32)},
+			&List{
+				[]Item{
+					&String{[]byte("1")},
+					&String{[]byte("2")},
+					&String{[]byte("3")},
+					&String{[]byte("4")},
+					&String{[]byte("5")},
+					&String{[]byte("6")},
+					&String{[]byte("7")},
+					&String{[]byte("8")},
+					&String{[]byte("9")},
+					&String{[]byte("10")},
+					&String{[]byte("11")},
+					&String{[]byte("12")},
+					&String{[]byte("13")},
+					&String{[]byte("14")},
+					&String{[]byte("15")},
+					&String{[]byte("16")},
+				},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		Encode(example)
+	}
+}


### PR DESCRIPTION
Adds a benchmark for the encoding efficiency of the RLP package.

Initial results:
```
cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
BenchmarkListEncoding-4   	  932325	      1253 ns/op	     721 B/op	      27 allocs/op
```