### PR TITLE
Move S5 import/export into an importable package

### DIFF
--- a/go/state/mpt/io/common.go
+++ b/go/state/mpt/io/common.go
@@ -1,4 +1,4 @@
-package main
+package io
 
 import (
 	"fmt"
@@ -7,25 +7,25 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/state/mpt"
 )
 
-type mptInfo struct {
-	config mpt.MptConfig
-	mode   mpt.StorageMode
+type MptInfo struct {
+	Config mpt.MptConfig
+	Mode   mpt.StorageMode
 }
 
-func checkMptDirectoryAndGetInfo(dir string) (mptInfo, error) {
+func CheckMptDirectoryAndGetInfo(dir string) (MptInfo, error) {
 	// check that the provided repository is a directory
 	if stat, err := os.Stat(dir); err != nil {
-		return mptInfo{}, fmt.Errorf("no such directory: %v", dir)
+		return MptInfo{}, fmt.Errorf("no such directory: %v", dir)
 	} else if !stat.IsDir() {
-		return mptInfo{}, fmt.Errorf("%v is not a directory", dir)
+		return MptInfo{}, fmt.Errorf("%v is not a directory", dir)
 	}
 
 	// try to obtain information of the contained MPT
 	return getMptInfo(dir)
 }
 
-func getMptInfo(dir string) (mptInfo, error) {
-	var res mptInfo
+func getMptInfo(dir string) (MptInfo, error) {
+	var res MptInfo
 	meta, present, err := mpt.ReadForestMetadata(dir + "/forest.json")
 	if err != nil {
 		return res, err
@@ -46,8 +46,8 @@ func getMptInfo(dir string) (mptInfo, error) {
 		mode = mpt.Mutable
 	}
 
-	return mptInfo{
-		config: config,
-		mode:   mode,
+	return MptInfo{
+		Config: config,
+		Mode:   mode,
 	}, nil
 }

--- a/go/state/mpt/io/io.go
+++ b/go/state/mpt/io/io.go
@@ -1,4 +1,4 @@
-package main
+package io
 
 import (
 	"bytes"
@@ -34,16 +34,16 @@ var stateMagicNumber []byte = []byte("Carmen-S5-live-v01")
 // state of the LiveDB.
 func Export(directory string, out io.Writer) error {
 
-	info, err := checkMptDirectoryAndGetInfo(directory)
+	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
 	}
 
-	if info.config.Name != mpt.S5LiveConfig.Name {
-		return fmt.Errorf("can only support export of LiveDB instances, found %v in directory", info.mode)
+	if info.Config.Name != mpt.S5LiveConfig.Name {
+		return fmt.Errorf("can only support export of LiveDB instances, found %v in directory", info.Mode)
 	}
 
-	db, err := mpt.OpenGoFileState(directory, info.config)
+	db, err := mpt.OpenGoFileState(directory, info.Config)
 	if err != nil {
 		return fmt.Errorf("failed to open LiveDB: %v", err)
 	}

--- a/go/state/mpt/io/io_test.go
+++ b/go/state/mpt/io/io_test.go
@@ -1,4 +1,4 @@
-package main
+package io
 
 import (
 	"bytes"

--- a/go/state/mpt/tool/export.go
+++ b/go/state/mpt/tool/export.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/state/mpt/io"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -31,7 +32,7 @@ func doExport(context *cli.Context) error {
 	bufferedWriter := bufio.NewWriter(file)
 	out := gzip.NewWriter(bufferedWriter)
 	return errors.Join(
-		Export(dir, out),
+		io.Export(dir, out),
 		out.Close(),
 		bufferedWriter.Flush(),
 		file.Close(),

--- a/go/state/mpt/tool/import.go
+++ b/go/state/mpt/tool/import.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	mptIo "github.com/Fantom-foundation/Carmen/go/state/mpt/io"
 	"io"
 	"os"
 
@@ -38,7 +39,7 @@ func doImport(context *cli.Context) error {
 		return err
 	}
 	return errors.Join(
-		Import(dir, in),
+		mptIo.Import(dir, in),
 		file.Close(),
 	)
 }

--- a/go/state/mpt/tool/info.go
+++ b/go/state/mpt/tool/info.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/state/mpt/io"
 
 	"github.com/Fantom-foundation/Carmen/go/state/mpt"
 	"github.com/urfave/cli/v2"
@@ -34,18 +35,18 @@ func info(context *cli.Context) error {
 	withStats := context.Bool(statsFlag.Name)
 
 	// try to obtain information of the contained MPT
-	mptInfo, err := checkMptDirectoryAndGetInfo(dir)
+	mptInfo, err := io.CheckMptDirectoryAndGetInfo(dir)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Directory contains an MPT State with the following properties:\n")
-	fmt.Printf("\tMPT Configuration: %v\n", mptInfo.config.Name)
-	fmt.Printf("\tMode:              %v\n", mptInfo.mode)
+	fmt.Printf("\tMPT Configuration: %v\n", mptInfo.Config.Name)
+	fmt.Printf("\tMode:              %v\n", mptInfo.Mode)
 
 	// attempt to open the MPT
-	if mptInfo.mode == mpt.Mutable {
-		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.config)
+	if mptInfo.Mode == mpt.Mutable {
+		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.Config)
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil
@@ -67,7 +68,7 @@ func info(context *cli.Context) error {
 			return fmt.Errorf("error closing forest: %v", err)
 		}
 	} else {
-		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.config)
+		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config)
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil
@@ -90,7 +91,7 @@ func info(context *cli.Context) error {
 
 		if withStats {
 			fmt.Printf("\nCollecting Node Statistics ...\n")
-			stats, err := mpt.GetForestNodeStatistics(dir, mptInfo.config)
+			stats, err := mpt.GetForestNodeStatistics(dir, mptInfo.Config)
 			if err != nil {
 				return err
 			}

--- a/go/state/mpt/tool/verify.go
+++ b/go/state/mpt/tool/verify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/state/mpt/io"
 	"time"
 
 	"github.com/Fantom-foundation/Carmen/go/state/mpt"
@@ -23,7 +24,7 @@ func verify(context *cli.Context) error {
 	dir := context.Args().Get(0)
 
 	// try to obtain information of the contained MPT
-	info, err := checkMptDirectoryAndGetInfo(dir)
+	info, err := io.CheckMptDirectoryAndGetInfo(dir)
 	if err != nil {
 		return err
 	}
@@ -31,10 +32,10 @@ func verify(context *cli.Context) error {
 	// run forest verification
 	observer := &verificationObserver{}
 
-	if info.mode == mpt.Immutable {
-		return mpt.VerifyArchive(dir, info.config, observer)
+	if info.Mode == mpt.Immutable {
+		return mpt.VerifyArchive(dir, info.Config, observer)
 	}
-	return mpt.VerifyFileLiveTrie(dir, info.config, observer)
+	return mpt.VerifyFileLiveTrie(dir, info.Config, observer)
 }
 
 type verificationObserver struct {


### PR DESCRIPTION
Moves S5 import/export so it can be called from go-opera-norma for the purpose of the genesis import/export.