### PR TITLE
Fix file depot closing

### DIFF
--- a/go/backend/depot/file/file.go
+++ b/go/backend/depot/file/file.go
@@ -372,7 +372,10 @@ func (m *Depot[I]) Flush() error {
 
 // Close the store
 func (m *Depot[I]) Close() error {
-	return m.Flush()
+	return errors.Join(
+		m.Flush(),
+		m.offsetsFile.Close(),
+		m.contentsFile.Close())
 }
 
 func (m *Depot[I]) ReleasePreviousSnapshot() {


### PR DESCRIPTION
Seems file depots are not being closed correctly. This should fix it.