### PR TITLE
Add a make file for C++ dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------------
+# Makefile for Carmen
+#
+# v1.0 (2023/09/05) - Initial version
+#
+# (c) Fantom Foundation, 2023
+# --------------------------------------------------------------------------
+
+.PHONY: all clean
+
+all: carmen-cpp
+
+# this target builds the C++ library required by Go
+carmen-cpp: 
+	@cd ./go/lib ; \
+	./build_libcarmen.sh ;
+
+clean:
+	cd ./go ; \
+	rm -f lib/libcarmen.so ; \
+	cd ../cpp ; \
+	bazel clean ; \


### PR DESCRIPTION
This file is added to move control on the build process of Carmen from client projects to Carmen itself.

Projects like Aida include Carmen-specific build rules. This PR should help to decouple those dependencies.