### PR TITLE
Fix encoding of embedded nodes

### DIFF
--- a/.github/workflows/go-osx.yml
+++ b/.github/workflows/go-osx.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: Run Go tests
       working-directory: ./go
-      run: go test -v ./...
+      run: go test -v ./... -parallel 4

--- a/go/state/mpt/hasher.go
+++ b/go/state/mpt/hasher.go
@@ -183,10 +183,10 @@ func encodeBranch(node *BranchNode, nodes NodeSource, hashes HashSource) ([]byte
 			if err != nil {
 				return nil, err
 			}
-			encoded = hash[:]
+			items[i] = rlp.String{Str: hash[:]}
+		} else {
+			items[i] = rlp.Encoded{Data: encoded}
 		}
-
-		items[i] = rlp.String{Str: encoded}
 	}
 
 	// There is one 17th entry which would be filled if this node is a terminator. However,
@@ -258,9 +258,14 @@ func encodeExtension(node *ExtensionNode, nodes NodeSource, hashes HashSource) (
 		if err != nil {
 			return nil, err
 		}
-		encoded = hash[:]
+		items[1] = rlp.String{Str: hash[:]}
+	} else {
+		// TODO: the use of a direct encoding here is done for
+		// symetry with the branch node, but there is no unit test
+		// for this yet; it would require to find two keys or address
+		// with a very long common hash prefix.
+		items[1] = rlp.Encoded{Data: encoded}
 	}
-	items[1] = &rlp.String{Str: encoded}
 
 	return rlp.Encode(rlp.List{Items: items}), nil
 }

--- a/go/state/mpt/rlp/rlp.go
+++ b/go/state/mpt/rlp/rlp.go
@@ -138,6 +138,19 @@ func getEncodedLengthLength(length int) int {
 	return int(getNumBytes(uint64(length))) + 1
 }
 
+// Encoded allows for embedding an already RLP encoded data fragment in a new RLP encoding.
+type Encoded struct {
+	Data []byte
+}
+
+func (e Encoded) write(writer *writer) {
+	writer.Write(e.Data)
+}
+
+func (e Encoded) getEncodedLength() int {
+	return len(e.Data)
+}
+
 // ----------------------------------------------------------------------------
 //                           Utility Item Types
 // ----------------------------------------------------------------------------

--- a/go/state/mpt/rlp/rlp_test.go
+++ b/go/state/mpt/rlp/rlp_test.go
@@ -107,6 +107,24 @@ func expand(prefix []byte, size int) []byte {
 	return res
 }
 
+func TestEncoding_EncodeEncoded(t *testing.T) {
+	tests := [][]byte{
+		{},
+		{1},
+		{1, 2},
+		{1, 2, 3},
+	}
+
+	for _, test := range tests {
+		if got, want := Encode(Encoded{test}), test; !bytes.Equal(got, want) {
+			t.Errorf("invalid encoding, wanted %v, got %v", want, got)
+		}
+		if got, want := (Encoded{test}).getEncodedLength(), len(test); got != want {
+			t.Errorf("invalid result for encoded length, wanted %d, got %d", want, got)
+		}
+	}
+}
+
 func TestEncoding_Uint64(t *testing.T) {
 	tests := []struct {
 		input  uint64


### PR DESCRIPTION
This PR fixes the way small nodes (<32 bytes) are embedded into enclosing nodes.

This fixes a hashing issue found for block 652606.