### PR TITLE
Lock MPT threads to OS threads

### DIFF
--- a/go/state/go_state.go
+++ b/go/state/go_state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/archive"
@@ -96,6 +97,8 @@ func (s *GoState) Apply(block uint64, update common.Update) error {
 			err := make(chan error, 10)
 
 			go func() {
+				runtime.LockOSThread()
+				defer runtime.UnlockOSThread()
 				defer close(flush)
 				defer close(done)
 				// Process all incoming updates, no not stop on errors.

--- a/go/state/mpt/tool/benchmark.go
+++ b/go/state/mpt/tool/benchmark.go
@@ -149,6 +149,9 @@ func runBenchmark(
 	params benchmarkParams,
 	observer func(string, ...any),
 ) (benchmarkResult, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	res := benchmarkResult{}
 	// Start profiling ...
 	if err := startCpuProfiler(fmt.Sprintf("%s_%06d", params.cpuProfilePrefix, 1)); err != nil {

--- a/go/state/mpt/write_buffer.go
+++ b/go/state/mpt/write_buffer.go
@@ -4,6 +4,7 @@ package mpt
 
 import (
 	"errors"
+	"runtime"
 	"sort"
 	"sync"
 
@@ -82,6 +83,8 @@ func makeWriteBuffer(sink NodeSink, capacity int) WriteBuffer {
 	}
 
 	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
 		defer close(done)
 		defer close(flushDone)
 		counter := 0


### PR DESCRIPTION
This PR locks the thread used by the following goroutines to be exclusive:
- the goroutine updating archives
- the goroutine writing modified MPT nodes to the disk
- the goroutine running the data insertion benchmark

The effect is a roughly ~50% increase in write performance (evaluated on `profiling5`):
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/e20e959e-7031-4807-aa02-d00f64f71d71)

![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/05872ae3-734a-463b-b84c-5769e209767c)
