### PR TITLE
Replace custom hasher pool with sync.Pool

### DIFF
--- a/go/common/cached_hasher_test.go
+++ b/go/common/cached_hasher_test.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	"golang.org/x/crypto/sha3"
 	"testing"
 	"unsafe"
+
+	"golang.org/x/crypto/sha3"
 )
 
 func TestHashPassThrough(t *testing.T) {
@@ -32,41 +33,6 @@ func TestHashPassThroughRunParallel(t *testing.T) {
 	}
 }
 
-func TestHasherPool(t *testing.T) {
-	pool := newHasherPool()
-
-	hasher := pool.getHasher()
-
-	// hasher created as new - the pool is empty
-	if len(pool.pool) != 0 {
-		t.Errorf("pool is not empty: %d", len(pool.pool))
-	}
-
-	// hasher returned to the pool
-	pool.returnHasher(hasher)
-
-	if len(pool.pool) != 1 {
-		t.Errorf("pool is empty: %d", len(pool.pool))
-	}
-
-	if pool.pool[0] != hasher {
-		t.Errorf("hasher not the same as the one in the pool")
-	}
-
-	// get again from the pool
-	hasher2 := pool.getHasher()
-
-	if hasher2 != hasher {
-		t.Errorf("hasher not the same as the one in the pool")
-	}
-
-	// hasher returned - the pool is empty
-
-	if len(pool.pool) != 0 {
-		t.Errorf("pool capacity should change: %d", len(pool.pool))
-	}
-}
-
 func TestMemoryFootprint(t *testing.T) {
 	cacheSize := 1000
 	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
@@ -92,13 +58,4 @@ func TestMemoryFootprint(t *testing.T) {
 	if got, want := hasher.GetMemoryFootprint().GetChild("cache").Total(), uintptr(cacheSize)*(unsafe.Sizeof(h)+unsafe.Sizeof(adr)); got < want {
 		t.Errorf("no memory foodprint provided")
 	}
-
-	if hasher.GetMemoryFootprint().GetChild("hashersPool") == nil {
-		t.Errorf("memory footprint missing")
-	}
-
-	if got, want := hasher.GetMemoryFootprint().GetChild("hashersPool").Total(), uintptr(0); got <= want {
-		t.Errorf("no memory foodprint provided")
-	}
-
 }

--- a/go/common/keccak.go
+++ b/go/common/keccak.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"sync"
+
+	"golang.org/x/crypto/sha3"
+)
+
+var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
+
+func Keccak256(data []byte) Hash {
+	hasher := keccakHasherPool.Get().(keccakHasher)
+	hasher.Reset()
+	hasher.Write(data)
+	var res Hash
+	hasher.Read(res[:])
+	keccakHasherPool.Put(hasher)
+	return res
+}
+
+type keccakHasher interface {
+	Reset()
+	Write(in []byte) (int, error)
+	Read(out []byte) (int, error)
+}

--- a/go/state/mpt/hasher.go
+++ b/go/state/mpt/hasher.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"sync"
 
-	"golang.org/x/crypto/sha3"
-
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/state/mpt/rlp"
 	"github.com/Fantom-foundation/Carmen/go/state/mpt/shared"
@@ -199,7 +197,7 @@ func makeEthereumLikeHasher() hasher {
 
 type ethHasher struct{}
 
-var emptyNodeEthereumHash = keccak256(rlp.Encode(rlp.String{}))
+var emptyNodeEthereumHash = common.Keccak256(rlp.Encode(rlp.String{}))
 
 func (h ethHasher) updateHashes(id NodeId, manager NodeManager) (common.Hash, error) {
 	if id.IsEmpty() {
@@ -218,7 +216,7 @@ func (h ethHasher) updateHashes(id NodeId, manager NodeManager) (common.Hash, er
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return keccak256(data), nil
+	return common.Keccak256(data), nil
 }
 
 func (h ethHasher) getHash(id NodeId, source NodeSource) (common.Hash, error) {
@@ -238,7 +236,7 @@ func (h ethHasher) getHash(id NodeId, source NodeSource) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return keccak256(data), nil
+	return common.Keccak256(data), nil
 }
 
 // encode computes the RLP encoding of the given node. If needed, additional nodes are
@@ -659,22 +657,4 @@ func getLowerBoundForEncodedSizeValue(node *ValueNode, limit int, nodes NodeSour
 		value = value[1:]
 	}
 	return size + len(value) + 1, nil
-}
-
-var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
-
-func keccak256(data []byte) common.Hash {
-	hasher := keccakHasherPool.Get().(keccakHasher)
-	hasher.Reset()
-	hasher.Write(data)
-	var res common.Hash
-	hasher.Read(res[:])
-	keccakHasherPool.Put(hasher)
-	return res
-}
-
-type keccakHasher interface {
-	Reset()
-	Write(in []byte) (int, error)
-	Read(out []byte) (int, error)
 }

--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -297,11 +297,11 @@ func TestEthereumLikeHasher_BranchNode_KnownHash_EmbeddedNode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctxt := newNodeContext(t, ctrl)
 	ctxt.EXPECT().hashKey(gomock.Any()).AnyTimes().DoAndReturn(func(key common.Key) (common.Hash, error) {
-		return keccak256(key[:]), nil
+		return common.Keccak256(key[:]), nil
 	})
 
 	ctxt.EXPECT().hashKey(gomock.Any()).AnyTimes().DoAndReturn(func(k common.Key) common.Hash {
-		return keccak256(k[:])
+		return common.Keccak256(k[:])
 	})
 
 	// This test case reconstructs an issue encountered while hashing the

--- a/go/state/mpt/root_hash_test.go
+++ b/go/state/mpt/root_hash_test.go
@@ -120,7 +120,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithEvenLength(t *testing.T) {
 	// These two addresses have the same first byte when hashed:
 	addr1 := common.Address{0x04}
 	addr2 := common.Address{0x2F}
-	if a, b := keccak256(addr1[:])[0], keccak256(addr2[:])[0]; a != b {
+	if a, b := common.Keccak256(addr1[:])[0], common.Keccak256(addr2[:])[0]; a != b {
 		t.Fatalf("invalid setup, addresses do not have common prefix")
 	}
 
@@ -147,7 +147,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithOddLength(t *testing.T) {
 	// These two addresses have the same first nibble when hashed:
 	addr1 := common.Address{0x02}
 	addr2 := common.Address{0x07}
-	if a, b := keccak256(addr1[:])[0], keccak256(addr2[:])[0]; (a>>4) != (b>>4) && a == b {
+	if a, b := common.Keccak256(addr1[:])[0], common.Keccak256(addr2[:])[0]; (a>>4) != (b>>4) && a == b {
 		t.Fatalf("invalid setup, addresses do not have single prefix bit prefix")
 	}
 

--- a/go/state/mpt/verification.go
+++ b/go/state/mpt/verification.go
@@ -379,11 +379,11 @@ func (s *verificationNodeSource) getHashFor(NodeId) (common.Hash, error) {
 }
 
 func (s *verificationNodeSource) hashKey(key common.Key) common.Hash {
-	return keccak256(key[:])
+	return common.Keccak256(key[:])
 }
 
 func (s *verificationNodeSource) hashAddress(address common.Address) common.Hash {
-	return keccak256(address[:])
+	return common.Keccak256(address[:])
 }
 
 func (s *verificationNodeSource) close() error {


### PR DESCRIPTION
This PR applies some improvements to the hashing used by the CachedHasher (used for Address and Slot-Key hashing in the MPT):
 - it replaces the custom hasher pool with a `sync.Pool`
 - it uses a more direct keccak interface as the standard `hash.Hash` interface, as introduced by #553 for state hashing

The result is a ~50% speedup for missed hashes and a reduction in memory allocations:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Carmen/go/common
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
                            │ log_old.txt  │             log_new.txt              │
                            │    sec/op    │    sec/op     vs base                │
AddressHitLatency-12          65.75n ±  4%   66.31n ±  2%        ~ (p=0.481 n=10)
AddressMissLatency-12         2.844µ ±  3%   1.310µ ±  9%  -53.93% (p=0.000 n=10)
KeyHitLatency-12              52.47n ±  5%   52.66n ±  3%        ~ (p=0.684 n=10)
KeyMissLatency-12             2.727µ ±  6%   1.426µ ±  4%  -47.73% (p=0.000 n=10)
AddressesHitsRunParallel-12   651.4n ±  6%   629.0n ± 35%        ~ (p=0.912 n=10)
AddressesMissRunParallel-12   1.761µ ± 12%   1.834µ ±  8%   +4.15% (p=0.019 n=10)
geomean                       559.5n         442.6n        -20.89%

                            │  log_old.txt   │              log_new.txt               │
                            │      B/op      │     B/op      vs base                  │
AddressHitLatency-12           0.000 ±  0%     0.000 ±   0%        ~ (p=1.000 n=10) ¹
AddressMissLatency-12         537.00 ±  0%     57.00 ±   0%  -89.39% (p=0.000 n=10)
KeyHitLatency-12               0.000 ±  0%     0.000 ±   0%        ~ (p=1.000 n=10) ¹
KeyMissLatency-12             546.00 ±  0%     66.00 ±   0%  -87.91% (p=0.000 n=10)
AddressesHitsRunParallel-12   61.500 ± 22%     7.000 ± 129%  -88.62% (p=0.000 n=10)
AddressesMissRunParallel-12   537.00 ±  0%     57.00 ±   0%  -89.39% (p=0.000 n=10)
geomean                                    ²                 -76.82%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │ log_old.txt  │             log_new.txt              │
                            │  allocs/op   │ allocs/op   vs base                  │
AddressHitLatency-12          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
AddressMissLatency-12         4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.000 n=10)
KeyHitLatency-12              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
KeyMissLatency-12             4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.000 n=10)
AddressesHitsRunParallel-12   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
AddressesMissRunParallel-12   4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                                  ²               -29.29%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

The difference can also be seen in profiles. Before:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/a3934863-e9ca-4679-ad5c-34424811f049)

After:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/d2c72a0f-0268-4966-bc8d-c42d80fa740c)
