### PR TITLE
benchmarks async vs non-async access to N-ways cache

### DIFF
--- a/go/common/nways_cache_benchmark_test.go
+++ b/go/common/nways_cache_benchmark_test.go
@@ -1,23 +1,24 @@
 package common
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 )
 
 var isink int
 
-//func BenchmarkNWaysEvictions(b *testing.B) {
-//	cacheSize := 100_000
-//	for ways := 2; ways < 128; ways *= 2 {
-//		c := NewNWaysCache[int, int](cacheSize, ways)
-//		b.Run(fmt.Sprintf("N-ways cache N %d", ways), func(b *testing.B) {
-//			for i := 0; i < b.N; i++ {
-//				c.Set(i, i)
-//			}
-//		})
-//	}
-//}
+func BenchmarkNWaysEvictions(b *testing.B) {
+	cacheSize := 100_000
+	for ways := 2; ways < 128; ways *= 2 {
+		c := NewNWaysCache[int, int](cacheSize, ways)
+		b.Run(fmt.Sprintf("N-ways cache N %d", ways), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.Set(i, i)
+			}
+		})
+	}
+}
 
 func BenchmarkNWaysSequentialWrites(b *testing.B) {
 	b.StopTimer()


### PR DESCRIPTION
This benchmarks accesses to n-ways cacche synchronously and asynchronously. These results suggests the parallel access is not faster. Please have a look if measurement is done right. 

```
BenchmarkNWaysSequentialWrites
BenchmarkNWaysSequentialWrites-8   	47443362	        25.07 ns/op
BenchmarkNWaysParallelWrites
BenchmarkNWaysParallelWrites-8     	22922908	        48.86 ns/op
BenchmarkNWaysSequentialReads
BenchmarkNWaysSequentialReads-8    	45786090	        26.43 ns/op
BenchmarkNWaysParallelReads
BenchmarkNWaysParallelReads-8      	12050571	        86.10 ns/op 
```