### PR TITLE
Add sync-wrapper for stock implementations

### DIFF
--- a/go/backend/stock/synced/synced.go
+++ b/go/backend/stock/synced/synced.go
@@ -1,0 +1,64 @@
+package synced
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/stock"
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+type syncedStock[I stock.Index, V any] struct {
+	mu     sync.Mutex
+	nested stock.Stock[I, V]
+}
+
+// Sync wraps the provided stock into a synchronizing wrapper making sure that
+// at any time only one operation is performed on the given stock.
+func Sync[I stock.Index, V any](stock stock.Stock[I, V]) stock.Stock[I, V] {
+	if res, ok := stock.(*syncedStock[I, V]); ok {
+		return res
+	}
+	return &syncedStock[I, V]{nested: stock}
+}
+
+func (s *syncedStock[I, V]) New() (I, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.New()
+}
+
+func (s *syncedStock[I, V]) Get(index I) (V, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.Get(index)
+}
+
+func (s *syncedStock[I, V]) Set(index I, value V) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.Set(index, value)
+}
+
+func (s *syncedStock[I, V]) Delete(index I) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.Delete(index)
+}
+
+func (s *syncedStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.GetMemoryFootprint()
+}
+
+func (s *syncedStock[I, V]) Flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.Flush()
+}
+
+func (s *syncedStock[I, V]) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.Close()
+}

--- a/go/backend/stock/synced/synced_test.go
+++ b/go/backend/stock/synced/synced_test.go
@@ -1,0 +1,98 @@
+package synced
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/stock"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/file"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/memory"
+)
+
+var configs = []stock.NamedStockFactory{
+	{
+		ImplementationName: "syncedMemory",
+		Open:               openMemoryStock,
+	},
+	{
+		ImplementationName: "syncedFile",
+		Open:               openFileStock,
+	},
+}
+
+func TestSyncedStock(t *testing.T) {
+	for _, config := range configs {
+		stock.RunStockTests(t, config)
+	}
+}
+
+func openMemoryStock(t *testing.T, directory string) (stock.Stock[int, int], error) {
+	nested, err := memory.OpenStock[int, int](stock.IntEncoder{}, directory)
+	if err != nil {
+		return nil, err
+	}
+	return Sync(nested), nil
+}
+
+func openFileStock(t *testing.T, directory string) (stock.Stock[int, int], error) {
+	nested, err := file.OpenStock[int, int](stock.IntEncoder{}, directory)
+	if err != nil {
+		return nil, err
+	}
+	return Sync(nested), nil
+}
+
+func testCanBeAccessedConcurrently(t *testing.T, factory stock.NamedStockFactory) {
+	const N = 10
+	stock, err := factory.Open(t, t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create empty stock: %v", err)
+	}
+	defer stock.Close()
+
+	var wg sync.WaitGroup
+	var errors [N]error
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, err := stock.New()
+			if err != nil {
+				errors[i] = fmt.Errorf("unable to create new item: %v", err)
+				return
+			}
+			if err := stock.Set(id, i); err != nil {
+				errors[i] = fmt.Errorf("failed to update item: %v", err)
+				return
+			}
+			if value, err := stock.Get(id); err != nil || value != i {
+				errors[i] = fmt.Errorf("failed to load item: %v, %d != %d", err, value, i)
+				return
+			}
+			if err := stock.Delete(id); err != nil {
+				errors[i] = fmt.Errorf("failed to free item: %v", err)
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	for i, err := range errors {
+		if err != nil {
+			t.Errorf("error in goroutine %d: %v", i, err)
+		}
+	}
+}
+
+func TestSyncedStock_CanBeAccessedConcurrently(t *testing.T) {
+	// This test is expected to be run with the --race option to detect
+	// race conditions between concurrent accesses.
+	for _, config := range configs {
+		t.Run(config.ImplementationName, func(t *testing.T) {
+			testCanBeAccessedConcurrently(t, config)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a simple sync wrapper for the Stock interface to enable basic concurrent access.

The test cases added in this PR depend on #518 to detect synchronization issues.