### PR TITLE
Improve memory management of RLP encoding

### DIFF
--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -407,8 +407,7 @@ func TestEthereumLikeHasher_GetLowerBoundForAccountNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		accountRef := NewNodeReference(AccountId(1))
-		encoded, err := hasher.encode(&accountRef, test, shared.HashHandle[Node]{}, nodesSource)
+		encoded, err := hasher.encode(test, nodesSource, nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -451,8 +450,7 @@ func TestEthereumLikeHasher_GetLowerBoundForBranchNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		branchRef := NewNodeReference(BranchId(1))
-		encoded, err := hasher.encode(&branchRef, test, shared.HashHandle[Node]{}, nodeManager)
+		encoded, err := hasher.encode(test, nodeManager, nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -500,8 +498,7 @@ func TestEthereumLikeHasher_GetLowerBoundForExtensionNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		extensionRef := NewNodeReference(ExtensionId(1))
-		encoded, err := hasher.encode(&extensionRef, test, shared.HashHandle[Node]{}, nodeManager)
+		encoded, err := hasher.encode(test, nodeManager, nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}
@@ -538,8 +535,7 @@ func TestEthereumLikeHasher_GetLowerBoundForValueNode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get lower bound for encoding: %v", err)
 		}
-		valueRef := NewNodeReference(ValueId(1))
-		encoded, err := hasher.encode(&valueRef, test, shared.HashHandle[Node]{}, nodeManager)
+		encoded, err := hasher.encode(test, nodeManager, nil)
 		if err != nil {
 			t.Fatalf("failed to encode test value: %v", err)
 		}


### PR DESCRIPTION
This modification removes many memory allocations from the RLP encoding process.

The result is a ~10% improvement in throughput for the insertion benchmark:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/ec20d9a3-5e9d-4002-b5ca-484c9afb091e)

This is also observable in the CPU profile. Before:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/0e5f6d2c-1b54-483f-ab8c-a935b036a6bb)

After:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/26840470-94be-4c6c-8158-cfb11846e74e)
