### PR TITLE
creates Jenkins pipeline to build the project and run the fuzzing

### DIFF
--- a/go/Jenkinsfile
+++ b/go/Jenkinsfile
@@ -1,0 +1,98 @@
+pipeline {
+    agent {label 'short'}
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                stash 'source'
+            }
+        }
+        
+        stage('Build') {
+            steps {
+                sh 'cd go && go build ./...'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'cd go && go test ./...'
+            }
+        }
+
+        stage('Parallelism Test') {
+            steps {
+                sh 'cd go/backend/stock/synced && go test ./... -race -run TestSyncedStock_CanBeAccessedConcurrently'
+            }
+        }
+
+        stage('Fuzzing') {
+            parallel {
+                stage('FastMap') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./common -fuzztime 3m -fuzz=FuzzMapOperations'
+                    }
+                }
+                stage('Fuzzing NWays Cache') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./common/ -fuzztime 3m -fuzz FuzzLruCache_RandomOps'
+                    }
+                }
+                stage('Fuzzing LRU Cache') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./common/ -fuzztime 3m -fuzz FuzzNWays_RandomOps'
+                    }
+                }
+                stage('Fuzzing Buffered File') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/utils -fuzztime 3m -fuzz FuzzBufferedFile_RandomOps'
+                    }
+                }
+                stage('Fuzzing Buffered Fil - data') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/utils -fuzztime 3m -fuzz FuzzBufferedFile_ReadWrite'
+                    }
+                }
+                stage('Fuzzing Stack') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/stock/file -fuzztime 3m -fuzz FuzzStack_RandomOps'
+                    }
+                }                
+                stage('Fuzzing Stock - file') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/stock/file -fuzztime 3m -fuzz FuzzFileStock_RandomOps'
+                    }
+                }                  
+                stage('Fuzzing Stock - memory') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/stock/memory -fuzztime 3m -fuzz FuzzMemoryStock_RandomOps'
+                    }
+                }  
+                stage('Fuzzing Stock - synced') {
+                    agent {label 'short'}
+                    steps {
+                        unstash 'source'
+                        sh 'cd go && go test ./backend/stock/memory -fuzztime 3m -fuzz FuzzSyncStock_RandomOps'
+                    }
+                } 
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a Jenkins Pipeline that builds Carmen, runs Unit tests and runs in parallel Fuzzing tests. 

There are three limitations at the moment:
1. All fuzzing tests are executed in parallel on one agent. It may be expensive, but it is ready for a later upgrade where fuzzing tests can be distributed to many agents. 
2. The length of fuzzing tests is set to 3mins only at the moment. It should be extended later when server capacity is available. 
3.  Each fuzzing creates a directory in `$GOCACHE/fuzz` with discovered paths in the code. It would be good to somehow share this cache across the nodes so that every new execution can start where previous run has ended. 

 