### PR TITLE
Fix marking of branch nodes as frozen when loaded from disk

### DIFF
--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -558,6 +558,7 @@ func (n *BranchNode) IsFrozen() bool {
 
 func (n *BranchNode) MarkFrozen() {
 	n.frozen = true
+	n.frozenChildren = ^uint16(0)
 }
 
 func (n *BranchNode) Freeze(manager NodeManager, this shared.WriteHandle[Node]) error {


### PR DESCRIPTION
This change marks child nodes of frozen branch nodes loaded from disk as frozen, reducing the need for fetching child nodes when freezing archive branches.

Before:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/1453070e-5b61-43a9-8c7a-0d76e271f9b7)

After:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/31233482-346c-4426-9c83-21899c8d5e86)
