### PR TITLE
Eliminate memory allocations and deferred executions in branch freezes

### DIFF
--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -563,16 +563,17 @@ func (n *BranchNode) Freeze(manager NodeManager, this shared.WriteHandle[Node]) 
 		return nil
 	}
 	n.frozen = true
-	for _, cur := range n.children {
-		if cur.IsEmpty() {
+	for i := 0; i < len(n.children); i++ {
+		if n.children[i].IsEmpty() {
 			continue
 		}
-		handle, err := manager.getMutableNode(cur)
+		handle, err := manager.getMutableNode(n.children[i])
 		if err != nil {
 			return err
 		}
-		defer handle.Release()
-		if err := handle.Get().Freeze(manager, handle); err != nil {
+		err = handle.Get().Freeze(manager, handle)
+		handle.Release()
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This change eliminated memory allocation calls and deferred executions in BranchNode Freeze operations.

Before:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/0cd9e3ca-ea61-4934-b7cd-23be9183adbe)

After:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/454ee42b-a5f2-4ef3-9e91-8441ae263487)
