### PR TITLE
integrates cached hasher for key and address hashing

### DIFF
--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -48,12 +48,16 @@ func TestMptHasher_GetLowerBoundForAccountNode(t *testing.T) {
 	hashSource := NewMockHashSource(ctrl)
 	hashSource.EXPECT().getHashFor(gomock.Any()).AnyTimes().Return(common.Hash{}, nil)
 
+	nodesSource := NewMockNodeSource(ctrl)
+	nodesSource.EXPECT().getConfig().AnyTimes().Return(S5Config)
+	nodesSource.EXPECT().hashAddress(gomock.Any()).AnyTimes().Return(common.Hash{})
+
 	for _, test := range tests {
 		size, err := getLowerBoundForEncodedSize(test, 10000, nil)
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := encode(test, nil, hashSource)
+		encoded, err := encode(test, nodesSource, hashSource)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -79,6 +83,7 @@ func TestMptHasher_GetLowerBoundForBranchNode(t *testing.T) {
 	nodeSource := NewMockNodeSource(ctrl)
 	nodeSource.EXPECT().getNode(smallChild).AnyTimes().Return(smallValue, nil)
 	nodeSource.EXPECT().getNode(bigChild).AnyTimes().Return(bigValue, nil)
+	nodeSource.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(common.Hash{})
 
 	tests := []*BranchNode{
 		(&BranchNode{}),
@@ -118,6 +123,7 @@ func TestMptHasher_GetLowerBoundForExtensionNode(t *testing.T) {
 	nodeSource := NewMockNodeSource(ctrl)
 	nodeSource.EXPECT().getNode(smallChild).AnyTimes().Return(smallValue, nil)
 	nodeSource.EXPECT().getNode(bigChild).AnyTimes().Return(bigValue, nil)
+	nodeSource.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(common.Hash{})
 
 	tests := []*ExtensionNode{
 		(&ExtensionNode{next: smallChild}),
@@ -162,12 +168,16 @@ func TestMptHasher_GetLowerBoundForValueNode(t *testing.T) {
 		(&ValueNode{pathLength: 64, value: common.Value{255}}),
 	}
 
+	ctrl := gomock.NewController(t)
+	nodeSource := NewMockNodeSource(ctrl)
+	nodeSource.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(common.Hash{})
+
 	for _, test := range tests {
 		size, err := getLowerBoundForEncodedSize(test, 10000, nil)
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := encode(test, nil, nil)
+		encoded, err := encode(test, nodeSource, nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}

--- a/go/state/mpt/nibble.go
+++ b/go/state/mpt/nibble.go
@@ -1,5 +1,7 @@
 package mpt
 
+import "github.com/Fantom-foundation/Carmen/go/common"
+
 // Nibble is a 4-bit signed integer in the range 0-F. It is a single letter
 // used to navigate in the MPT structure.
 type Nibble byte
@@ -20,13 +22,33 @@ func (n Nibble) String() string {
 	return string(n.Rune())
 }
 
-// ToNibblePath converts the given path into a slice of Nibbles. Optionally, the
-// path is hashed before being converted.
-func ToNibblePath(path []byte, hashPath bool) []Nibble {
-	if hashPath {
-		hash := keccak256(path)
-		return ToNibblePath(hash[:], false)
+// AddressToNibblePath converts the given path into a slice of Nibbles. Optionally, the
+// path is hashed before being converted. The path is hashed when hashing is enabled in configuration.
+func AddressToNibblePath(address common.Address, source NodeSource) []Nibble {
+	var path []byte
+	if source != nil && source.getConfig().UseHashedPaths {
+		hash := source.hashAddress(address)
+		path = hash[:]
+	} else {
+		path = address[:]
 	}
+
+	res := make([]Nibble, len(path)*2)
+	parseNibbles(res, path)
+	return res
+}
+
+// KeyToNibblePath converts the given path into a slice of Nibbles. Optionally, the
+// path is hashed before being converted. The path is hashed when hashing is enabled in configuration.
+func KeyToNibblePath(key common.Key, source NodeSource) []Nibble {
+	var path []byte
+	if source != nil && source.getConfig().UseHashedPaths {
+		hash := source.hashKey(key)
+		path = hash[:]
+	} else {
+		path = key[:]
+	}
+
 	res := make([]Nibble, len(path)*2)
 	parseNibbles(res, path)
 	return res

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -293,6 +293,34 @@ func (mr *MockNodeSourceMockRecorder) getNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNode", reflect.TypeOf((*MockNodeSource)(nil).getNode), arg0)
 }
 
+// hashAddress mocks base method.
+func (m *MockNodeSource) hashAddress(address common.Address) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashAddress", address)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashAddress indicates an expected call of hashAddress.
+func (mr *MockNodeSourceMockRecorder) hashAddress(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashAddress", reflect.TypeOf((*MockNodeSource)(nil).hashAddress), address)
+}
+
+// hashKey mocks base method.
+func (m *MockNodeSource) hashKey(arg0 common.Key) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashKey", arg0)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashKey indicates an expected call of hashKey.
+func (mr *MockNodeSourceMockRecorder) hashKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashKey", reflect.TypeOf((*MockNodeSource)(nil).hashKey), arg0)
+}
+
 // MockNodeManager is a mock of NodeManager interface.
 type MockNodeManager struct {
 	ctrl     *gomock.Controller
@@ -422,6 +450,34 @@ func (m *MockNodeManager) getNode(arg0 NodeId) (Node, error) {
 func (mr *MockNodeManagerMockRecorder) getNode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNode", reflect.TypeOf((*MockNodeManager)(nil).getNode), arg0)
+}
+
+// hashAddress mocks base method.
+func (m *MockNodeManager) hashAddress(address common.Address) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashAddress", address)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashAddress indicates an expected call of hashAddress.
+func (mr *MockNodeManagerMockRecorder) hashAddress(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashAddress", reflect.TypeOf((*MockNodeManager)(nil).hashAddress), address)
+}
+
+// hashKey mocks base method.
+func (m *MockNodeManager) hashKey(arg0 common.Key) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashKey", arg0)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashKey indicates an expected call of hashKey.
+func (mr *MockNodeManagerMockRecorder) hashKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashKey", reflect.TypeOf((*MockNodeManager)(nil).hashKey), arg0)
 }
 
 // invalidateHash mocks base method.

--- a/go/state/mpt/nodes_test.go
+++ b/go/state/mpt/nodes_test.go
@@ -3525,9 +3525,9 @@ func (c *nodeContext) equalTries(a, b NodeId) bool {
 }
 
 func addressToNibbles(addr common.Address) []Nibble {
-	return ToNibblePath(addr[:], false)
+	return AddressToNibblePath(addr, nil)
 }
 
 func keyToNibbles(key common.Key) []Nibble {
-	return ToNibblePath(key[:], false)
+	return KeyToNibblePath(key, nil)
 }


### PR DESCRIPTION
This PR integrates new CachedHasher for:
* hashing Account addresses in the MPT
* hashing Keys in the MPT account subtree