### PR TITLE
Kjezek/use pool for rlp allocations

### DIFF
--- a/go/state/mpt/hasher.go
+++ b/go/state/mpt/hasher.go
@@ -339,7 +339,7 @@ func (h ethHasher) encodeBranch(id NodeId, node *BranchNode, handle shared.Write
 			items[i] = rlp.Encoded{Data: encoded}
 		} else {
 			// passing by pointer to hash limits convTslice() calls
-			items[i] = rlp.Hash{Str: &node.hashes[i]}
+			items[i] = rlp.Hash{Hash: &node.hashes[i]}
 		}
 	}
 
@@ -434,11 +434,11 @@ func (h *ethHasher) encodeAccount(id NodeId, node *AccountNode, handle shared.Wr
 	items[0] = rlp.Uint64{Value: node.info.Nonce.ToUint64()}
 	items[1] = rlp.BigInt{Value: node.info.Balance.ToBigInt()}
 	if storageRoot.IsEmpty() {
-		items[2] = rlp.Hash{Str: &emptyNodeEthereumHash}
+		items[2] = rlp.Hash{Hash: &emptyNodeEthereumHash}
 	} else {
-		items[2] = rlp.Hash{Str: &node.storageHash}
+		items[2] = rlp.Hash{Hash: &node.storageHash}
 	}
-	items[3] = rlp.Hash{Str: &node.info.CodeHash}
+	items[3] = rlp.Hash{Hash: &node.info.CodeHash}
 	value := rlp.Encode(rlp.List{Items: items})
 
 	// Encode the leaf node by combining the partial path with the value.

--- a/go/state/mpt/rlp/rlp.go
+++ b/go/state/mpt/rlp/rlp.go
@@ -87,12 +87,12 @@ func (s String) getEncodedLength() int {
 // to slice, which executes runtime.convTSlice() many times.
 // Especially on ARM architecture it was detected to take considerable runtime.
 type Hash struct {
-	Str *common.Hash
+	Hash *common.Hash
 }
 
 func (s Hash) write(writer *writer) {
 	encodeLength(32, 0x80, writer)
-	writer.Write(s.Str[:])
+	writer.Write(s.Hash[:])
 }
 
 func (s Hash) getEncodedLength() int {


### PR DESCRIPTION
This PR reduces allocations needed for converting nodes to hashes. This part of profile is now approx. two times faster (albeit not enabling a huge change in total) 

This was measured on Macbook M1 chip - it seems that the allocations are more expensive on this platform, it was not visible on the server setup.  

Before:
<img width="2560" alt="image" src="https://github.com/Fantom-foundation/Carmen/assets/7114574/ba36979b-6e89-49b8-8c40-28bbc9dbd9d6">

After:

<img width="2543" alt="image" src="https://github.com/Fantom-foundation/Carmen/assets/7114574/73ffd9ee-5377-4e5c-83c2-2eee7cd9a603">



Before on the server - there is less allocations, but still some. 
<img width="2559" alt="image" src="https://github.com/Fantom-foundation/Carmen/assets/7114574/dba59eb4-a127-41ae-80fd-1d1ae324b233">

