### PR TITLE
copies all account information when copied a frozen account

### DIFF
--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -1307,8 +1307,8 @@ func (n *AccountNode) setPathLength(manager NodeManager, thisId NodeId, this sha
 		}
 		defer newHandle.Release()
 		newNode := newHandle.Get().(*AccountNode)
-		newNode.address = n.address
-		newNode.info = n.info
+		*newNode = *n
+		newNode.frozen = false
 		newNode.pathLength = length
 		return newId, false, manager.update(newId, newHandle)
 	}


### PR DESCRIPTION
This PR copies all account properties  when it is duplicated from its frozen counterpart. In particular, storageId was not copied before this PR causing missing slots in the Archive.   