### PR TITLE
Introduce view and hash permissions

### DIFF
--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -72,7 +72,7 @@ func TestHasher_ExtensionNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			})
 
 			// The node is updated while being hashed.
-			ctxt.EXPECT().update(id, gomock.Any())
+			ctxt.EXPECT().updateHash(id, gomock.Any())
 
 			hasher := algorithm.createHasher()
 			_, _, err := hasher.updateHashes(id, ctxt)
@@ -143,7 +143,7 @@ func TestHasher_BranchNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			})
 
 			// The node is updated while being hashed.
-			ctxt.EXPECT().update(id, gomock.Any())
+			ctxt.EXPECT().updateHash(id, gomock.Any())
 			ctxt.EXPECT().hashAddress(gomock.Any()).MaxTimes(2)
 
 			hasher := algorithm.createHasher()
@@ -245,7 +245,7 @@ func TestHasher_AccountNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			})
 
 			// The node is updated while being hashed.
-			ctxt.EXPECT().update(id, gomock.Any())
+			ctxt.EXPECT().updateHash(id, gomock.Any())
 			ctxt.EXPECT().hashAddress(gomock.Any()).MaxTimes(1)
 
 			hasher := algorithm.createHasher()
@@ -403,7 +403,7 @@ func TestEthereumLikeHasher_GetLowerBoundForAccountNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := hasher.encode(AccountId(1), test, shared.WriteHandle[Node]{}, nil, nodesSource, EmptyPath(), nil)
+		encoded, err := hasher.encode(AccountId(1), test, shared.HashHandle[Node]{}, nil, nodesSource, EmptyPath(), nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -425,10 +425,10 @@ func TestEthereumLikeHasher_GetLowerBoundForBranchNode(t *testing.T) {
 	bigValue := shared.MakeShared[Node](&ValueNode{pathLength: 64, value: one})
 
 	nodeManager := NewMockNodeManager(ctrl)
-	nodeManager.EXPECT().getNode(smallChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
+	nodeManager.EXPECT().getViewAccess(smallChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
 		return smallValue.GetReadHandle(), nil
 	})
-	nodeManager.EXPECT().getNode(bigChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
+	nodeManager.EXPECT().getViewAccess(bigChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
 		return bigValue.GetReadHandle(), nil
 	})
 	nodeManager.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(common.Hash{})
@@ -446,7 +446,7 @@ func TestEthereumLikeHasher_GetLowerBoundForBranchNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := hasher.encode(BranchId(1), test, shared.WriteHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(BranchId(1), test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -468,11 +468,11 @@ func TestEthereumLikeHasher_GetLowerBoundForExtensionNode(t *testing.T) {
 	bigValue := shared.MakeShared[Node](&ValueNode{pathLength: 64, value: one})
 
 	nodeManager := NewMockNodeManager(ctrl)
-	nodeManager.EXPECT().getNode(smallChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
-		return smallValue.GetReadHandle(), nil
+	nodeManager.EXPECT().getViewAccess(smallChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ViewHandle[Node], error) {
+		return smallValue.GetViewHandle(), nil
 	})
-	nodeManager.EXPECT().getNode(bigChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
-		return bigValue.GetReadHandle(), nil
+	nodeManager.EXPECT().getViewAccess(bigChild).AnyTimes().DoAndReturn(func(NodeId) (shared.ViewHandle[Node], error) {
+		return bigValue.GetViewHandle(), nil
 	})
 
 	nodeManager.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(common.Hash{})
@@ -494,7 +494,7 @@ func TestEthereumLikeHasher_GetLowerBoundForExtensionNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := hasher.encode(ExtensionId(1), test, shared.WriteHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(ExtensionId(1), test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -531,7 +531,7 @@ func TestEthereumLikeHasher_GetLowerBoundForValueNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		encoded, err := hasher.encode(ValueId(1), test, shared.WriteHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(ValueId(1), test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}

--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -201,7 +201,8 @@ type Node interface {
 // storage. It also serves as a central source for trie configuration flags.
 type NodeSource interface {
 	getConfig() MptConfig
-	getNode(NodeId) (shared.ReadHandle[Node], error)
+	getReadAccess(NodeId) (shared.ReadHandle[Node], error)
+	getViewAccess(NodeId) (shared.ViewHandle[Node], error)
 	getHashFor(NodeId) (common.Hash, error)
 	hashKey(common.Key) common.Hash
 	hashAddress(address common.Address) common.Hash
@@ -212,7 +213,8 @@ type NodeSource interface {
 type NodeManager interface {
 	NodeSource
 
-	getMutableNode(NodeId) (shared.WriteHandle[Node], error)
+	getHashAccess(NodeId) (shared.HashHandle[Node], error)
+	getWriteAccess(NodeId) (shared.WriteHandle[Node], error)
 
 	createAccount() (NodeId, shared.WriteHandle[Node], error)
 	createBranch() (NodeId, shared.WriteHandle[Node], error)
@@ -220,6 +222,7 @@ type NodeManager interface {
 	createValue() (NodeId, shared.WriteHandle[Node], error)
 
 	update(NodeId, shared.WriteHandle[Node]) error
+	updateHash(NodeId, shared.HashHandle[Node]) error
 
 	release(NodeId) error
 }
@@ -354,7 +357,7 @@ func (n *BranchNode) getNextNodeInBranch(
 	path []Nibble,
 ) (shared.ReadHandle[Node], []Nibble, error) {
 	next := n.children[path[0]]
-	node, err := source.getNode(next)
+	node, err := source.getReadAccess(next)
 	if err != nil {
 		return shared.ReadHandle[Node]{}, nil, err
 	}
@@ -397,7 +400,7 @@ func (n *BranchNode) setNextNode(
 ) (NodeId, bool, error) {
 	// Forward call to child node.
 	child := n.children[path[0]]
-	node, err := manager.getMutableNode(child)
+	node, err := manager.getWriteAccess(child)
 	if err != nil {
 		return 0, false, err
 	}
@@ -457,7 +460,7 @@ func (n *BranchNode) setNextNode(
 			// This branch became obsolete and needs to be removed.
 			if remaining.IsExtension() {
 				// The present extension can be extended.
-				extension, err := manager.getMutableNode(remaining)
+				extension, err := manager.getWriteAccess(remaining)
 				if err != nil {
 					return 0, false, err
 				}
@@ -501,7 +504,7 @@ func (n *BranchNode) setNextNode(
 			} else if manager.getConfig().TrackSuffixLengthsInLeafNodes {
 				// If suffix lengths need to be tracked, leaf nodes require an update.
 				if remaining.IsAccount() {
-					handle, err := manager.getMutableNode(remaining)
+					handle, err := manager.getWriteAccess(remaining)
 					if err != nil {
 						return 0, false, err
 					}
@@ -511,7 +514,7 @@ func (n *BranchNode) setNextNode(
 						return 0, false, err
 					}
 				} else if remaining.IsValue() {
-					handle, err := manager.getMutableNode(remaining)
+					handle, err := manager.getWriteAccess(remaining)
 					if err != nil {
 						return 0, false, err
 					}
@@ -569,7 +572,7 @@ func (n *BranchNode) Release(manager NodeManager, thisId NodeId, this shared.Wri
 	}
 	for _, cur := range n.children {
 		if !cur.IsEmpty() {
-			handle, err := manager.getMutableNode(cur)
+			handle, err := manager.getWriteAccess(cur)
 			if err != nil {
 				return err
 			}
@@ -610,7 +613,7 @@ func (n *BranchNode) Freeze(manager NodeManager, this shared.WriteHandle[Node]) 
 		if n.children[i].IsEmpty() || n.isChildFrozen(byte(i)) {
 			continue
 		}
-		handle, err := manager.getMutableNode(n.children[i])
+		handle, err := manager.getWriteAccess(n.children[i])
 		if err != nil {
 			return err
 		}
@@ -636,7 +639,7 @@ func (n *BranchNode) Check(source NodeSource, thisId NodeId, path []Nibble) erro
 		}
 		numChildren++
 
-		if handle, err := source.getNode(child); err == nil {
+		if handle, err := source.getViewAccess(child); err == nil {
 			defer handle.Release()
 			if err := handle.Get().Check(source, child, append(path, Nibble(i))); err != nil {
 				errs = append(errs, err)
@@ -667,7 +670,7 @@ func (n *BranchNode) Dump(source NodeSource, thisId NodeId, indent string) {
 			continue
 		}
 
-		if handle, err := source.getNode(child); err == nil {
+		if handle, err := source.getViewAccess(child); err == nil {
 			defer handle.Release()
 			handle.Get().Dump(source, child, fmt.Sprintf("%s  %v ", indent, Nibble(i)))
 		} else {
@@ -689,7 +692,7 @@ func (b *BranchNode) Visit(source NodeSource, thisId NodeId, depth int, visitor 
 			continue
 		}
 
-		if handle, err := source.getNode(child); err == nil {
+		if handle, err := source.getViewAccess(child); err == nil {
 			defer handle.Release()
 			if abort, err := handle.Get().Visit(source, child, depth+1, visitor); abort || err != nil {
 				return abort, err
@@ -763,7 +766,7 @@ func (n *ExtensionNode) getNextNodeInExtension(
 		shared := shared.MakeShared[Node](EmptyNode{})
 		return shared.GetReadHandle(), nil, nil
 	}
-	handle, err := source.getNode(n.next)
+	handle, err := source.getReadAccess(n.next)
 	if err != nil {
 		return shared.ReadHandle[Node]{}, nil, err
 	}
@@ -807,7 +810,7 @@ func (n *ExtensionNode) setNextNode(
 ) (NodeId, bool, error) {
 	// Check whether the updates targets the node referenced by this extension.
 	if n.path.IsPrefixOf(path) {
-		handle, err := manager.getMutableNode(n.next)
+		handle, err := manager.getWriteAccess(n.next)
 		if err != nil {
 			return 0, false, err
 		}
@@ -847,7 +850,7 @@ func (n *ExtensionNode) setNextNode(
 
 			if newRoot.IsExtension() {
 				// If the new next is an extension, merge it into this extension.
-				handle, err := manager.getMutableNode(newRoot)
+				handle, err := manager.getWriteAccess(newRoot)
 				if err != nil {
 					return 0, false, err
 				}
@@ -870,7 +873,7 @@ func (n *ExtensionNode) setNextNode(
 
 				// Grow path length of next nodes if tracking of length is enabled.
 				if manager.getConfig().TrackSuffixLengthsInLeafNodes {
-					root, err := manager.getMutableNode(newRoot)
+					root, err := manager.getWriteAccess(newRoot)
 					if err != nil {
 						return 0, false, err
 					}
@@ -1023,7 +1026,7 @@ func (n *ExtensionNode) Release(manager NodeManager, thisId NodeId, this shared.
 	if n.frozen {
 		return nil
 	}
-	handle, err := manager.getMutableNode(n.next)
+	handle, err := manager.getWriteAccess(n.next)
 	if err != nil {
 		return err
 	}
@@ -1057,7 +1060,7 @@ func (n *ExtensionNode) Freeze(manager NodeManager, this shared.WriteHandle[Node
 		return nil
 	}
 	n.frozen = true
-	handle, err := manager.getMutableNode(n.next)
+	handle, err := manager.getWriteAccess(n.next)
 	if err != nil {
 		return err
 	}
@@ -1078,7 +1081,7 @@ func (n *ExtensionNode) Check(source NodeSource, thisId NodeId, path []Nibble) e
 	if !n.next.IsBranch() {
 		errs = append(errs, fmt.Errorf("node %v - extension path must be followed by a branch", thisId))
 	}
-	if handle, err := source.getNode(n.next); err == nil {
+	if handle, err := source.getViewAccess(n.next); err == nil {
 		defer handle.Release()
 		extended := path
 		for i := 0; i < n.path.Length(); i++ {
@@ -1103,7 +1106,7 @@ func (n *ExtensionNode) Check(source NodeSource, thisId NodeId, path []Nibble) e
 
 func (n *ExtensionNode) Dump(source NodeSource, thisId NodeId, indent string) {
 	fmt.Printf("%sExtension (ID: %v/%t, dirtyHash: %t, Embedded: %t, Hash: %v, dirtyHash: %t): %v\n", indent, thisId, n.frozen, n.nextHashDirty, n.nextIsEmbedded, formatHashForDump(n.hash), n.hashDirty, &n.path)
-	if handle, err := source.getNode(n.next); err == nil {
+	if handle, err := source.getViewAccess(n.next); err == nil {
 		defer handle.Release()
 		handle.Get().Dump(source, n.next, indent+"  ")
 	} else {
@@ -1119,7 +1122,7 @@ func (n *ExtensionNode) Visit(source NodeSource, thisId NodeId, depth int, visit
 	case VisitResponsePrune:
 		return false, nil
 	}
-	if handle, err := source.getNode(n.next); err == nil {
+	if handle, err := source.getViewAccess(n.next); err == nil {
 		defer handle.Release()
 		return handle.Get().Visit(source, n.next, depth+1, visitor)
 	} else {
@@ -1176,7 +1179,7 @@ func (n *AccountNode) GetSlot(source NodeSource, address common.Address, path []
 		return common.Value{}, false, nil
 	}
 	subPath := KeyToNibblePath(key, source)
-	root, err := source.getNode(n.storage)
+	root, err := source.getReadAccess(n.storage)
 	if err != nil {
 		return common.Value{}, false, err
 	}
@@ -1197,7 +1200,7 @@ func (n *AccountNode) SetAccount(manager NodeManager, thisId NodeId, this shared
 			}
 			// Recursively release the entire state DB.
 			// TODO: consider performing this asynchronously.
-			root, err := manager.getMutableNode(n.storage)
+			root, err := manager.getWriteAccess(n.storage)
 			if err != nil {
 				return 0, false, err
 			}
@@ -1342,7 +1345,7 @@ func (n *AccountNode) SetSlot(manager NodeManager, thisId NodeId, this shared.Wr
 	}
 
 	// Continue from here with a value insertion.
-	handle, err := manager.getMutableNode(n.storage)
+	handle, err := manager.getWriteAccess(n.storage)
 	if err != nil {
 		return 0, false, err
 	}
@@ -1406,7 +1409,7 @@ func (n *AccountNode) ClearStorage(manager NodeManager, thisId NodeId, this shar
 		return newId, false, nil
 	}
 
-	rootHandle, err := manager.getMutableNode(n.storage)
+	rootHandle, err := manager.getWriteAccess(n.storage)
 	if err != nil {
 		return thisId, false, err
 	}
@@ -1476,7 +1479,7 @@ func (n *AccountNode) Freeze(manager NodeManager, this shared.WriteHandle[Node])
 		return nil
 	}
 	n.frozen = true
-	handle, err := manager.getMutableNode(n.storage)
+	handle, err := manager.getWriteAccess(n.storage)
 	if err != nil {
 		return err
 	}
@@ -1502,7 +1505,7 @@ func (n *AccountNode) Check(source NodeSource, thisId NodeId, path []Nibble) err
 	}
 
 	if !n.storage.IsEmpty() {
-		if node, err := source.getNode(n.storage); err == nil {
+		if node, err := source.getViewAccess(n.storage); err == nil {
 			defer node.Release()
 			if err := node.Get().Check(source, n.storage, make([]Nibble, 0, common.KeySize*2)); err != nil {
 				errs = append(errs, err)
@@ -1530,7 +1533,7 @@ func (n *AccountNode) Dump(source NodeSource, thisId NodeId, indent string) {
 	if n.storage.IsEmpty() {
 		return
 	}
-	if node, err := source.getNode(n.storage); err == nil {
+	if node, err := source.getViewAccess(n.storage); err == nil {
 		defer node.Release()
 		node.Get().Dump(source, n.storage, indent+"  ")
 	} else {
@@ -1549,7 +1552,7 @@ func (n *AccountNode) Visit(source NodeSource, thisId NodeId, depth int, visitor
 	if n.storage.IsEmpty() {
 		return false, nil
 	}
-	if node, err := source.getNode(n.storage); err == nil {
+	if node, err := source.getViewAccess(n.storage); err == nil {
 		defer node.Release()
 		return node.Get().Visit(source, thisId, depth+1, visitor)
 	} else {

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -321,19 +321,34 @@ func (mr *MockNodeSourceMockRecorder) getHashFor(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getHashFor", reflect.TypeOf((*MockNodeSource)(nil).getHashFor), arg0)
 }
 
-// getNode mocks base method.
-func (m *MockNodeSource) getNode(arg0 NodeId) (shared.ReadHandle[Node], error) {
+// getReadAccess mocks base method.
+func (m *MockNodeSource) getReadAccess(arg0 NodeId) (shared.ReadHandle[Node], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getNode", arg0)
+	ret := m.ctrl.Call(m, "getReadAccess", arg0)
 	ret0, _ := ret[0].(shared.ReadHandle[Node])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// getNode indicates an expected call of getNode.
-func (mr *MockNodeSourceMockRecorder) getNode(arg0 interface{}) *gomock.Call {
+// getReadAccess indicates an expected call of getReadAccess.
+func (mr *MockNodeSourceMockRecorder) getReadAccess(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNode", reflect.TypeOf((*MockNodeSource)(nil).getNode), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getReadAccess", reflect.TypeOf((*MockNodeSource)(nil).getReadAccess), arg0)
+}
+
+// getViewAccess mocks base method.
+func (m *MockNodeSource) getViewAccess(arg0 NodeId) (shared.ViewHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getViewAccess", arg0)
+	ret0, _ := ret[0].(shared.ViewHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getViewAccess indicates an expected call of getViewAccess.
+func (mr *MockNodeSourceMockRecorder) getViewAccess(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getViewAccess", reflect.TypeOf((*MockNodeSource)(nil).getViewAccess), arg0)
 }
 
 // hashAddress mocks base method.
@@ -465,6 +480,21 @@ func (mr *MockNodeManagerMockRecorder) getConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getConfig", reflect.TypeOf((*MockNodeManager)(nil).getConfig))
 }
 
+// getHashAccess mocks base method.
+func (m *MockNodeManager) getHashAccess(arg0 NodeId) (shared.HashHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getHashAccess", arg0)
+	ret0, _ := ret[0].(shared.HashHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getHashAccess indicates an expected call of getHashAccess.
+func (mr *MockNodeManagerMockRecorder) getHashAccess(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getHashAccess", reflect.TypeOf((*MockNodeManager)(nil).getHashAccess), arg0)
+}
+
 // getHashFor mocks base method.
 func (m *MockNodeManager) getHashFor(arg0 NodeId) (common.Hash, error) {
 	m.ctrl.T.Helper()
@@ -480,34 +510,49 @@ func (mr *MockNodeManagerMockRecorder) getHashFor(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getHashFor", reflect.TypeOf((*MockNodeManager)(nil).getHashFor), arg0)
 }
 
-// getMutableNode mocks base method.
-func (m *MockNodeManager) getMutableNode(arg0 NodeId) (shared.WriteHandle[Node], error) {
+// getReadAccess mocks base method.
+func (m *MockNodeManager) getReadAccess(arg0 NodeId) (shared.ReadHandle[Node], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getMutableNode", arg0)
-	ret0, _ := ret[0].(shared.WriteHandle[Node])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// getMutableNode indicates an expected call of getMutableNode.
-func (mr *MockNodeManagerMockRecorder) getMutableNode(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getMutableNode", reflect.TypeOf((*MockNodeManager)(nil).getMutableNode), arg0)
-}
-
-// getNode mocks base method.
-func (m *MockNodeManager) getNode(arg0 NodeId) (shared.ReadHandle[Node], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getNode", arg0)
+	ret := m.ctrl.Call(m, "getReadAccess", arg0)
 	ret0, _ := ret[0].(shared.ReadHandle[Node])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// getNode indicates an expected call of getNode.
-func (mr *MockNodeManagerMockRecorder) getNode(arg0 interface{}) *gomock.Call {
+// getReadAccess indicates an expected call of getReadAccess.
+func (mr *MockNodeManagerMockRecorder) getReadAccess(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNode", reflect.TypeOf((*MockNodeManager)(nil).getNode), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getReadAccess", reflect.TypeOf((*MockNodeManager)(nil).getReadAccess), arg0)
+}
+
+// getViewAccess mocks base method.
+func (m *MockNodeManager) getViewAccess(arg0 NodeId) (shared.ViewHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getViewAccess", arg0)
+	ret0, _ := ret[0].(shared.ViewHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getViewAccess indicates an expected call of getViewAccess.
+func (mr *MockNodeManagerMockRecorder) getViewAccess(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getViewAccess", reflect.TypeOf((*MockNodeManager)(nil).getViewAccess), arg0)
+}
+
+// getWriteAccess mocks base method.
+func (m *MockNodeManager) getWriteAccess(arg0 NodeId) (shared.WriteHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getWriteAccess", arg0)
+	ret0, _ := ret[0].(shared.WriteHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getWriteAccess indicates an expected call of getWriteAccess.
+func (mr *MockNodeManagerMockRecorder) getWriteAccess(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getWriteAccess", reflect.TypeOf((*MockNodeManager)(nil).getWriteAccess), arg0)
 }
 
 // hashAddress mocks base method.
@@ -564,6 +609,20 @@ func (m *MockNodeManager) update(arg0 NodeId, arg1 shared.WriteHandle[Node]) err
 func (mr *MockNodeManagerMockRecorder) update(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "update", reflect.TypeOf((*MockNodeManager)(nil).update), arg0, arg1)
+}
+
+// updateHash mocks base method.
+func (m *MockNodeManager) updateHash(arg0 NodeId, arg1 shared.HashHandle[Node]) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "updateHash", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// updateHash indicates an expected call of updateHash.
+func (mr *MockNodeManagerMockRecorder) updateHash(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateHash", reflect.TypeOf((*MockNodeManager)(nil).updateHash), arg0, arg1)
 }
 
 // MockleafNode is a mock of leafNode interface.

--- a/go/state/mpt/nodes_test.go
+++ b/go/state/mpt/nodes_test.go
@@ -293,7 +293,7 @@ func TestBranchNode_SetAccount_WithExistingAccount_ChangedInfo(t *testing.T) {
 	// The account node that is targeted should marked to be updated.
 	readHandle := node.GetReadHandle()
 	branch := readHandle.Get().(*BranchNode)
-	account, _ := ctxt.getMutableNode(branch.children[8])
+	account, _ := ctxt.getWriteAccess(branch.children[8])
 	ctxt.EXPECT().update(branch.children[8], account)
 	account.Release()
 	readHandle.Release()
@@ -3139,7 +3139,7 @@ func TestAccountNode_Frozen_SetSlot_WithExistingSlotValue(t *testing.T) {
 	}
 
 	// check value is gone for the new root
-	newHandle, _ := ctxt.getNode(newRoot)
+	newHandle, _ := ctxt.getReadAccess(newRoot)
 	defer newHandle.Release()
 	if val, exists, _ := newHandle.Get().GetSlot(ctxt, addr, path[:], key); val != newValue || !exists {
 		t.Errorf("value for key %v should not exist", key)
@@ -3287,7 +3287,7 @@ func TestAccountNode_Frozen_ClearStorage(t *testing.T) {
 	}
 
 	// check value is gone for the new root
-	newHandle, _ := ctxt.getNode(newRoot)
+	newHandle, _ := ctxt.getReadAccess(newRoot)
 	defer newHandle.Release()
 	if _, exists, _ := newHandle.Get().GetSlot(ctxt, addr, path[:], key); exists {
 		t.Errorf("value for key %v should not exist", key)
@@ -4313,10 +4313,16 @@ func (c *nodeContext) Build(desc NodeDesc) (NodeId, *shared.Shared[Node]) {
 	}
 
 	id, node := desc.Build(c)
-	c.EXPECT().getNode(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
+	c.EXPECT().getReadAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
 		return node.GetReadHandle(), nil
 	})
-	c.EXPECT().getMutableNode(id).AnyTimes().DoAndReturn(func(NodeId) (shared.WriteHandle[Node], error) {
+	c.EXPECT().getViewAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ViewHandle[Node], error) {
+		return node.GetViewHandle(), nil
+	})
+	c.EXPECT().getHashAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.HashHandle[Node], error) {
+		return node.GetHashHandle(), nil
+	})
+	c.EXPECT().getWriteAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.WriteHandle[Node], error) {
 		return node.GetWriteHandle(), nil
 	})
 	c.index[id] = entry{id, node}
@@ -4409,7 +4415,7 @@ func (c *nodeContext) Check(t *testing.T, id NodeId) {
 }
 
 func (c *nodeContext) Freeze(id NodeId) {
-	handle, _ := c.getMutableNode(id)
+	handle, _ := c.getWriteAccess(id)
 	defer handle.Release()
 	handle.Get().Freeze(c, handle)
 }
@@ -4451,13 +4457,19 @@ func (c *nodeContext) Clone(id NodeId) (NodeId, *shared.Shared[Node]) {
 		return EmptyId(), c.index[id].node
 	}
 
-	handle, _ := c.getNode(id)
+	handle, _ := c.getReadAccess(id)
 	defer handle.Release()
 	id, res := c.cloneInternal(handle.Get())
-	c.EXPECT().getNode(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
+	c.EXPECT().getReadAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ReadHandle[Node], error) {
 		return res.GetReadHandle(), nil
 	})
-	c.EXPECT().getMutableNode(id).AnyTimes().DoAndReturn(func(NodeId) (shared.WriteHandle[Node], error) {
+	c.EXPECT().getViewAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.ViewHandle[Node], error) {
+		return res.GetViewHandle(), nil
+	})
+	c.EXPECT().getHashAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.HashHandle[Node], error) {
+		return res.GetHashHandle(), nil
+	})
+	c.EXPECT().getWriteAccess(id).AnyTimes().DoAndReturn(func(NodeId) (shared.WriteHandle[Node], error) {
 		return res.GetWriteHandle(), nil
 	})
 	c.index[id] = entry{id, res}
@@ -4592,8 +4604,8 @@ func (c *nodeContext) equal(a, b Node) bool {
 }
 
 func (c *nodeContext) equalTries(a, b NodeId) bool {
-	nodeA, _ := c.getNode(a)
-	nodeB, _ := c.getNode(b)
+	nodeA, _ := c.getReadAccess(a)
+	nodeB, _ := c.getReadAccess(b)
 	defer nodeA.Release()
 	defer nodeB.Release()
 	return c.equal(nodeA.Get(), nodeB.Get())

--- a/go/state/mpt/shared/shared_test.go
+++ b/go/state/mpt/shared/shared_test.go
@@ -74,6 +74,94 @@ func TestShared_WriteAccessBlocksWriteAccess(t *testing.T) {
 	}
 }
 
+type noHandle struct{}
+
+func (noHandle) Release() {}
+
+func TestShared_AccessCombinations(t *testing.T) {
+	type releaser interface {
+		Release()
+	}
+
+	shared := MakeShared(10)
+
+	permission := map[string]func() (releaser, bool){
+		"none": func() (releaser, bool) { return noHandle{}, true },
+		"read": func() (releaser, bool) {
+			handle, success := shared.TryGetReadHandle()
+			return &handle, success
+		},
+		"view": func() (releaser, bool) {
+			handle, success := shared.TryGetViewHandle()
+			return &handle, success
+		},
+		"hash": func() (releaser, bool) {
+			handle, success := shared.TryGetHashHandle()
+			return &handle, success
+		},
+		"write": func() (releaser, bool) {
+			handle, success := shared.TryGetWriteHandle()
+			return &handle, success
+		},
+	}
+
+	// describes all combinations of held and wanted permissions
+	rules := map[string]map[string]bool{
+		"none": {
+			"none":  true,
+			"read":  true,
+			"view":  true,
+			"hash":  true,
+			"write": true,
+		},
+		"read": {
+			"none":  true,
+			"read":  true,
+			"view":  true,
+			"hash":  true,
+			"write": false,
+		},
+		"view": {
+			"none":  true,
+			"read":  true,
+			"view":  true,
+			"hash":  false,
+			"write": false,
+		},
+		"hash": {
+			"none":  true,
+			"read":  true,
+			"view":  false,
+			"hash":  false,
+			"write": false,
+		},
+		"write": {
+			"none":  true,
+			"read":  false,
+			"view":  false,
+			"hash":  false,
+			"write": false,
+		},
+	}
+
+	for held, rule := range rules {
+		have, success := permission[held]()
+		if !success {
+			t.Fatalf("failed to get permission %s", held)
+		}
+		for want, expected := range rule {
+			got, success := permission[want]()
+			if success != expected {
+				t.Errorf("unexpected permission grant, held %s, wanted %s, expected %t, got %t", held, want, expected, success)
+			}
+			if success {
+				got.Release()
+			}
+		}
+		have.Release()
+	}
+}
+
 func TestShared_ReadIsInvalidatesByRelease(t *testing.T) {
 	shared := MakeShared(10)
 
@@ -90,6 +178,44 @@ func TestShared_ReadIsInvalidatesByRelease(t *testing.T) {
 	read.Release()
 	if read.Valid() {
 		t.Errorf("released read handle should be invalid")
+	}
+}
+
+func TestShared_ViewIsInvalidatesByRelease(t *testing.T) {
+	shared := MakeShared(10)
+
+	view := ViewHandle[int]{}
+	if view.Valid() {
+		t.Errorf("default view handle should not be valid")
+	}
+
+	view = shared.GetViewHandle()
+	if !view.Valid() {
+		t.Errorf("granted view handle should be valid")
+	}
+
+	view.Release()
+	if view.Valid() {
+		t.Errorf("released view handle should be invalid")
+	}
+}
+
+func TestShared_HashIsInvalidatesByRelease(t *testing.T) {
+	shared := MakeShared(10)
+
+	hash := HashHandle[int]{}
+	if hash.Valid() {
+		t.Errorf("default hash handle should not be valid")
+	}
+
+	hash = shared.GetHashHandle()
+	if !hash.Valid() {
+		t.Errorf("granted hash handle should be valid")
+	}
+
+	hash.Release()
+	if hash.Valid() {
+		t.Errorf("released hash handle should be invalid")
 	}
 }
 
@@ -174,27 +300,41 @@ func TestShared_WriteHandleSynchronizesAccess(t *testing.T) {
 }
 
 func Benchmark_ReadSequential(b *testing.B) {
-	const N = 1_000
 	shared := MakeShared(0)
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < N; j++ {
-			read := shared.GetReadHandle()
-			read.Get()
-			read.Release()
-		}
+		read := shared.GetReadHandle()
+		read.Get()
+		read.Release()
 	}
 }
 
 func Benchmark_ReadParallel(b *testing.B) {
-	const N = 1_000
 	shared := MakeShared(0)
 	b.RunParallel(func(b *testing.PB) {
 		for b.Next() {
-			for j := 0; j < N; j++ {
-				read := shared.GetReadHandle()
-				read.Get()
-				read.Release()
-			}
+			read := shared.GetReadHandle()
+			read.Get()
+			read.Release()
+		}
+	})
+}
+
+func Benchmark_ViewSequential(b *testing.B) {
+	shared := MakeShared(0)
+	for i := 0; i < b.N; i++ {
+		view := shared.GetViewHandle()
+		view.Get()
+		view.Release()
+	}
+}
+
+func Benchmark_ViewParallel(b *testing.B) {
+	shared := MakeShared(0)
+	b.RunParallel(func(b *testing.PB) {
+		for b.Next() {
+			view := shared.GetViewHandle()
+			view.Get()
+			view.Release()
 		}
 	})
 }

--- a/go/state/mpt/verification.go
+++ b/go/state/mpt/verification.go
@@ -471,7 +471,7 @@ func (s *verificationNodeSource) getConfig() MptConfig {
 	return s.config
 }
 
-func (s *verificationNodeSource) getNode(id NodeId) (shared.ReadHandle[Node], error) {
+func (s *verificationNodeSource) getShared(id NodeId) (*shared.Shared[Node], error) {
 	var node Node
 	var err error
 	if s.overwriteId == id && s.overwriteNode != nil {
@@ -492,10 +492,25 @@ func (s *verificationNodeSource) getNode(id NodeId) (shared.ReadHandle[Node], er
 		node, err = &value, e
 	}
 	if err != nil {
+		return nil, err
+	}
+	return shared.MakeShared[Node](node), nil
+}
+
+func (s *verificationNodeSource) getReadAccess(id NodeId) (shared.ReadHandle[Node], error) {
+	node, err := s.getShared(id)
+	if err != nil {
 		return shared.ReadHandle[Node]{}, err
 	}
-	shared := shared.MakeShared[Node](node)
-	return shared.GetReadHandle(), nil
+	return node.GetReadHandle(), nil
+}
+
+func (s *verificationNodeSource) getViewAccess(id NodeId) (shared.ViewHandle[Node], error) {
+	node, err := s.getShared(id)
+	if err != nil {
+		return shared.ViewHandle[Node]{}, err
+	}
+	return node.GetViewHandle(), nil
 }
 
 func (s *verificationNodeSource) getHashFor(NodeId) (common.Hash, error) {

--- a/go/state/mpt/write_buffer.go
+++ b/go/state/mpt/write_buffer.go
@@ -39,7 +39,7 @@ type WriteBuffer interface {
 // NodeSink defines an interface for where WriteBuffers are able to write
 // node information to.
 type NodeSink interface {
-	Write(NodeId, shared.ReadHandle[Node]) error
+	Write(NodeId, shared.ViewHandle[Node]) error
 }
 
 func MakeWriteBuffer(sink NodeSink) WriteBuffer {
@@ -191,7 +191,7 @@ func (b *writeBuffer) emptyBuffer() {
 
 		// Lock read access on the node before unlocking the buffer to avoid
 		// another thread to cancel the write and gain write access in-between.
-		handle := node.GetReadHandle()
+		handle := node.GetViewHandle()
 		b.bufferMutex.Unlock()
 
 		if err := b.sink.Write(id, handle); err != nil {

--- a/go/state/mpt/write_buffer_mocks.go
+++ b/go/state/mpt/write_buffer_mocks.go
@@ -113,7 +113,7 @@ func (m *MockNodeSink) EXPECT() *MockNodeSinkMockRecorder {
 }
 
 // Write mocks base method.
-func (m *MockNodeSink) Write(arg0 NodeId, arg1 shared.ReadHandle[Node]) error {
+func (m *MockNodeSink) Write(arg0 NodeId, arg1 shared.ViewHandle[Node]) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/go/state/mpt/write_buffer_test.go
+++ b/go/state/mpt/write_buffer_test.go
@@ -29,9 +29,9 @@ func TestWriteBuffer_CanFlushASingleElement(t *testing.T) {
 
 	id := ValueId(12)
 	node := shared.MakeShared[Node](EmptyNode{})
-	read := node.GetReadHandle()
-	sink.EXPECT().Write(id, read)
-	read.Release()
+	view := node.GetViewHandle()
+	sink.EXPECT().Write(id, view)
+	view.Release()
 
 	buffer := MakeWriteBuffer(sink)
 	defer buffer.Close()
@@ -113,7 +113,7 @@ func TestWriteBuffer_AllQueuedEntriesArePresentUntilWritten(t *testing.T) {
 
 	written := map[NodeId]bool{}
 
-	sink.EXPECT().Write(gomock.Any(), gomock.Any()).AnyTimes().Do(func(id NodeId, _ shared.ReadHandle[Node]) {
+	sink.EXPECT().Write(gomock.Any(), gomock.Any()).AnyTimes().Do(func(id NodeId, _ shared.ViewHandle[Node]) {
 		// Check that everything that was enqueued and is not yet written is still present.
 		enqueuedLock.Lock()
 		for id := range enqueued {
@@ -150,13 +150,13 @@ func TestWriteBuffer_CheckThatLockedNodesAreWaitedFor(t *testing.T) {
 	value1 := shared.MakeShared[Node](EmptyNode{})
 	value2 := shared.MakeShared[Node](EmptyNode{})
 
-	read1 := value1.GetReadHandle()
-	sink.EXPECT().Write(id1, read1)
-	read1.Release()
+	view1 := value1.GetViewHandle()
+	sink.EXPECT().Write(id1, view1)
+	view1.Release()
 
-	read2 := value2.GetReadHandle()
-	sink.EXPECT().Write(id2, read2)
-	read2.Release()
+	view2 := value2.GetViewHandle()
+	sink.EXPECT().Write(id2, view2)
+	view2.Release()
 
 	buffer := makeWriteBuffer(sink, 100)
 	defer buffer.Close()
@@ -186,10 +186,10 @@ func TestWriteBuffer_AFailedFlushIsReported(t *testing.T) {
 
 	id := ValueId(12)
 	node := shared.MakeShared[Node](EmptyNode{})
-	read := node.GetReadHandle()
+	view := node.GetViewHandle()
 	err := fmt.Errorf("TestError")
-	sink.EXPECT().Write(id, read).Return(err)
-	read.Release()
+	sink.EXPECT().Write(id, view).Return(err)
+	view.Release()
 
 	buffer := MakeWriteBuffer(sink)
 	defer buffer.Close()


### PR DESCRIPTION
This PR introduces two additional levels of access permissions to nodes: *view* and *hash* permission.

The total set of permissions after this PR is as follows:
- read: grants the permission to read the content of nodes (but not hash-related data)
- view: grants the permission to read the content and hash related data of a node
- hash: grants the permission to read the content of the node and modify hash-related data
- write: grants the permission to modify any information of a node

The following matrix describes the relationship between those permissions (+ indicating that the wanted permission is granted, - that it is denied):
| want\held | none | read |  view | hash | write |
|:-----------:|:------:|:------:|:---:|:---:|:---:|
| read          |  +  |  +    |  + | +  | - |
| view          |  + |    +  | +  |  - | - |
| hash         |  + |   +   |  - |  - | - |
| write         |  + |   -   |  - | -  | - |

The *read* permission is intended for lookup operations in an MPT, as it used to be before this PR. However, serializers, consistency checks, dumps, and visit operations accessing hashing data are now required to request *view* permissions.

The *hash* permission is the new type of permission required for hashing algorithms updating the hashes of nodes (formerly those requested full *write* permissions). Finally, the *write* permission is required by code modifying the MPT content.

The aim of this change is to facilitate read operations while computing hashes of MPTs. This way, hashing can be conducted in parallel to block-processing operations.
