### PR TITLE
fixes reading of codes using ReadFully

### DIFF
--- a/go/state/mpt/state_test.go
+++ b/go/state/mpt/state_test.go
@@ -1,11 +1,12 @@
 package mpt
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
-	"testing"
-
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"io"
+	"testing"
 )
 
 func BenchmarkStorageChanges(b *testing.B) {
@@ -38,4 +39,68 @@ func BenchmarkStorageChanges(b *testing.B) {
 			})
 		}
 	}
+}
+
+func TestReadCodes(t *testing.T) {
+	var h1 common.Hash
+	var h2 common.Hash
+	var h3 common.Hash
+
+	h1[0] = 0xAA
+	h2[0] = 0xBB
+	h3[0] = 0xCC
+
+	h1[31] = 0xAA
+	h2[31] = 0xBB
+	h3[31] = 0xCC
+
+	code1 := []byte{0xDD, 0xEE, 0xFF}
+	code2 := []byte{0xDD, 0xEE}
+	code3 := []byte{0xEE}
+
+	var data []byte
+	data = append(data, append(binary.BigEndian.AppendUint32(h1[:], uint32(len(code1))), code1...)...)
+	data = append(data, append(binary.BigEndian.AppendUint32(h2[:], uint32(len(code2))), code2...)...)
+	data = append(data, append(binary.BigEndian.AppendUint32(h3[:], uint32(len(code3))), code3...)...)
+
+	reader := &testReader{data: data, chunkSize: 3}
+	res, err := parseCodes(reader)
+	if err != nil {
+		t.Fatalf("should not fail: %s", err)
+	}
+
+	if code, exists := res[h1]; !exists || !bytes.Equal(code, code1) {
+		t.Errorf("byted do not match: %x != %x", code, code1)
+	}
+
+	if code, exists := res[h2]; !exists || !bytes.Equal(code, code2) {
+		t.Errorf("byted do not match: %x != %x", code, code1)
+	}
+
+	if code, exists := res[h3]; !exists || !bytes.Equal(code, code3) {
+		t.Errorf("byted do not match: %x != %x", code, code1)
+	}
+}
+
+// testReader reads from the stored data
+// by various chunks.
+type testReader struct {
+	data      []byte
+	chunkSize int
+}
+
+func (r *testReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+
+	if r.chunkSize >= len(r.data) {
+		n := copy(p, r.data)
+		r.data = r.data[n:]
+		return n, nil
+	}
+
+	n := copy(p, r.data[0:r.chunkSize-1])
+	r.data = r.data[n:]
+	return n, nil
 }


### PR DESCRIPTION
This PR fixes reading of codes for Scheme 5

The previous code was fragile because `reader.Read` does not guarantee  that it reads all bytes at one call. It could happen then that the code marked data as corrupted when actually it was just not read fully yet. 

It is fixed by using `io.ReadFully`

I have not updated tests as I am not sure how to test this. It seems the original code was "mostly" working, and stopped to work when the file to read was huge. 