### PR TITLE
Improves check messages and fixes Slot-Insert to Missing Account

### DIFF
--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -366,7 +366,7 @@ func (f *Forest) Freeze(id NodeId) error {
 func (s *Forest) Flush() error {
 	// Get snapshot of set of dirty Node IDs.
 	s.dirtyMutex.Lock()
-	ids := make([]NodeId, len(s.dirty))
+	ids := make([]NodeId, 0, len(s.dirty))
 	for id := range s.dirty {
 		ids = append(ids, id)
 	}
@@ -468,7 +468,7 @@ func (s *Forest) Check(rootId NodeId) error {
 		return err
 	}
 	defer root.Release()
-	return root.Get().Check(s, make([]Nibble, 0, common.AddressSize*2))
+	return root.Get().Check(s, rootId, make([]Nibble, 0, common.AddressSize*2))
 }
 
 // -- NodeManager interface --

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -36,17 +36,17 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 }
 
 // Check mocks base method.
-func (m *MockNode) Check(source NodeSource, path []Nibble) error {
+func (m *MockNode) Check(source NodeSource, thisId NodeId, path []Nibble) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Check", source, path)
+	ret := m.ctrl.Call(m, "Check", source, thisId, path)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Check indicates an expected call of Check.
-func (mr *MockNodeMockRecorder) Check(source, path interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) Check(source, thisId, path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockNode)(nil).Check), source, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockNode)(nil).Check), source, thisId, path)
 }
 
 // ClearStorage mocks base method.
@@ -590,17 +590,17 @@ func (m *MockleafNode) EXPECT() *MockleafNodeMockRecorder {
 }
 
 // Check mocks base method.
-func (m *MockleafNode) Check(source NodeSource, path []Nibble) error {
+func (m *MockleafNode) Check(source NodeSource, thisId NodeId, path []Nibble) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Check", source, path)
+	ret := m.ctrl.Call(m, "Check", source, thisId, path)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Check indicates an expected call of Check.
-func (mr *MockleafNodeMockRecorder) Check(source, path interface{}) *gomock.Call {
+func (mr *MockleafNodeMockRecorder) Check(source, thisId, path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockleafNode)(nil).Check), source, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockleafNode)(nil).Check), source, thisId, path)
 }
 
 // ClearStorage mocks base method.


### PR DESCRIPTION
These are actually two orthogonal changes, let me know if you would like me to split them:

 - change 1: include the node ID in error messages produced by `Check()`. This simplifies locating issues in Dumps.
 
 - change 2: inserting a slot into a non-existing account created an inconsistent trie; this was fixed; In practice should not be possible since no slot update can be processed without an associated existing contract, and thus account. However, some tests in Aida try to insert such slots, causing the tests to fail due to a trie corruption. The fix does not cost extra performance nor does it add complexity.