### PR TITLE
Add ability to enumerate valid IDs in stocks

### DIFF
--- a/go/backend/stock/cache/cache.go
+++ b/go/backend/stock/cache/cache.go
@@ -70,6 +70,13 @@ func (s *cachedStock[I, V]) Delete(index I) error {
 	return nil
 }
 
+func (s *cachedStock[I, V]) GetIds() (stock.IndexSet[I], error) {
+	if err := s.Flush(); err != nil {
+		return nil, err
+	}
+	return s.underlying.GetIds()
+}
+
 func (s *cachedStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	var value V
 	res := common.NewMemoryFootprint(unsafe.Sizeof(*s))

--- a/go/backend/stock/file/file.go
+++ b/go/backend/stock/file/file.go
@@ -172,6 +172,18 @@ func (s *fileStock[I, V]) Delete(index I) error {
 	return s.freelist.Push(index)
 }
 
+func (s *fileStock[I, V]) GetIds() (stock.IndexSet[I], error) {
+	free, err := s.freelist.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	res := stock.MakeComplementSet[I](0, s.numValueSlots)
+	for _, i := range free {
+		res.Remove(i)
+	}
+	return res, nil
+}
+
 func (s *fileStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	res := common.NewMemoryFootprint(unsafe.Sizeof(*s))
 	res.AddChild("freelist", s.freelist.GetMemoryFootprint())

--- a/go/backend/stock/file/file_test.go
+++ b/go/backend/stock/file/file_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/backend/stock"
 )
 
-func TestInMemoryStock(t *testing.T) {
+func TestFileStock(t *testing.T) {
 	stock.RunStockTests(t, stock.NamedStockFactory{
 		ImplementationName: "file",
 		Open:               openFileStock,

--- a/go/backend/stock/index_set.go
+++ b/go/backend/stock/index_set.go
@@ -1,0 +1,45 @@
+package stock
+
+import "golang.org/x/exp/constraints"
+
+// ComplementSet is a set implementation for integer values in particular
+// suitable for large sets of continuous elements with few missing elements.
+type ComplementSet[I constraints.Integer] struct {
+	lowerBound I // inclusive
+	upperBound I // exclusive
+	excluded   map[I]struct{}
+}
+
+// MakeComplementSet creates a set containing the elements in the interval [lowerBound, upperBound).
+func MakeComplementSet[I constraints.Integer](lowerBound, upperBound I) *ComplementSet[I] {
+	return &ComplementSet[I]{
+		lowerBound: lowerBound,
+		upperBound: upperBound,
+	}
+}
+
+func (s *ComplementSet[I]) GetLowerBound() I {
+	return s.lowerBound
+}
+
+func (s *ComplementSet[I]) GetUpperBound() I {
+	return s.upperBound
+}
+
+func (s *ComplementSet[I]) Contains(i I) bool {
+	if i < s.lowerBound || i >= s.upperBound {
+		return false
+	}
+	_, excluded := s.excluded[i]
+	return !excluded
+}
+
+func (s *ComplementSet[I]) Remove(i I) {
+	if i < s.lowerBound || i >= s.upperBound {
+		return
+	}
+	if s.excluded == nil {
+		s.excluded = map[I]struct{}{}
+	}
+	s.excluded[i] = struct{}{}
+}

--- a/go/backend/stock/index_set_test.go
+++ b/go/backend/stock/index_set_test.go
@@ -1,0 +1,39 @@
+package stock
+
+import "testing"
+
+func TestComplementSet_LowerAndUpperBoundsAreRetained(t *testing.T) {
+	set := MakeComplementSet[int](12, 15)
+	if got, want := set.GetLowerBound(), 12; got != want {
+		t.Errorf("invalid lower bound, wanted %d, got %d", want, got)
+	}
+	if got, want := set.GetUpperBound(), 15; got != want {
+		t.Errorf("invalid upper bound, wanted %d, got %d", want, got)
+	}
+}
+
+func TestComplementSet_ContainsElementInRange(t *testing.T) {
+	set := MakeComplementSet[int](12, 15)
+	for i := 0; i < 20; i++ {
+		got := set.Contains(i)
+		want := (i >= 12) && (i < 15)
+		if got != want {
+			t.Errorf("error in membership for element %d, wanted %t, got %t", i, want, got)
+		}
+	}
+}
+
+func TestComplementSet_DoesNotContainExcludedElements(t *testing.T) {
+	set := MakeComplementSet[int](12, 19)
+	set.Remove(10)
+	set.Remove(14)
+	set.Remove(16)
+	set.Remove(20)
+	for i := 0; i < 30; i++ {
+		got := set.Contains(i)
+		want := (i >= 12) && (i < 19) && (i != 14) && (i != 16)
+		if got != want {
+			t.Errorf("error in membership for element %d, wanted %t, got %t", i, want, got)
+		}
+	}
+}

--- a/go/backend/stock/memory/memory.go
+++ b/go/backend/stock/memory/memory.go
@@ -159,6 +159,14 @@ func (s *inMemoryStock[I, V]) Delete(index I) error {
 	return nil
 }
 
+func (s *inMemoryStock[I, V]) GetIds() (stock.IndexSet[I], error) {
+	res := stock.MakeComplementSet[I](0, I(len(s.values)))
+	for _, i := range s.freeList {
+		res.Remove(i)
+	}
+	return res, nil
+}
+
 func (s *inMemoryStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	indexSize := unsafe.Sizeof(I(0))
 	valueSize := unsafe.Sizeof(s.values[0])

--- a/go/backend/stock/shadow/shadow.go
+++ b/go/backend/stock/shadow/shadow.go
@@ -3,6 +3,7 @@ package shadow
 import (
 	"errors"
 	"fmt"
+	"unsafe"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/stock"
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -61,8 +62,15 @@ func (s *shadowStock[I, V]) Delete(index I) error {
 	)
 }
 
+func (s *shadowStock[I, V]) GetIds() (stock.IndexSet[I], error) {
+	return s.primary.GetIds()
+}
+
 func (s *shadowStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
-	return s.primary.GetMemoryFootprint()
+	res := common.NewMemoryFootprint(unsafe.Sizeof(*s))
+	res.AddChild("primary", s.primary.GetMemoryFootprint())
+	res.AddChild("secondary", s.secondary.GetMemoryFootprint())
+	return res
 }
 
 func (s *shadowStock[I, V]) Flush() error {

--- a/go/backend/stock/synced/synced.go
+++ b/go/backend/stock/synced/synced.go
@@ -45,6 +45,12 @@ func (s *syncedStock[I, V]) Delete(index I) error {
 	return s.nested.Delete(index)
 }
 
+func (s *syncedStock[I, V]) GetIds() (stock.IndexSet[I], error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nested.GetIds()
+}
+
 func (s *syncedStock[I, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
This PR extends the Stock interface by a method requesting a set of IDs being active in the respective stock storage.

The intention is to use this as a building block for efficient MPT archive verification.