### PR TITLE
Kjezek/exnted cache benchmarks num ways

### DIFF
--- a/go/common/cache_test.go
+++ b/go/common/cache_test.go
@@ -78,6 +78,33 @@ func TestSettingExisting(t *testing.T) {
 	}
 }
 
+func TestPrintNumberOfEvictions(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExamplePrintNumberOfEvictions()
+}
+
+func ExamplePrintNumberOfEvictions() {
+	const N = 15_000
+	const CAPACITY = 10_000
+	keys := generateRandomKeys(N)
+
+	evictions := make(map[string]int)
+
+	for name, c := range initCaches(CAPACITY) {
+		evictions[name] = 0
+		for i := 0; i < N; i++ {
+			if _, _, evicted := c.Set(keys[i], i); evicted {
+				evictions[name]++
+			}
+		}
+	}
+	for name, count := range evictions {
+		fmt.Printf("Cache: %s, evictions: %2.2f%%\n", name, float32(count)/float32(N)*100)
+	}
+}
+
 // Cache implements a memory overlay for the key-value pair.
 // The keys can be set and obtained from the cache. The keys
 // accumulate in the cache until the cache is full, i.e. it reaches its capacity.
@@ -97,9 +124,13 @@ type cache[K any, V any] interface {
 
 func initCaches(capacity int) map[string]cache[int, int] {
 	return map[string]cache[int, int]{
-		"lruCache":            NewCache[int, int](capacity),
-		"synced lruCache":     NewSyncedCache[int, int](NewCache[int, int](capacity)),
-		"synced n-ways Cache": NewNWaysCache[int, int](capacity, 2),
+		"lruCache":        NewCache[int, int](capacity),
+		"synced lruCache": NewSyncedCache[int, int](NewCache[int, int](capacity)),
+		"2-ways Cache":    NewNWaysCache[int, int](capacity, 2),
+		"4-ways Cache":    NewNWaysCache[int, int](capacity, 4),
+		"8-ways Cache":    NewNWaysCache[int, int](capacity, 8),
+		"16-ways Cache":   NewNWaysCache[int, int](capacity, 16),
+		"32-ways Cache":   NewNWaysCache[int, int](capacity, 32),
 	}
 }
 

--- a/go/common/nways_cache_benchmark_test.go
+++ b/go/common/nways_cache_benchmark_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 )
 
-var isink int
-
 func BenchmarkNWaysEvictions(b *testing.B) {
 	cacheSize := 100_000
-	for ways := 2; ways < 128; ways *= 2 {
+	for ways := 2; ways <= 32; ways *= 2 {
 		c := NewNWaysCache[int, int](cacheSize, ways)
 		b.Run(fmt.Sprintf("N-ways cache N %d", ways), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -20,48 +18,24 @@ func BenchmarkNWaysEvictions(b *testing.B) {
 	}
 }
 
-func BenchmarkNWaysSequentialWrites(b *testing.B) {
-	b.StopTimer()
-	const N = 100_000
-	const SIZE = 1024
-	keys := generateRandomKeys(N)
-	c := NewNWaysCache[int, int](SIZE, 16)
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		c.Set(keys[i%N], i)
-	}
-}
-
 func BenchmarkNWaysParallelWrites(b *testing.B) {
 	b.StopTimer()
 	const N = 100_000
 	const SIZE = 1024
 	keys := generateRandomKeys(N)
-	c := NewNWaysCache[int, int](SIZE, 16)
 	b.StartTimer()
 
-	b.RunParallel(func(pb *testing.PB) {
-		pos := rand.Intn(N)
-		for pb.Next() {
-			pos++
-			c.Set(keys[pos%N], pos)
-		}
-	})
-}
-
-func BenchmarkNWaysSequentialReads(b *testing.B) {
-	b.StopTimer()
-	const N = 100_000
-	keys := generateRandomKeys(N)
-	c := NewNWaysCache[int, int](N, 16)
-	for i := 0; i < N; i++ {
-		c.Set(keys[i], i)
-	}
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		iSink, _ = c.Get(keys[i%N])
+	for ways := 2; ways <= 32; ways *= 2 {
+		c := NewNWaysCache[int, int](SIZE, ways)
+		b.Run(fmt.Sprintf("ways %d", ways), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				pos := rand.Intn(N)
+				for pb.Next() {
+					pos++
+					c.Set(keys[pos%N], pos)
+				}
+			})
+		})
 	}
 }
 
@@ -69,25 +43,23 @@ func BenchmarkNWaysParallelReads(b *testing.B) {
 	b.StopTimer()
 	const N = 100_000
 	keys := generateRandomKeys(N)
-	c := NewNWaysCache[int, int](N, 16)
-	for i := 0; i < N; i++ {
-		c.Set(keys[i], i)
-	}
 	b.StartTimer()
 
-	b.RunParallel(func(pb *testing.PB) {
-		pos := rand.Intn(N)
-		for pb.Next() {
-			pos++
-			isink, _ = c.Get(keys[pos%N])
+	for ways := 2; ways <= 32; ways *= 2 {
+		b.StopTimer()
+		c := NewNWaysCache[int, int](N, ways)
+		for i := 0; i < N; i++ {
+			c.Set(keys[i], i)
 		}
-	})
-}
-
-func generateRandomKeys(count int) []int {
-	keys := make([]int, 0, count)
-	for i := 0; i < count; i++ {
-		keys = append(keys, rand.Intn(1024*count))
+		b.StartTimer()
+		b.Run(fmt.Sprintf("ways %d", ways), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				pos := rand.Intn(N)
+				for pb.Next() {
+					pos++
+					iSink, _ = c.Get(keys[pos%N])
+				}
+			})
+		})
 	}
-	return keys
 }


### PR DESCRIPTION
Updated to commit only extended benchmarks, the number of ways not changed

It seems better to use 4 ways for the N-ways cache. It is up to 50% faster in benchmarks for the price of 5% more evictions.


```
BenchmarkCacheMissLatency/cache_2-ways_Cache-32         	121834335	        10.52 ns/op
BenchmarkCacheMissLatency/cache_4-ways_Cache-32         	102647392	        **11.77 ns/op**
BenchmarkCacheMissLatency/cache_8-ways_Cache-32         	77661262	        14.59 ns/op
BenchmarkCacheMissLatency/cache_16-ways_Cache-32        	64636717	        **19.49 ns/op**
BenchmarkCacheMissLatency/cache_32-ways_Cache-32        	42475720	        26.98 ns/op

BenchmarkCacheHitLatency/cache_4-ways_Cache-32          	107323800	        **11.14 ns/op**
BenchmarkCacheHitLatency/cache_8-ways_Cache-32          	87958752	        13.31 ns/op
BenchmarkCacheHitLatency/cache_16-ways_Cache-32         	78242590	        **16.04 ns/op**
BenchmarkCacheHitLatency/cache_32-ways_Cache-32         	59405781	        20.10 ns/op
BenchmarkCacheHitLatency/cache_2-ways_Cache-32          	107750337	        10.48 ns/op

BenchmarkCacheEvictions/cache_2-ways_Cache-32           	105204564	        11.88 ns/op
BenchmarkCacheEvictions/cache_4-ways_Cache-32           	87687259	        **14.09 ns/op**
BenchmarkCacheEvictions/cache_8-ways_Cache-32           	76512108	        16.94 ns/op
BenchmarkCacheEvictions/cache_16-ways_Cache-32          	48893409	        **22.97 ns/op**
BenchmarkCacheEvictions/cache_32-ways_Cache-32          	27924752	        39.89 ns/op

BenchmarkCacheSequentialWrites/cache_2-ways_Cache-32    	70803733	        17.16 ns/op
BenchmarkCacheSequentialWrites/cache_4-ways_Cache-32    	56787837	        **20.54 ns/op**
BenchmarkCacheSequentialWrites/cache_8-ways_Cache-32    	46992118	        25.89 ns/op
BenchmarkCacheSequentialWrites/cache_16-ways_Cache-32   	33750459	        **34.39 ns/op**
BenchmarkCacheSequentialWrites/cache_32-ways_Cache-32   	21528145	        55.13 ns/op

BenchmarkCacheSequentialReads/cache_16-ways_Cache-32    	38002965	        **30.87 ns/op**
BenchmarkCacheSequentialReads/cache_32-ways_Cache-32    	29652439	        36.16 ns/op
BenchmarkCacheSequentialReads/cache_2-ways_Cache-32     	53536783	        23.30 ns/op
BenchmarkCacheSequentialReads/cache_4-ways_Cache-32     	49075548	        **25.62 ns/op**
BenchmarkCacheSequentialReads/cache_8-ways_Cache-32     	39821858	        28.06 ns/op
```

```
BenchmarkNWaysEvictions/N-ways_cache_N_2-32         	100000000	        10.02 ns/op
BenchmarkNWaysEvictions/N-ways_cache_N_4-32         	95219902	        **12.26 ns/op**
BenchmarkNWaysEvictions/N-ways_cache_N_8-32         	74145246	        15.81 ns/op
BenchmarkNWaysEvictions/N-ways_cache_N_16-32        	50318221	        **22.54 ns/op**
BenchmarkNWaysEvictions/N-ways_cache_N_32-32        	31551050	        35.92 ns/op

BenchmarkNWaysParallelWrites/ways_2-32              	70083378	        17.15 ns/op
BenchmarkNWaysParallelWrites/ways_4-32              	63773581	        **18.86 ns/op**
BenchmarkNWaysParallelWrites/ways_8-32              	51780750	        22.91 ns/op
BenchmarkNWaysParallelWrites/ways_16-32             	38660892	        **30.88 ns/op**
BenchmarkNWaysParallelWrites/ways_32-32             	26888144	        44.13 ns/op

// reads slower - suspicious
BenchmarkNWaysParallelReads/ways_2-32               	19595534	        61.13 ns/op
BenchmarkNWaysParallelReads/ways_4-32               	20405810	        58.82 ns/op
BenchmarkNWaysParallelReads/ways_8-32               	34917908	        33.73 ns/op
BenchmarkNWaysParallelReads/ways_16-32              	22829469	        52.78 ns/op
BenchmarkNWaysParallelReads/ways_32-32              	23368720	        51.47 ns/op
```

Ad hoc experiment to store 15k elements in a cache with capacity of 10k
```
Cache: 2-ways Cache, evictions: 41.60%
Cache: 4-ways Cache, evictions: **37.17%**
Cache: 8-ways Cache, evictions: 34.75%
Cache: 16-ways Cache, evictions: **33.60%**
Cache: 32-ways Cache, evictions: 33.31%
Cache: lruCache, evictions: 33.32%
```

Also we could have 2-ways only for even better performance and more evictions.  