### PR TITLE
extends code coverage in common package

### DIFF
--- a/go/backend/archive/ldb/archive.go
+++ b/go/backend/archive/ldb/archive.go
@@ -15,7 +15,7 @@ import (
 type Archive struct {
 	db                       *common.LevelDbMemoryFootprintWrapper
 	reincarnationNumberCache map[common.Address]int
-	accountHashCache         *common.Cache[common.Address, common.Hash]
+	accountHashCache         *common.LruCache[common.Address, common.Hash]
 	batch                    leveldb.Batch
 	lastBlockCache           blockCache
 	addMutex                 sync.Mutex
@@ -25,7 +25,7 @@ func NewArchive(db *common.LevelDbMemoryFootprintWrapper) (*Archive, error) {
 	return &Archive{
 		db:                       db,
 		reincarnationNumberCache: map[common.Address]int{},
-		accountHashCache:         common.NewCache[common.Address, common.Hash](100_000),
+		accountHashCache:         common.NewLruCache[common.Address, common.Hash](100_000),
 	}, nil
 }
 

--- a/go/backend/depot/cache/cachedepot.go
+++ b/go/backend/depot/cache/cachedepot.go
@@ -10,13 +10,13 @@ import (
 // Depot wraps a Depot with a cache.
 type Depot[I common.Identifier] struct {
 	depot     depot.Depot[I]
-	cache     *common.Cache[I, []byte]
-	sizeCache *common.Cache[I, int]
+	cache     *common.LruCache[I, []byte]
+	sizeCache *common.LruCache[I, int]
 }
 
 // NewDepot constructs a new Depot instance, caching access to the wrapped Depot.
 func NewDepot[I common.Identifier](wrapped depot.Depot[I], cacheCapacity int, sizeCacheCapacity int) *Depot[I] {
-	return &Depot[I]{wrapped, common.NewCache[I, []byte](cacheCapacity), common.NewCache[I, int](sizeCacheCapacity)}
+	return &Depot[I]{wrapped, common.NewLruCache[I, []byte](cacheCapacity), common.NewLruCache[I, int](sizeCacheCapacity)}
 }
 
 func (m *Depot[I]) Set(id I, value []byte) (err error) {

--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -11,12 +11,12 @@ import (
 // Index wraps another index and a cache
 type Index[K comparable, I common.Identifier] struct {
 	wrapped index.Index[K, I]
-	cache   *common.Cache[K, I]
+	cache   *common.LruCache[K, I]
 }
 
 // NewIndex constructs a new Index instance, which either delegates to the wrapped index or gets data from the cache if it has them.
 func NewIndex[K comparable, I common.Identifier](wrapped index.Index[K, I], cacheCapacity int) *Index[K, I] {
-	return &Index[K, I]{wrapped, common.NewCache[K, I](cacheCapacity)}
+	return &Index[K, I]{wrapped, common.NewLruCache[K, I](cacheCapacity)}
 }
 
 // Size returns the number of registered keys.

--- a/go/backend/pagepool/pagepool.go
+++ b/go/backend/pagepool/pagepool.go
@@ -10,7 +10,7 @@ import (
 // is evicted when the capacity exceeds, and stored using PageStorage. When the pool is asked for
 // a page that does not exist in this pool, it tries to load it from the PageStorage.
 type PagePool[ID comparable, T Page] struct {
-	pagePool    *common.Cache[ID, T]
+	pagePool    *common.LruCache[ID, T]
 	pageStore   PageStorage[ID] // store where the overflown pages will be stored and where they are read from
 	pageFactory func() T
 
@@ -40,7 +40,7 @@ type PageStorage[ID any] interface {
 // freeIds are used for allocating IDs for new pages, when they are all used, this pool starts to allocate new IDs.
 func NewPagePool[ID comparable, T Page](capacity int, pageStore PageStorage[ID], pageFactory func() T) *PagePool[ID, T] {
 	return &PagePool[ID, T]{
-		pagePool:    common.NewCache[ID, T](capacity),
+		pagePool:    common.NewLruCache[ID, T](capacity),
 		pageStore:   pageStore,
 		pageFactory: pageFactory,
 		freePages:   make([]T, 0, capacity),

--- a/go/backend/store/cache/cachedstore.go
+++ b/go/backend/store/cache/cachedstore.go
@@ -10,13 +10,13 @@ import (
 // Store wraps a cache and a store. It caches the stored keys
 type Store[I common.Identifier, V any] struct {
 	store store.Store[I, V]
-	cache *common.Cache[I, V]
+	cache *common.LruCache[I, V]
 }
 
 // NewStore creates a new store wrapping the input one, and creates a new cache with the given capacity
 // this store maintains a cache of keys
 func NewStore[I common.Identifier, V any](store store.Store[I, V], cacheCapacity int) *Store[I, V] {
-	return &Store[I, V]{store, common.NewCache[I, V](cacheCapacity)}
+	return &Store[I, V]{store, common.NewLruCache[I, V](cacheCapacity)}
 }
 
 func (m *Store[I, V]) Set(id I, value V) error {

--- a/go/backend/store/cache/cachedstore_test.go
+++ b/go/backend/store/cache/cachedstore_test.go
@@ -30,7 +30,7 @@ func TestStoreCacheFilled(t *testing.T) {
 
 	// default value is cached
 	if _, exists := store.cache.Get(0); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 
 	// fill in next store elements
@@ -43,13 +43,13 @@ func TestStoreCacheFilled(t *testing.T) {
 
 	// and check the cache
 	if _, exists := store.cache.Get(0); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(1); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(2); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 }
 
@@ -74,16 +74,16 @@ func TestStoreCacheEviction(t *testing.T) {
 
 	// and check the cache - first one is evicted
 	if _, exists := store.cache.Get(0); exists {
-		t.Errorf("Cache item must be evicted")
+		t.Errorf("LruCache item must be evicted")
 	}
 	if _, exists := store.cache.Get(1); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(2); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(3); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 
 	// but the item is in the store - it will go back to the cache
@@ -93,15 +93,15 @@ func TestStoreCacheEviction(t *testing.T) {
 
 	// first value went back to the cache
 	if _, exists := store.cache.Get(0); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(1); exists {
-		t.Errorf("Cache item must be evicted")
+		t.Errorf("LruCache item must be evicted")
 	}
 	if _, exists := store.cache.Get(2); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 	if _, exists := store.cache.Get(3); !exists {
-		t.Errorf("Cache must be filled")
+		t.Errorf("LruCache must be filled")
 	}
 }

--- a/go/common/cache.go
+++ b/go/common/cache.go
@@ -1,0 +1,49 @@
+package common
+
+// Cache implements a memory overlay for the key-value pair.
+// The keys can be set and obtained from the cache. The keys
+// accumulate in the cache until the cache is full, i.e. it reaches its capacity.
+// When this happens, a new key causes eviction of another key.
+type Cache[K any, V any] interface {
+	// Get returns a value from the cache or false. If the value exists, its number of use is updated
+	Get(key K) (V, bool)
+	// Set associates a key to the cache.
+	// If the key is already present, the value is updated and the key marked as
+	// used. If the value is not present, a new entry is added to this
+	// cache. This causes another entry to be removed if the cache size is exceeded.
+	Set(key K, val V) (evictedKey K, evictedValue V, evicted bool)
+
+	// Remove deletes the key from the map and returns the deleted value
+	Remove(key K) (original V, exists bool)
+
+	// GetOrSet tries to locate the input key in the cache. IF the key exists, its value is returned.
+	// If the key does not exist, the input value is stored under this key.
+	// When the key is stored in this cache, another key and value may be evicted.
+	// This method returns true if the key was present in the cache. It also returns if another key was evicted due
+	// to inserting this key.
+	GetOrSet(key K, val V) (current V, present bool, evictedKey K, evictedValue V, evicted bool)
+
+	// Iterate goes over all cached entries and calls the callback for each key-value pair in the cache.
+	// When the callback returns false, iteration is interrupted.
+	Iterate(callback func(K, V) bool)
+
+	// IterateMutable goes over all cached entries and calls the callback for each key-value pair in the cache.
+	// When the callback returns false, iteration is interrupted.
+	// This method provides a pointer to the value allowing for its possible modifications.
+	// The value should be potentially modified in-place while keeping ownership of the pointer to the callback method.
+	IterateMutable(callback func(K, *V) bool)
+
+	// Clear removes all elements from the cahce.
+	Clear()
+
+	// GetMemoryFootprint provides the size of the cache in bytes
+	// If V is a pointer type, it needs to provide the size of a referenced value.
+	// If the size is different for individual values, use GetDynamicMemoryFootprint instead.
+	GetMemoryFootprint(referencedValueSize uintptr) *MemoryFootprint
+
+	// GetDynamicMemoryFootprint provides the size of the cache in bytes for values.
+	// It provides a callback method to calculate the size of each value individually.
+	// This is useful in situations where each value has a different size, for instance, slices
+	// or nested structs.
+	GetDynamicMemoryFootprint(valueSizeProvider func(V) uintptr) *MemoryFootprint
+}

--- a/go/common/cache_fuzzing_test.go
+++ b/go/common/cache_fuzzing_test.go
@@ -15,14 +15,14 @@ import (
 // i.e., it is not checked whether the eviction policy is correct.
 
 func FuzzLruCache_RandomOps(f *testing.F) {
-	fn := func() cache[int8, int16] {
-		return NewCache[int8, int16](128)
+	fn := func() Cache[int8, int16] {
+		return NewLruCache[int8, int16](128)
 	}
 	fuzzing.Fuzz[cacheFuzzingContext](f, &cacheFuzzingCampaign{fn})
 }
 
 func FuzzNWays_RandomOps(f *testing.F) {
-	fn := func() cache[int8, int16] {
+	fn := func() Cache[int8, int16] {
 		return NewNWaysCache[int8, int16](128, 16)
 	}
 	fuzzing.Fuzz[cacheFuzzingContext](f, &cacheFuzzingCampaign{fn})
@@ -46,7 +46,7 @@ func (op cacheOpType) serialise() []byte {
 }
 
 type cacheFuzzingCampaign struct {
-	initCache func() cache[int8, int16] // factory to create cache instance.
+	initCache func() Cache[int8, int16] // factory to create cache instance.
 }
 
 func (c *cacheFuzzingCampaign) Init() []fuzzing.OperationSequence[cacheFuzzingContext] {
@@ -91,7 +91,7 @@ func (c *cacheFuzzingCampaign) Cleanup(fuzzing.TestingT, *cacheFuzzingContext) {
 }
 
 type cacheFuzzingContext struct {
-	cache  cache[int8, int16]
+	cache  Cache[int8, int16]
 	shadow map[int8]int16
 }
 

--- a/go/common/cached_hasher.go
+++ b/go/common/cached_hasher.go
@@ -15,7 +15,7 @@ import (
 // hashing, i.e. the caller must make sure the hasher is thread local
 // (i.e. not share across threads)
 type CachedHasher[T comparable] struct {
-	cache      *Cache[T, Hash]
+	cache      *LruCache[T, Hash]
 	serializer Serializer[T]
 	cached     bool
 	lock       *sync.Mutex
@@ -26,7 +26,7 @@ type CachedHasher[T comparable] struct {
 // Input serializer is used to convert the type, which will be hashed, to byte slice.
 func NewCachedHasher[T comparable](cacheCapacity int, serializer Serializer[T]) *CachedHasher[T] {
 	return &CachedHasher[T]{
-		cache:      NewCache[T, Hash](cacheCapacity),
+		cache:      NewLruCache[T, Hash](cacheCapacity),
 		serializer: serializer,
 		cached:     cacheCapacity > 0,
 		lock:       &sync.Mutex{},

--- a/go/common/cached_hasher_test.go
+++ b/go/common/cached_hasher_test.go
@@ -33,6 +33,16 @@ func TestHashPassThroughRunParallel(t *testing.T) {
 	}
 }
 
+func TestHash_NonCached_PassThrough(t *testing.T) {
+	cacheSize := 0
+	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
+	var adr Address
+	adr[0]++
+	if got, want := hasher.Hash(adr), GetHash(sha3.NewLegacyKeccak256(), adr[:]); got != want {
+		t.Errorf("hashes do not match: %v != %v", got, want)
+	}
+}
+
 func TestMemoryFootprint(t *testing.T) {
 	cacheSize := 1000
 	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})

--- a/go/common/interfaces_test.go
+++ b/go/common/interfaces_test.go
@@ -1,0 +1,11 @@
+package common
+
+import "testing"
+
+func Test_MapEntry_String(t *testing.T) {
+	e := MapEntry[int, int]{10, 20}
+
+	if got, want := e.String(), "Entry: 10 -> 20"; got != want {
+		t.Errorf("provided string does not match: %s != %s", got, want)
+	}
+}

--- a/go/common/lru_cache_test.go
+++ b/go/common/lru_cache_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestLruExceedCapacity(t *testing.T) {
-	c := NewCache[int, int](3)
+	c := NewLruCache[int, int](3)
 
 	c.Set(1, 11)
 	c.Set(2, 22)
@@ -32,7 +32,7 @@ func TestLruExceedCapacity(t *testing.T) {
 
 // TestLRUOrder test correct ordering of the keys
 func TestLRUOrder(t *testing.T) {
-	c := NewCache[int, int](3)
+	c := NewLruCache[int, int](3)
 
 	c.Set(1, 11)
 	c.Set(2, 22)
@@ -64,28 +64,8 @@ func TestLRUOrder(t *testing.T) {
 	}
 }
 
-func TestHitRatio(t *testing.T) {
-	if !MissHitMeasuring {
-		t.Skip("MissHitMeasuring is disabled - skipping the test")
-	}
-
-	c := NewCache[int, int](3)
-	c.Set(1, 11)
-	c.Set(2, 22)
-
-	c.Get(1) // hit
-	c.Get(8) // miss
-	c.Get(2) // hit
-	c.Get(9) // miss
-
-	report := c.getHitRatioReport()
-	if report != "(misses: 2, hits: 2, hitRatio: 0.500000)" {
-		t.Errorf("unexpected memory footprint report: %s", report)
-	}
-}
-
 func TestLRUCache_GetOrSet(t *testing.T) {
-	c := NewCache[int, int](4)
+	c := NewLruCache[int, int](4)
 
 	if _, present, _, _, evicted := c.GetOrSet(1, 11); present || evicted {
 		t.Errorf("value should be neither present nor evicted")
@@ -109,4 +89,12 @@ func TestLRUCache_GetOrSet(t *testing.T) {
 		t.Errorf("value should be evicted: %d != 9", current)
 	}
 
+}
+
+func TestCache_Entry_String(t *testing.T) {
+	e := entry[int, int]{10, 20, nil, nil}
+
+	if got, want := e.String(), "Entry: 10 -> 20"; got != want {
+		t.Errorf("provided string does not match: %s != %s", got, want)
+	}
 }

--- a/go/common/mem_footprint.go
+++ b/go/common/mem_footprint.go
@@ -65,22 +65,18 @@ func includeObjectIntoTotal(mf *MemoryFootprint, includedObjects map[*MemoryFoot
 
 // ToString provides the memory footprint as a tree summary in a string
 // The name param allows to give a name to the root of the tree.
-func (mf *MemoryFootprint) ToString(name string) (str string, err error) {
+func (mf *MemoryFootprint) ToString(name string) string {
 	var sb strings.Builder
-	err = mf.toStringBuilder(&sb, name)
-	return sb.String(), err
+	mf.toStringBuilder(&sb, name)
+	return sb.String()
 }
 
 // Allow memory footprints to be used in format strings.
 func (mf *MemoryFootprint) String() string {
-	str, err := mf.ToString(".")
-	if err != nil {
-		panic(fmt.Sprintf("error printing memory usage to string: %v", err))
-	}
-	return str
+	return mf.ToString(".")
 }
 
-func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) (err error) {
+func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) {
 	// Print children in order for simpler comparison.
 	names := make([]string, 0, len(mf.children))
 	for name := range mf.children {
@@ -91,17 +87,11 @@ func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) (er
 	for _, name := range names {
 		footprint := mf.children[name]
 		fullPath := path + "/" + name
-		err = footprint.toStringBuilder(sb, fullPath)
-		if err != nil {
-			return
-		}
+		footprint.toStringBuilder(sb, fullPath)
 	}
 
 	// Show sum at the bottom.
-	err = memoryAmountToString(sb, mf.Total())
-	if err != nil {
-		return
-	}
+	memoryAmountToString(sb, mf.Total())
 	sb.WriteRune(' ')
 	sb.WriteString(path)
 	if len(mf.note) != 0 {
@@ -113,7 +103,7 @@ func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) (er
 	return
 }
 
-func memoryAmountToString(sb *strings.Builder, bytes uintptr) (err error) {
+func memoryAmountToString(sb *strings.Builder, bytes uintptr) {
 	const unit = 1024
 	const prefixes = " KMGTPE"
 	div, exp := 1, 0
@@ -121,6 +111,6 @@ func memoryAmountToString(sb *strings.Builder, bytes uintptr) (err error) {
 		div *= unit
 		exp++
 	}
-	_, err = fmt.Fprintf(sb, "%6.1f %cB", float64(bytes)/float64(div), prefixes[exp])
-	return err
+	// writing to the string.Builder can never return error
+	_, _ = fmt.Fprintf(sb, "%6.1f %cB", float64(bytes)/float64(div), prefixes[exp])
 }

--- a/go/common/mem_footprint_test.go
+++ b/go/common/mem_footprint_test.go
@@ -24,6 +24,41 @@ func TestMemoryFootprintIsFormatable(t *testing.T) {
 	expectSubstr(t, print, "10.2 MB ./right")
 }
 
+func TestMemoryFootprintContainsNote(t *testing.T) {
+	fp := NewMemoryFootprint(12)
+	fp.SetNote("Hello")
+
+	if !strings.Contains(fp.String(), "Hello") {
+		t.Errorf("note not printed")
+	}
+}
+
+func TestMemoryFootprintValue(t *testing.T) {
+	fp := NewMemoryFootprint(12)
+
+	if got, want := fp.Value(), 12; got != uintptr(want) {
+		t.Errorf("value does not match: %d != %d", got, want)
+	}
+}
+
+func TestMemoryFootprint_Recursive(t *testing.T) {
+	fp := NewMemoryFootprint(12)
+	fp.AddChild("x", fp)
+
+	if got, want := fp.Total(), 12; got != uintptr(want) {
+		t.Errorf("value does not match: %d != %d", got, want)
+	}
+}
+
+func TestMemoryFootprint_ChildNil(t *testing.T) {
+	fp := NewMemoryFootprint(12)
+	fp.AddChild("x", nil)
+
+	if got, want := fp.Total(), 12; got != uintptr(want) {
+		t.Errorf("value does not match: %d != %d", got, want)
+	}
+}
+
 func TestMemoryFootprintPrintsComponentsInOrder(t *testing.T) {
 	fp := NewMemoryFootprint(4)
 	fp.AddChild("b", NewMemoryFootprint(5))

--- a/go/common/miss_hit_cache.go
+++ b/go/common/miss_hit_cache.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// MissHitTrackingCache is a cache wrapping another cache while tracking
+// the number of missed and existing entries.
+// Ech time the method Get() of the wrapped cache is executed,
+// this implementation checks whether the item was present or not, and increments respective counters.
+// The report of miss/hit ration is provided as part of the memory footprint report.
+type MissHitTrackingCache[K comparable, V any] struct {
+	cache  Cache[K, V]
+	misses atomic.Uint64
+	hits   atomic.Uint64
+}
+
+// NewMissHitTrackingCache creates a new cache that is tracking
+// the number of missed and existing entries.
+// Actual data are stored and retrieved by wrapping the input cache.
+func NewMissHitTrackingCache[K comparable, V any](cache Cache[K, V]) *MissHitTrackingCache[K, V] {
+	return &MissHitTrackingCache[K, V]{
+		cache: cache,
+	}
+}
+
+func (c *MissHitTrackingCache[K, V]) Iterate(callback func(K, V) bool) {
+	c.cache.Iterate(callback)
+}
+
+func (c *MissHitTrackingCache[K, V]) IterateMutable(callback func(K, *V) bool) {
+	c.cache.IterateMutable(callback)
+}
+
+func (c *MissHitTrackingCache[K, V]) Get(key K) (V, bool) {
+	v, exists := c.cache.Get(key)
+	if exists {
+		c.hits.Add(1)
+	} else {
+		c.misses.Add(1)
+	}
+
+	return v, exists
+}
+
+func (c *MissHitTrackingCache[K, V]) Set(key K, val V) (evictedKey K, evictedValue V, evicted bool) {
+	return c.cache.Set(key, val)
+}
+
+func (c *MissHitTrackingCache[K, V]) GetOrSet(key K, val V) (current V, present bool, evictedKey K, evictedValue V, evicted bool) {
+	return c.cache.GetOrSet(key, val)
+}
+
+func (c *MissHitTrackingCache[K, V]) Remove(key K) (original V, exists bool) {
+	return c.cache.Remove(key)
+}
+
+func (c *MissHitTrackingCache[K, V]) Clear() {
+	c.cache.Clear()
+}
+
+// GetMemoryFootprint provides the size of the cache in memory in bytes
+// If V is a pointer type, it needs to provide the size of a referenced value.
+// If the size is different for individual values, use GetDynamicMemoryFootprint instead.
+func (c *MissHitTrackingCache[K, V]) GetMemoryFootprint(referencedValueSize uintptr) *MemoryFootprint {
+	mf := c.cache.GetMemoryFootprint(referencedValueSize)
+	mf.SetNote(c.getHitRatioReport())
+	return mf
+}
+
+// GetDynamicMemoryFootprint provides the size of the cache in memory in bytes for values,
+// which reference dynamic amount of memory - like slices.
+func (c *MissHitTrackingCache[K, V]) GetDynamicMemoryFootprint(valueSizeProvider func(V) uintptr) *MemoryFootprint {
+	mf := c.cache.GetDynamicMemoryFootprint(valueSizeProvider)
+	mf.SetNote(c.getHitRatioReport())
+	return mf
+}
+
+// getHitRatioReport reports about the cache miss/hit ration, when the tracking of this statistic is enabled.
+// When this statistics is disabled, the result of this method should not be considered.
+func (c *MissHitTrackingCache[K, V]) getHitRatioReport() string {
+	hits := c.hits.Load()
+	misses := c.misses.Load()
+	hitRatio := float32(hits) / float32(hits+misses)
+	return fmt.Sprintf("(misses: %d, hits: %d, hitRatio: %f)", misses, hits, hitRatio)
+}

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -7,6 +7,13 @@ import (
 	"testing"
 )
 
+func TestUpdateEmpty(t *testing.T) {
+	update := Update{}
+	if !update.IsEmpty() {
+		t.Errorf("update should be empty")
+	}
+}
+
 func TestUpdateEmptyUpdateCheckReportsNoErrors(t *testing.T) {
 	update := Update{}
 	if err := update.Check(); err != nil {

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -40,7 +40,7 @@ type CppState struct {
 	// A pointer to an owned C++ object containing the actual state information.
 	state unsafe.Pointer
 	// cache of contract codes
-	codeCache *common.Cache[common.Address, []byte]
+	codeCache *common.LruCache[common.Address, []byte]
 }
 
 func newCppState(impl C.enum_StateImpl, params state.Parameters) (state.State, error) {
@@ -54,7 +54,7 @@ func newCppState(impl C.enum_StateImpl, params state.Parameters) (state.State, e
 
 	return state.WrapIntoSyncedState(&CppState{
 		state:     st,
-		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
+		codeCache: common.NewLruCache[common.Address, []byte](CodeCacheSize),
 	}), nil
 }
 
@@ -247,7 +247,7 @@ func (cs *CppState) GetMemoryFootprint() *common.MemoryFootprint {
 func (cs *CppState) GetArchiveState(block uint64) (state.State, error) {
 	return &CppState{
 		state:     C.Carmen_GetArchiveState(cs.state, C.uint64_t(block)),
-		codeCache: common.NewCache[common.Address, []byte](CodeCacheSize),
+		codeCache: common.NewLruCache[common.Address, []byte](CodeCacheSize),
 	}, nil
 }
 

--- a/go/state/go_state_test.go
+++ b/go/state/go_state_test.go
@@ -458,10 +458,7 @@ func TestGetMemoryFootprint(t *testing.T) {
 			defer state.Close()
 
 			memoryFootprint := state.GetMemoryFootprint()
-			str, err := memoryFootprint.ToString("state")
-			if err != nil {
-				t.Fatalf("failed to get state memory footprint; %s", err)
-			}
+			str := memoryFootprint.ToString("state")
 			if config.schema <= 3 && !strings.Contains(str, "hashTree") {
 				t.Errorf("memory footprint string does not contain any hashTree")
 			}

--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -72,7 +72,7 @@ type Forest struct {
 	storageMode StorageMode
 
 	// A unified cache for all node types.
-	nodeCache      *common.Cache[NodeId, *shared.Shared[Node]]
+	nodeCache      *common.LruCache[NodeId, *shared.Shared[Node]]
 	nodeCacheMutex sync.Mutex
 
 	// The set of dirty nodes. Nodes are dirty if there in-memory
@@ -243,7 +243,7 @@ func makeForest(
 		accounts:      synced.Sync(accounts),
 		values:        synced.Sync(values),
 		storageMode:   mode,
-		nodeCache:     common.NewCache[NodeId, *shared.Shared[Node]](cacheCapacity),
+		nodeCache:     common.NewLruCache[NodeId, *shared.Shared[Node]](cacheCapacity),
 		dirty:         map[NodeId]struct{}{},
 		hasher:        config.Hashing.createHasher(),
 		keyHasher:     common.NewCachedHasher[common.Key](hashesCacheCapacity, common.KeySerializer{}),

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -178,7 +178,7 @@ type stateDB struct {
 	writtenSlots map[*slotValue]bool
 
 	// A non-transactional local cache of stored storage values.
-	storedDataCache *common.Cache[slotId, storedDataCacheValue]
+	storedDataCache *common.LruCache[slotId, storedDataCacheValue]
 
 	// A non-transactional reincarnation counter for accounts. This is used to efficiently invalidate data in
 	// the storedDataCache upon account deletion. The maintained values are internal information only.
@@ -372,7 +372,7 @@ func createStateDBWith(state State, storedDataCacheCapacity int, canApplyChanges
 		balances:          map[common.Address]*balanceValue{},
 		nonces:            map[common.Address]*nonceValue{},
 		data:              common.NewFastMap[slotId, *slotValue](slotHasher{}),
-		storedDataCache:   common.NewCache[slotId, storedDataCacheValue](storedDataCacheCapacity),
+		storedDataCache:   common.NewLruCache[slotId, storedDataCacheValue](storedDataCacheCapacity),
 		reincarnation:     map[common.Address]uint64{},
 		codes:             map[common.Address]*codeValue{},
 		refund:            0,

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -247,8 +247,8 @@ func TestCanComputeNonEmptyMemoryFootprint(t *testing.T) {
 		if fp.Total() <= 0 {
 			t.Errorf("memory footprint should not be empty")
 		}
-		if _, err := fp.ToString("top"); err != nil {
-			t.Errorf("Unable to print footprint: %v", err)
+		if len(fp.ToString("top")) == 0 {
+			t.Errorf("footprint text empty: %v", fp.ToString("top"))
 		}
 	})
 }


### PR DESCRIPTION
This Pr extends code coverage of selected components from the `common` package  to 100%.

In particular it extends:
* chahes
* fast map
* memory footprint
* Update
* serialisers, comparators, 