### PR TITLE
Add lock protection to code map

### DIFF
--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -195,7 +195,7 @@ func (a *ArchiveTrie) GetCode(block uint64, account common.Address) (code []byte
 	if err != nil {
 		return nil, err
 	}
-	return a.head.code[info.CodeHash], nil
+	return a.head.GetCodeForHash(info.CodeHash), nil
 }
 
 func (a *ArchiveTrie) GetNonce(block uint64, account common.Address) (nonce common.Nonce, err error) {


### PR DESCRIPTION
This PR adds synchronization protection for the map of codes in an MPT state. The lack of synchronization was identified using Aida's new archive query feature.