### PR TITLE
Switch to iterative algorithm for MPT hashing

### DIFF
--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -180,7 +180,10 @@ func TestHasher_BranchNode_UpdateHash_DirtyFlagsForEmptyChildrenAreClearedButNoU
 				dirty:     []int{1, 2, 3}, // < all empty children
 			})
 
-			// the node is not marked to be modified
+			// Only the branch node is signaled to be updated.
+			hashHandle, _ := ctxt.getHashAccess(&ref)
+			ctxt.EXPECT().updateHash(ref.Id(), hashHandle)
+			hashHandle.Release()
 
 			hasher := algorithm.createHasher()
 			_, _, err := hasher.updateHashes(&ref, ctxt)
@@ -405,7 +408,7 @@ func TestEthereumLikeHasher_GetLowerBoundForAccountNode(t *testing.T) {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
 		accountRef := NewNodeReference(AccountId(1))
-		encoded, err := hasher.encode(&accountRef, test, shared.HashHandle[Node]{}, nil, nodesSource, EmptyPath(), nil)
+		encoded, err := hasher.encode(&accountRef, test, shared.HashHandle[Node]{}, nodesSource)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -449,7 +452,7 @@ func TestEthereumLikeHasher_GetLowerBoundForBranchNode(t *testing.T) {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
 		branchRef := NewNodeReference(BranchId(1))
-		encoded, err := hasher.encode(&branchRef, test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(&branchRef, test, shared.HashHandle[Node]{}, nodeManager)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -498,7 +501,7 @@ func TestEthereumLikeHasher_GetLowerBoundForExtensionNode(t *testing.T) {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
 		extensionRef := NewNodeReference(ExtensionId(1))
-		encoded, err := hasher.encode(&extensionRef, test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(&extensionRef, test, shared.HashHandle[Node]{}, nodeManager)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -536,7 +539,7 @@ func TestEthereumLikeHasher_GetLowerBoundForValueNode(t *testing.T) {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
 		valueRef := NewNodeReference(ValueId(1))
-		encoded, err := hasher.encode(&valueRef, test, shared.HashHandle[Node]{}, nil, nodeManager, EmptyPath(), nil)
+		encoded, err := hasher.encode(&valueRef, test, shared.HashHandle[Node]{}, nodeManager)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}


### PR DESCRIPTION
This PR replaces the recursive algorithm for hashing MPTs with an iterative equivalent. The main reasons are:
- simplifies the implementation of the `encode` function, by disentangling hashing and encoding
- provides better insights into latency-contributing factors of hashing in CPU profiles

This change has a minor positive effect on hashing performance:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/9e3b46ca-86a9-43f1-803b-516827e68aba)

The CPU profile flattens out as expected. Before:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/5787c074-c973-4520-b487-409e73b92fbf)

After:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/ed231417-2b2a-4b2b-9c6b-1420f572ca99)
