### PR TITLE
Compute state hash after each update

### DIFF
--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -78,6 +78,12 @@ func (s *GoState) Apply(block uint64, update common.Update) error {
 	if err != nil {
 		return err
 	}
+
+	// Finish the block by refreshing the hash.
+	if _, err := s.GetHash(); err != nil {
+		return err
+	}
+
 	if s.archive != nil {
 		// If the writer is not yet active, start it.
 		if s.archiveWriter == nil {


### PR DESCRIPTION
This fixes the failing nightly builds of Carmen.

The state hash at the end of a Block should always be computed, as it is part of the finalization of a hash. By doing this implicitly in the State's `Apply` function, future improvements like lazy or asynchronous computation may be supported.