### PR TITLE
Add support for StateDB reuse

### DIFF
--- a/go/common/lru_cache.go
+++ b/go/common/lru_cache.go
@@ -139,7 +139,9 @@ func (c *Cache[K, V]) Remove(key K) (original V, exists bool) {
 }
 
 func (c *Cache[K, V]) Clear() {
-	c.cache = make(map[K]*entry[K, V], c.capacity)
+	if len(c.cache) > 0 {
+		c.cache = make(map[K]*entry[K, V], c.capacity)
+	}
 	c.head = nil
 	c.tail = nil
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -3406,7 +3406,7 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 								stateDb.EndBlock(uint64(block))
 								block++
 							} else {
-								stateDb.(*stateDB).reset()
+								stateDb.(*stateDB).resetBlockContext()
 							}
 						}
 					}()


### PR DESCRIPTION
This PR adds support for reusing `stateDB` instances for archive operations.

The creation of `stateDB` instances can be costly, and may easily dominate the execution time of archive-based operations if the operation to be conducted is short-lift (e.g. fetching a single balance). With this change, a reuse mechanism is introduced.

To that end, the `StateDB` interface needed to be split into three different interfaces (suggestions for better names are welcome):
 - the `VmStateDB` interface defining the basic operations required by VM implementations for processing transactions
 - the `StateDB` interface, extending the `VmStateDB` interface by DB management operations like the committing of blocks, the fetching of archive states, or the support for Bulk loads
 - the `NonCommittableStateDB` interface, extending the `VmStateDB` interface by the ability to release underlying resources (as needed for the `stateDB` reuse); this interface is used to redefine the type returned by `GetArchiveStateDB` calls.

The integration of the ability to reuse StateDB instances for archive operations can lead to substantial performance improvements, as demonstrated in Aida's hash verification tool ([here](https://github.com/Fantom-foundation/Aida/pull/716)).
