### PR TITLE
Refactor GetBlockHeight for Archives

### DIFF
--- a/go/backend/archive/archive.go
+++ b/go/backend/archive/archive.go
@@ -1,8 +1,9 @@
 package archive
 
 import (
-	"github.com/Fantom-foundation/Carmen/go/common"
 	"io"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
 )
 
 // An Archive retains a history of state mutations in a blockchain on a
@@ -16,8 +17,9 @@ type Archive interface {
 	// Add adds the changes of the given block to this archive.
 	Add(block uint64, update common.Update) error
 
-	// GetLastBlockHeight gets the maximum block height inserted so far, returns 0 if there is none.
-	GetLastBlockHeight() (block uint64, err error)
+	// GetBlockHeight gets the maximum block height inserted so far. If there
+	// is no block in the archive, the empty flag is set instead.
+	GetBlockHeight() (block uint64, empty bool, err error)
 
 	// Exists allows to fetch a historic existence status of a given account.
 	Exists(block uint64, account common.Address) (exists bool, err error)

--- a/go/state/archive_state.go
+++ b/go/state/archive_state.go
@@ -93,12 +93,12 @@ func (s *ArchiveState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVer
 }
 
 func (s *ArchiveState) GetArchiveState(block uint64) (State, error) {
-	lastBlock, err := s.archive.GetLastBlockHeight()
+	height, empty, err := s.archive.GetBlockHeight()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get last block in the archive; %s", err)
+		return nil, fmt.Errorf("failed to get block height from the archive; %s", err)
 	}
-	if block > lastBlock {
-		return nil, fmt.Errorf("block %d is not present in the archive (last block %d)", block, lastBlock)
+	if empty || block > height {
+		return nil, fmt.Errorf("block %d is not present in the archive (height %d)", block, height)
 	}
 	return &ArchiveState{
 		archive: s.archive,
@@ -106,10 +106,10 @@ func (s *ArchiveState) GetArchiveState(block uint64) (State, error) {
 	}, nil
 }
 
-func (s *ArchiveState) GetLastArchiveBlockHeight() (uint64, error) {
-	lastBlock, err := s.archive.GetLastBlockHeight()
+func (s *ArchiveState) GetArchiveBlockHeight() (uint64, bool, error) {
+	height, empty, err := s.archive.GetBlockHeight()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get last block in the archive; %s", err)
+		return 0, false, fmt.Errorf("failed to get last block in the archive; %s", err)
 	}
-	return lastBlock, nil
+	return height, empty, nil
 }

--- a/go/state/cpp_state.go
+++ b/go/state/cpp_state.go
@@ -238,8 +238,8 @@ func (cs *CppState) GetArchiveState(block uint64) (State, error) {
 	}, nil
 }
 
-func (cs *CppState) GetLastArchiveBlockHeight() (uint64, error) {
-	return 0, fmt.Errorf("last archive block not available in cpp state")
+func (cs *CppState) GetArchiveBlockHeight() (uint64, bool, error) {
+	return 0, false, fmt.Errorf("archive block not available in cpp state")
 }
 
 type objectId struct {

--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -195,9 +195,12 @@ func (s *GoState) GetArchiveState(block uint64) (as State, err error) {
 	if s.archive == nil {
 		return nil, fmt.Errorf("archive not enabled for this GoState")
 	}
-	lastBlock, err := s.archive.GetLastBlockHeight()
+	lastBlock, empty, err := s.archive.GetBlockHeight()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last block in the archive; %s", err)
+	}
+	if empty {
+		return nil, fmt.Errorf("block %d is not present in the archive (archive is empty)", block)
 	}
 	if block > lastBlock {
 		return nil, fmt.Errorf("block %d is not present in the archive (last block %d)", block, lastBlock)
@@ -208,15 +211,15 @@ func (s *GoState) GetArchiveState(block uint64) (as State, err error) {
 	}, nil
 }
 
-func (s *GoState) GetLastArchiveBlockHeight() (uint64, error) {
+func (s *GoState) GetArchiveBlockHeight() (uint64, bool, error) {
 	if s.archive == nil {
-		return 0, fmt.Errorf("archive not enabled for this GoState")
+		return 0, false, fmt.Errorf("archive not enabled for this GoState")
 	}
-	lastBlock, err := s.archive.GetLastBlockHeight()
+	lastBlock, empty, err := s.archive.GetBlockHeight()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get last block in the archive; %s", err)
+		return 0, false, fmt.Errorf("failed to get last block in the archive; %s", err)
 	}
-	return lastBlock, nil
+	return lastBlock, empty, nil
 }
 
 func (s *GoState) GetProof() (backend.Proof, error) {

--- a/go/state/mock_state.go
+++ b/go/state/mock_state.go
@@ -107,6 +107,22 @@ func (mr *MockStateMockRecorder) Flush() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockState)(nil).Flush))
 }
 
+// GetArchiveBlockHeight mocks base method.
+func (m *MockState) GetArchiveBlockHeight() (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArchiveBlockHeight")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetArchiveBlockHeight indicates an expected call of GetArchiveBlockHeight.
+func (mr *MockStateMockRecorder) GetArchiveBlockHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchiveBlockHeight", reflect.TypeOf((*MockState)(nil).GetArchiveBlockHeight))
+}
+
 // GetArchiveState mocks base method.
 func (m *MockState) GetArchiveState(block uint64) (State, error) {
 	m.ctrl.T.Helper()
@@ -195,21 +211,6 @@ func (m *MockState) GetHash() (common.Hash, error) {
 func (mr *MockStateMockRecorder) GetHash() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHash", reflect.TypeOf((*MockState)(nil).GetHash))
-}
-
-// GetLastArchiveBlockHeight mocks base method.
-func (m *MockState) GetLastArchiveBlockHeight() (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastArchiveBlockHeight")
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLastArchiveBlockHeight indicates an expected call of GetLastArchiveBlockHeight.
-func (mr *MockStateMockRecorder) GetLastArchiveBlockHeight() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastArchiveBlockHeight", reflect.TypeOf((*MockState)(nil).GetLastArchiveBlockHeight))
 }
 
 // GetMemoryFootprint mocks base method.
@@ -395,6 +396,22 @@ func (mr *MockdirectUpdateStateMockRecorder) Flush() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockdirectUpdateState)(nil).Flush))
 }
 
+// GetArchiveBlockHeight mocks base method.
+func (m *MockdirectUpdateState) GetArchiveBlockHeight() (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArchiveBlockHeight")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetArchiveBlockHeight indicates an expected call of GetArchiveBlockHeight.
+func (mr *MockdirectUpdateStateMockRecorder) GetArchiveBlockHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchiveBlockHeight", reflect.TypeOf((*MockdirectUpdateState)(nil).GetArchiveBlockHeight))
+}
+
 // GetArchiveState mocks base method.
 func (m *MockdirectUpdateState) GetArchiveState(block uint64) (State, error) {
 	m.ctrl.T.Helper()
@@ -483,21 +500,6 @@ func (m *MockdirectUpdateState) GetHash() (common.Hash, error) {
 func (mr *MockdirectUpdateStateMockRecorder) GetHash() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHash", reflect.TypeOf((*MockdirectUpdateState)(nil).GetHash))
-}
-
-// GetLastArchiveBlockHeight mocks base method.
-func (m *MockdirectUpdateState) GetLastArchiveBlockHeight() (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastArchiveBlockHeight")
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLastArchiveBlockHeight indicates an expected call of GetLastArchiveBlockHeight.
-func (mr *MockdirectUpdateStateMockRecorder) GetLastArchiveBlockHeight() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastArchiveBlockHeight", reflect.TypeOf((*MockdirectUpdateState)(nil).GetLastArchiveBlockHeight))
 }
 
 // GetMemoryFootprint mocks base method.

--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -132,11 +132,11 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update) error {
 	return nil
 }
 
-func (a *ArchiveTrie) GetLastBlockHeight() (block uint64, err error) {
+func (a *ArchiveTrie) GetBlockHeight() (block uint64, empty bool, err error) {
 	if len(a.roots) == 0 {
-		return 0, fmt.Errorf("no block in archive")
+		return 0, true, nil
 	}
-	return uint64(len(a.roots) - 1), nil
+	return uint64(len(a.roots) - 1), false, nil
 }
 
 func (a *ArchiveTrie) Exists(block uint64, account common.Address) (exists bool, err error) {

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -49,9 +49,10 @@ type State interface {
 	// An error is returned if the archive is not enabled or if it is empty.
 	GetArchiveState(block uint64) (State, error)
 
-	// GetLastArchiveBlockHeight provides the last block height available in the archive.
-	// An error is returned if the archive is not enabled or if it is empty.
-	GetLastArchiveBlockHeight() (uint64, error)
+	// GetArchiveBlockHeight provides the block height available in the archive. If
+	// there is no block in the archive, the empty flag is returned.
+	// An error is returned if the archive is not enabled or an IO issue occurred.
+	GetArchiveBlockHeight() (height uint64, empty bool, err error)
 
 	// States can be snapshotted.
 	backend.Snapshotable

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -92,8 +92,9 @@ type StateDB interface {
 	GetArchiveStateDB(block uint64) (StateDB, error)
 
 	// GetLastArchiveBlockHeight provides the last block height available in the archive.
-	// An error is returned if the archive is not enabled or if it is empty.
-	GetLastArchiveBlockHeight() (uint64, error)
+	// An empty archive is signaled by an extra return value. An error is returned if the
+	// archive is not enabled or some other issue has occurred.
+	GetArchiveBlockHeight() (height uint64, empty bool, err error)
 
 	// GetMemoryFootprint computes an approximation of the memory used by this state.
 	GetMemoryFootprint() *common.MemoryFootprint
@@ -1204,8 +1205,8 @@ func (s *stateDB) GetArchiveStateDB(block uint64) (StateDB, error) {
 	return CreateNonCommittableStateDBUsing(archiveState), nil
 }
 
-func (s *stateDB) GetLastArchiveBlockHeight() (uint64, error) {
-	return s.state.GetLastArchiveBlockHeight()
+func (s *stateDB) GetArchiveBlockHeight() (uint64, bool, error) {
+	return s.state.GetArchiveBlockHeight()
 }
 
 func (s *stateDB) resetTransactionContext() {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -547,7 +547,7 @@ func TestLastArchiveBlock(t *testing.T) {
 				t.Parallel()
 				dir := t.TempDir()
 				if config.name[0:3] == "cpp" {
-					t.Skipf("GetLastArchiveBlockHeight not supported by the cpp state")
+					t.Skipf("GetArchiveBlockHeight not supported by the cpp state")
 				}
 				s, err := config.createStateWithArchive(dir, archiveType)
 				if err != nil {
@@ -559,9 +559,12 @@ func TestLastArchiveBlock(t *testing.T) {
 				}
 				defer s.Close()
 
-				lastBlockHeight, err := s.GetLastArchiveBlockHeight()
-				if err == nil {
-					t.Fatalf("obtaining the last block from an empty archive did not failed")
+				_, empty, err := s.GetArchiveBlockHeight()
+				if err != nil {
+					t.Fatalf("obtaining the last block from an empty archive failed: %v", err)
+				}
+				if !empty {
+					t.Fatalf("empty archive is not reporting lack of blocks")
 				}
 
 				if err := s.Apply(1, common.Update{
@@ -580,12 +583,12 @@ func TestLastArchiveBlock(t *testing.T) {
 					t.Fatalf("failed to flush updates, %s", err)
 				}
 
-				lastBlockHeight, err = s.GetLastArchiveBlockHeight()
+				lastBlockHeight, empty, err := s.GetArchiveBlockHeight()
 				if err != nil {
 					t.Fatalf("failed to get the last available block height; %s", err)
 				}
-				if lastBlockHeight != 2 {
-					t.Errorf("invalid last available block height %d (expected 2)", lastBlockHeight)
+				if empty || lastBlockHeight != 2 {
+					t.Errorf("invalid last available block height %d (expected 2); empty: %t", lastBlockHeight, empty)
 				}
 
 				state2, err := s.GetArchiveState(lastBlockHeight)

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -103,10 +103,10 @@ func (s *syncedState) GetArchiveState(block uint64) (State, error) {
 	return s.state.GetArchiveState(block)
 }
 
-func (s *syncedState) GetLastArchiveBlockHeight() (uint64, error) {
+func (s *syncedState) GetArchiveBlockHeight() (uint64, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.state.GetLastArchiveBlockHeight()
+	return s.state.GetArchiveBlockHeight()
 }
 
 func (s *syncedState) GetProof() (backend.Proof, error) {


### PR DESCRIPTION
This PR refactors the way the block height of Archives is reported. In particular, it cleans up the reporting of empty archives.

Previous signature:
```
GetLastBlockHeight() (block uint64, err error)
```
New Signature:
```
GetBlockHeight() (block uint64, empty bool, err error)
```

The aim is to make it possible for client code to differentiate between an empty archive and a failed retrieval without the need to parse error messages.