### PR TITLE
Replace Read with ReadAll in the MPT Archive root loader

### DIFF
--- a/go/backend/utils/chunk_reader.go
+++ b/go/backend/utils/chunk_reader.go
@@ -34,7 +34,7 @@ func (r *chunkReader) Read(p []byte) (int, error) {
 		return n, nil
 	}
 
-	n := copy(p, r.data[0:r.size-1])
+	n := copy(p, r.data[0:r.size])
 	r.data = r.data[n:]
 	return n, nil
 }


### PR DESCRIPTION
The utilisation of a `Read` may result in a partial read. `ReadAll` fixes this problem.