### PR TITLE
Eliminate double-buffering in RLP encoding

### DIFF
--- a/go/state/mpt/hasher.go
+++ b/go/state/mpt/hasher.go
@@ -3,7 +3,6 @@ package mpt
 //go:generate mockgen -source hasher.go -destination hasher_mocks.go -package mpt
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"reflect"
@@ -158,9 +157,7 @@ func encodeBranch(node *BranchNode, nodes NodeSource, hashes HashSource) ([]byte
 	// branch nodes are never terminators in State or Storage Tries.
 	items[len(children)] = &rlp.String{}
 
-	var buffer bytes.Buffer
-	rlp.List{Items: items}.Write(&buffer)
-	return buffer.Bytes(), nil
+	return rlp.Encode(rlp.List{Items: items}), nil
 }
 
 func encodeExtension(node *ExtensionNode, nodes NodeSource, hashes HashSource) ([]byte, error) {
@@ -187,9 +184,7 @@ func encodeExtension(node *ExtensionNode, nodes NodeSource, hashes HashSource) (
 	}
 	items[1] = &rlp.String{Str: encoded}
 
-	var buffer bytes.Buffer
-	rlp.List{Items: items}.Write(&buffer)
-	return buffer.Bytes(), nil
+	return rlp.Encode(rlp.List{Items: items}), nil
 }
 
 func encodeAccount(node *AccountNode, nodes NodeSource, hashes HashSource) ([]byte, error) {
@@ -228,9 +223,7 @@ func encodeValue(node *ValueNode, nodes NodeSource, hashSource HashSource) ([]by
 	}
 	items[1] = &rlp.String{Str: rlp.Encode(&rlp.String{Str: value[:]})}
 
-	var buffer bytes.Buffer
-	rlp.List{Items: items}.Write(&buffer)
-	return buffer.Bytes(), nil
+	return rlp.Encode(rlp.List{Items: items}), nil
 }
 
 func encodePath(unhashed []byte, numNibbles int) []byte {

--- a/go/state/mpt/rlp/rlp_test.go
+++ b/go/state/mpt/rlp/rlp_test.go
@@ -64,7 +64,10 @@ func TestEncoding_EncodeStrings(t *testing.T) {
 
 	for _, test := range tests {
 		if got, want := Encode(String{test.input}), test.result; !bytes.Equal(got, want) {
-			t.Errorf("invalid encoding, wanted %v, got %v", want, got)
+			t.Errorf("invalid encoding, wanted %v, got %v, input %v", want, got, test.input)
+		}
+		if got, want := (String{test.input}).getEncodedLength(), len(test.result); got != want {
+			t.Errorf("invalid result for encoded length, wanted %d, got %d, input %v", want, got, test.input)
 		}
 	}
 }
@@ -90,7 +93,10 @@ func TestEncoding_EncodeList(t *testing.T) {
 
 	for _, test := range tests {
 		if got, want := Encode(List{test.input}), test.result; !bytes.Equal(got, want) {
-			t.Errorf("invalid encoding, wanted %v, got %v", want, got)
+			t.Errorf("invalid encoding, wanted %v, got %v, input %v", want, got, test.input)
+		}
+		if got, want := (List{test.input}).getEncodedLength(), len(test.result); got != want {
+			t.Errorf("invalid result for encoded length, wanted %d, got %d, input %v", want, got, test.input)
 		}
 	}
 }
@@ -132,7 +138,10 @@ func TestEncoding_Uint64(t *testing.T) {
 	}
 	for _, test := range tests {
 		if got, want := Encode(Uint64{test.input}), test.result; !bytes.Equal(got, want) {
-			t.Errorf("invalid encoding, wanted %v, got %v", want, got)
+			t.Errorf("invalid encoding, wanted %v, got %v, input %v", want, got, test.input)
+		}
+		if got, want := (Uint64{test.input}).getEncodedLength(), len(test.result); got != want {
+			t.Errorf("invalid result for encoded length, wanted %d, got %d, input %v", want, got, test.input)
 		}
 	}
 }
@@ -173,7 +182,10 @@ func TestEncoding_BigInt(t *testing.T) {
 	}
 	for _, test := range tests {
 		if got, want := Encode(BigInt{test.input}), test.result; !bytes.Equal(got, want) {
-			t.Errorf("invalid encoding, wanted %v, got %v", want, got)
+			t.Errorf("invalid encoding, wanted %v, got %v, input %v", want, got, test.input)
+		}
+		if got, want := (BigInt{test.input}).getEncodedLength(), len(test.result); got != want {
+			t.Errorf("invalid result for encoded length, wanted %d, got %d, input %v", want, got, test.input)
 		}
 	}
 }


### PR DESCRIPTION
This PR updates the RLP library to use a two-pass encoding instead of a single-pass encoding.

In the first pass, the size of the resulting byte string is computed. After allocating the needed memory once, the RLP encoding is written into a single buffer in the second pass. This reduces the number of memory allocations and de-allocations, and thus the overall processing efficiency.

```
name            old time/op    new time/op    delta
ListEncoding-4    1.20µs ± 9%    0.51µs ± 4%  -57.18%  (p=0.000 n=10+9)

name            old alloc/op   new alloc/op   delta
ListEncoding-4      721B ± 0%      152B ± 0%  -78.92%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
ListEncoding-4      27.0 ± 0%       2.0 ± 0%  -92.59%  (p=0.000 n=10+10)
```

This also reduces the execution time of the S5 storage change benchmark by ~9%:
```
name                              old time/op  new time/op  delta
StorageChanges/S5/with_hashing-4  1.85ms ± 7%  1.68ms ± 2%  -9.41%  (p=0.000 n=10+8)
```