### PR TITLE
removes emptying value from the memory stock when the ID is released

### DIFF
--- a/go/backend/stock/memory/memory.go
+++ b/go/backend/stock/memory/memory.go
@@ -128,8 +128,6 @@ func (s *inMemoryStock[I, V]) New() (I, error) {
 	if lenFreeList > 0 {
 		index = s.freeList[lenFreeList-1]
 		s.freeList = s.freeList[0 : lenFreeList-1]
-		var value V
-		s.values[index] = value
 	} else {
 		var value V
 		s.values = append(s.values, value)


### PR DESCRIPTION
This PR avoids emptying a value from the stock, when the ID was released. It is not a real bug, but other stocks behave differently - it is up to the user not to rely of a value of a released ID, but the stock does not remove the value. Since there was this inconsistency, fuzzing reported a bug for this particular implementation. 

Furthermore, behaviour of this feature was not ideal, because it removes the old value only when a new ID was generated. It means that in a scenario where (1) ID is created, (2) value assigned under this ID, (3) ID is deleted -> a query to this ID would still return the value, because it still exists, and would be emptied only when another (4) new ID is called. 