### PR TITLE
makes closing stock after fuzzing optional

### DIFF
--- a/go/backend/stock/file/file_test.go
+++ b/go/backend/stock/file/file_test.go
@@ -213,5 +213,5 @@ func FuzzFileStock_RandomOps(f *testing.F) {
 		return OpenStock[int, int](stock.IntEncoder{}, directory)
 	}
 
-	stock.FuzzStock_RandomOps(f, open)
+	stock.FuzzStock_RandomOps(f, open, true)
 }

--- a/go/backend/stock/memory/memory_test.go
+++ b/go/backend/stock/memory/memory_test.go
@@ -38,5 +38,5 @@ func FuzzMemoryStock_RandomOps(f *testing.F) {
 		return OpenStock[int, int](stock.IntEncoder{}, directory)
 	}
 
-	stock.FuzzStock_RandomOps(f, open)
+	stock.FuzzStock_RandomOps(f, open, false)
 }

--- a/go/backend/stock/stock_fuzzing_utils.go
+++ b/go/backend/stock/stock_fuzzing_utils.go
@@ -96,7 +96,7 @@ func parseOperations(b []byte) []op {
 	return ops
 }
 
-func FuzzStock_RandomOps(f *testing.F, factory OpenStockFactory) {
+func FuzzStock_RandomOps(f *testing.F, factory OpenStockFactory, shouldClose bool) {
 
 	payload1 := 99
 	payload2 := ^99
@@ -129,7 +129,9 @@ func FuzzStock_RandomOps(f *testing.F, factory OpenStockFactory) {
 		if err != nil {
 			t.Fatalf("failed to open buffered file: %v", err)
 		}
-		defer st.Close()
+		if shouldClose {
+			defer st.Close()
+		}
 
 		ids := make(map[int]bool)
 		values := make(map[int]int)

--- a/go/backend/stock/synced/synced_test.go
+++ b/go/backend/stock/synced/synced_test.go
@@ -103,5 +103,5 @@ func FuzzSyncStock_RandomOps(f *testing.F) {
 		return Sync(nested), err
 	}
 
-	stock.FuzzStock_RandomOps(f, open)
+	stock.FuzzStock_RandomOps(f, open, true)
 }


### PR DESCRIPTION
This PR makes calling stock.Close() optional at the end of a fuzzing campaign. 

There seems to be a bug in fuzzing that clean-up after the fuzzing campaign still counts into total runtime. Sometimes closing the stock may take some time, which exceeds the limit of 1s. 

In particular this happens for the memory stock, which is flushed to the disk when closing. It takes tens of seconds for some fuzzing runs. 