### PR TITLE
Add C based keccak hashing

### DIFF
--- a/go/common/keccak.go
+++ b/go/common/keccak.go
@@ -1,14 +1,24 @@
 package common
 
+/*
+#include "keccak.h"
+*/
+import "C"
+
 import (
 	"sync"
+	"unsafe"
 
 	"golang.org/x/crypto/sha3"
 )
 
+func Keccak256(data []byte) Hash {
+	return keccak256_C(data)
+}
+
 var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
 
-func Keccak256(data []byte) Hash {
+func keccak256_Go(data []byte) Hash {
 	hasher := keccakHasherPool.Get().(keccakHasher)
 	hasher.Reset()
 	hasher.Write(data)
@@ -22,4 +32,14 @@ type keccakHasher interface {
 	Reset()
 	Write(in []byte) (int, error)
 	Read(out []byte) (int, error)
+}
+
+var emptyKeccak256Hash = keccak256_Go([]byte{})
+
+func keccak256_C(data []byte) Hash {
+	if len(data) == 0 {
+		return emptyKeccak256Hash
+	}
+	res := C.carmen_keccak256(unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	return Hash(res)
 }

--- a/go/common/keccak.h
+++ b/go/common/keccak.h
@@ -1,0 +1,398 @@
+// This header file is based on the chfast/ethash project:
+//
+//  source: https://github.com/chfast/ethash/tree/8e18c3d715d3d759f44ac10f70f9c93b227e18c2
+//  License: Apache-2.0 license (https://github.com/chfast/ethash/blob/8e18c3d715d3d759f44ac10f70f9c93b227e18c2/LICENSE)
+//
+// This file merges extracts of codes from the project and adds Carmen specific
+// modifications to facilitate the adaption in the Carmen project.
+//
+// ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+// Copyright 2018 Pawel Bylica.
+// SPDX-License-Identifier: Apache-2.0
+
+// Provide __has_attribute macro if not defined.
+#ifndef __has_attribute
+#define __has_attribute(name) 0
+#endif
+
+// [[always_inline]]
+#if defined(_MSC_VER)
+#define ALWAYS_INLINE __forceinline
+#elif __has_attribute(always_inline)
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef __cplusplus
+#define noexcept  // Ignore noexcept in C code.
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+union ethash_hash256
+{
+    uint64_t word64s[4];
+    uint32_t word32s[8];
+    uint8_t bytes[32];
+    char str[32];
+};
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define to_le64(X) __builtin_bswap64(X)
+#else
+#define to_le64(X) X
+#endif
+
+/// Loads 64-bit integer from given memory location as little-endian number.
+static inline ALWAYS_INLINE uint64_t load_le(const uint8_t* data)
+{
+    /* memcpy is the best way of expressing the intention. Every compiler will
+       optimize is to single load instruction if the target architecture
+       supports unaligned memory access (GCC and clang even in O0).
+       This is great trick because we are violating C/C++ memory alignment
+       restrictions with no performance penalty. */
+    uint64_t word;
+    __builtin_memcpy(&word, data, sizeof(word));
+    return to_le64(word);
+}
+
+/// Rotates the bits of x left by the count value specified by s.
+/// The s must be in range <0, 64> exclusively, otherwise the result is undefined.
+static inline uint64_t rol(uint64_t x, unsigned s)
+{
+    return (x << s) | (x >> (64 - s));
+}
+
+static const uint64_t round_constants[24] = {  //
+    0x0000000000000001, 0x0000000000008082, 0x800000000000808a, 0x8000000080008000,
+    0x000000000000808b, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+    0x000000000000008a, 0x0000000000000088, 0x0000000080008009, 0x000000008000000a,
+    0x000000008000808b, 0x800000000000008b, 0x8000000000008089, 0x8000000000008003,
+    0x8000000000008002, 0x8000000000000080, 0x000000000000800a, 0x800000008000000a,
+    0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008};
+
+
+/// The Keccak-f[1600] function.
+///
+/// The implementation of the Keccak-f function with 1600-bit width of the permutation (b).
+/// The size of the state is also 1600 bit what gives 25 64-bit words.
+///
+/// @param state  The state of 25 64-bit words on which the permutation is to be performed.
+///
+/// The implementation based on:
+/// - "simple" implementation by Ronny Van Keer, included in "Reference and optimized code in C",
+///   https://keccak.team/archives.html, CC0-1.0 / Public Domain.
+static inline ALWAYS_INLINE void keccakf1600_implementation(uint64_t state[25])
+{
+    uint64_t Aba, Abe, Abi, Abo, Abu;
+    uint64_t Aga, Age, Agi, Ago, Agu;
+    uint64_t Aka, Ake, Aki, Ako, Aku;
+    uint64_t Ama, Ame, Ami, Amo, Amu;
+    uint64_t Asa, Ase, Asi, Aso, Asu;
+
+    uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
+    uint64_t Ega, Ege, Egi, Ego, Egu;
+    uint64_t Eka, Eke, Eki, Eko, Eku;
+    uint64_t Ema, Eme, Emi, Emo, Emu;
+    uint64_t Esa, Ese, Esi, Eso, Esu;
+
+    uint64_t Ba, Be, Bi, Bo, Bu;
+
+    uint64_t Da, De, Di, Do, Du;
+
+    Aba = state[0];
+    Abe = state[1];
+    Abi = state[2];
+    Abo = state[3];
+    Abu = state[4];
+    Aga = state[5];
+    Age = state[6];
+    Agi = state[7];
+    Ago = state[8];
+    Agu = state[9];
+    Aka = state[10];
+    Ake = state[11];
+    Aki = state[12];
+    Ako = state[13];
+    Aku = state[14];
+    Ama = state[15];
+    Ame = state[16];
+    Ami = state[17];
+    Amo = state[18];
+    Amu = state[19];
+    Asa = state[20];
+    Ase = state[21];
+    Asi = state[22];
+    Aso = state[23];
+    Asu = state[24];
+
+    for (size_t n = 0; n < 24; n += 2)
+    {
+        // Round (n + 0): Axx -> Exx
+
+        Ba = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
+        Be = Abe ^ Age ^ Ake ^ Ame ^ Ase;
+        Bi = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
+        Bo = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
+        Bu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
+
+        Da = Bu ^ rol(Be, 1);
+        De = Ba ^ rol(Bi, 1);
+        Di = Be ^ rol(Bo, 1);
+        Do = Bi ^ rol(Bu, 1);
+        Du = Bo ^ rol(Ba, 1);
+
+        Ba = Aba ^ Da;
+        Be = rol(Age ^ De, 44);
+        Bi = rol(Aki ^ Di, 43);
+        Bo = rol(Amo ^ Do, 21);
+        Bu = rol(Asu ^ Du, 14);
+        Eba = Ba ^ (~Be & Bi) ^ round_constants[n];
+        Ebe = Be ^ (~Bi & Bo);
+        Ebi = Bi ^ (~Bo & Bu);
+        Ebo = Bo ^ (~Bu & Ba);
+        Ebu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Abo ^ Do, 28);
+        Be = rol(Agu ^ Du, 20);
+        Bi = rol(Aka ^ Da, 3);
+        Bo = rol(Ame ^ De, 45);
+        Bu = rol(Asi ^ Di, 61);
+        Ega = Ba ^ (~Be & Bi);
+        Ege = Be ^ (~Bi & Bo);
+        Egi = Bi ^ (~Bo & Bu);
+        Ego = Bo ^ (~Bu & Ba);
+        Egu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Abe ^ De, 1);
+        Be = rol(Agi ^ Di, 6);
+        Bi = rol(Ako ^ Do, 25);
+        Bo = rol(Amu ^ Du, 8);
+        Bu = rol(Asa ^ Da, 18);
+        Eka = Ba ^ (~Be & Bi);
+        Eke = Be ^ (~Bi & Bo);
+        Eki = Bi ^ (~Bo & Bu);
+        Eko = Bo ^ (~Bu & Ba);
+        Eku = Bu ^ (~Ba & Be);
+
+        Ba = rol(Abu ^ Du, 27);
+        Be = rol(Aga ^ Da, 36);
+        Bi = rol(Ake ^ De, 10);
+        Bo = rol(Ami ^ Di, 15);
+        Bu = rol(Aso ^ Do, 56);
+        Ema = Ba ^ (~Be & Bi);
+        Eme = Be ^ (~Bi & Bo);
+        Emi = Bi ^ (~Bo & Bu);
+        Emo = Bo ^ (~Bu & Ba);
+        Emu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Abi ^ Di, 62);
+        Be = rol(Ago ^ Do, 55);
+        Bi = rol(Aku ^ Du, 39);
+        Bo = rol(Ama ^ Da, 41);
+        Bu = rol(Ase ^ De, 2);
+        Esa = Ba ^ (~Be & Bi);
+        Ese = Be ^ (~Bi & Bo);
+        Esi = Bi ^ (~Bo & Bu);
+        Eso = Bo ^ (~Bu & Ba);
+        Esu = Bu ^ (~Ba & Be);
+
+
+        // Round (n + 1): Exx -> Axx
+
+        Ba = Eba ^ Ega ^ Eka ^ Ema ^ Esa;
+        Be = Ebe ^ Ege ^ Eke ^ Eme ^ Ese;
+        Bi = Ebi ^ Egi ^ Eki ^ Emi ^ Esi;
+        Bo = Ebo ^ Ego ^ Eko ^ Emo ^ Eso;
+        Bu = Ebu ^ Egu ^ Eku ^ Emu ^ Esu;
+
+        Da = Bu ^ rol(Be, 1);
+        De = Ba ^ rol(Bi, 1);
+        Di = Be ^ rol(Bo, 1);
+        Do = Bi ^ rol(Bu, 1);
+        Du = Bo ^ rol(Ba, 1);
+
+        Ba = Eba ^ Da;
+        Be = rol(Ege ^ De, 44);
+        Bi = rol(Eki ^ Di, 43);
+        Bo = rol(Emo ^ Do, 21);
+        Bu = rol(Esu ^ Du, 14);
+        Aba = Ba ^ (~Be & Bi) ^ round_constants[n + 1];
+        Abe = Be ^ (~Bi & Bo);
+        Abi = Bi ^ (~Bo & Bu);
+        Abo = Bo ^ (~Bu & Ba);
+        Abu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Ebo ^ Do, 28);
+        Be = rol(Egu ^ Du, 20);
+        Bi = rol(Eka ^ Da, 3);
+        Bo = rol(Eme ^ De, 45);
+        Bu = rol(Esi ^ Di, 61);
+        Aga = Ba ^ (~Be & Bi);
+        Age = Be ^ (~Bi & Bo);
+        Agi = Bi ^ (~Bo & Bu);
+        Ago = Bo ^ (~Bu & Ba);
+        Agu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Ebe ^ De, 1);
+        Be = rol(Egi ^ Di, 6);
+        Bi = rol(Eko ^ Do, 25);
+        Bo = rol(Emu ^ Du, 8);
+        Bu = rol(Esa ^ Da, 18);
+        Aka = Ba ^ (~Be & Bi);
+        Ake = Be ^ (~Bi & Bo);
+        Aki = Bi ^ (~Bo & Bu);
+        Ako = Bo ^ (~Bu & Ba);
+        Aku = Bu ^ (~Ba & Be);
+
+        Ba = rol(Ebu ^ Du, 27);
+        Be = rol(Ega ^ Da, 36);
+        Bi = rol(Eke ^ De, 10);
+        Bo = rol(Emi ^ Di, 15);
+        Bu = rol(Eso ^ Do, 56);
+        Ama = Ba ^ (~Be & Bi);
+        Ame = Be ^ (~Bi & Bo);
+        Ami = Bi ^ (~Bo & Bu);
+        Amo = Bo ^ (~Bu & Ba);
+        Amu = Bu ^ (~Ba & Be);
+
+        Ba = rol(Ebi ^ Di, 62);
+        Be = rol(Ego ^ Do, 55);
+        Bi = rol(Eku ^ Du, 39);
+        Bo = rol(Ema ^ Da, 41);
+        Bu = rol(Ese ^ De, 2);
+        Asa = Ba ^ (~Be & Bi);
+        Ase = Be ^ (~Bi & Bo);
+        Asi = Bi ^ (~Bo & Bu);
+        Aso = Bo ^ (~Bu & Ba);
+        Asu = Bu ^ (~Ba & Be);
+    }
+
+    state[0] = Aba;
+    state[1] = Abe;
+    state[2] = Abi;
+    state[3] = Abo;
+    state[4] = Abu;
+    state[5] = Aga;
+    state[6] = Age;
+    state[7] = Agi;
+    state[8] = Ago;
+    state[9] = Agu;
+    state[10] = Aka;
+    state[11] = Ake;
+    state[12] = Aki;
+    state[13] = Ako;
+    state[14] = Aku;
+    state[15] = Ama;
+    state[16] = Ame;
+    state[17] = Ami;
+    state[18] = Amo;
+    state[19] = Amu;
+    state[20] = Asa;
+    state[21] = Ase;
+    state[22] = Asi;
+    state[23] = Aso;
+    state[24] = Asu;
+}
+
+static void keccakf1600_generic(uint64_t state[25])
+{
+    keccakf1600_implementation(state);
+}
+
+/// The pointer to the best Keccak-f[1600] function implementation,
+/// selected during runtime initialization.
+static void (*keccakf1600_best)(uint64_t[25]) = keccakf1600_generic;
+
+
+#if !defined(_MSC_VER) && defined(__x86_64__) && __has_attribute(target)
+__attribute__((target("bmi,bmi2"))) static void keccakf1600_bmi(uint64_t state[25])
+{
+    keccakf1600_implementation(state);
+}
+
+__attribute__((constructor)) static void select_keccakf1600_implementation(void)
+{
+    // Init CPU information.
+    // This is needed on macOS because of the bug: https://bugs.llvm.org/show_bug.cgi?id=48459.
+    __builtin_cpu_init();
+
+    // Check if both BMI and BMI2 are supported. Some CPUs like Intel E5-2697 v2 incorrectly
+    // report BMI2 but not BMI being available.
+    if (__builtin_cpu_supports("bmi") && __builtin_cpu_supports("bmi2"))
+        keccakf1600_best = keccakf1600_bmi;
+}
+#endif
+
+
+static inline ALWAYS_INLINE void keccak(
+    uint64_t* out, size_t bits, const uint8_t* data, size_t size)
+{
+    static const size_t word_size = sizeof(uint64_t);
+    const size_t hash_size = bits / 8;
+    const size_t block_size = (1600 - bits * 2) / 8;
+
+    size_t i;
+    uint64_t* state_iter;
+    uint64_t last_word = 0;
+    uint8_t* last_word_iter = (uint8_t*)&last_word;
+
+    uint64_t state[25] = {0};
+
+    while (size >= block_size)
+    {
+        for (i = 0; i < (block_size / word_size); ++i)
+        {
+            state[i] ^= load_le(data);
+            data += word_size;
+        }
+
+        keccakf1600_best(state);
+
+        size -= block_size;
+    }
+
+    state_iter = state;
+
+    while (size >= word_size)
+    {
+        *state_iter ^= load_le(data);
+        ++state_iter;
+        data += word_size;
+        size -= word_size;
+    }
+
+    while (size > 0)
+    {
+        *last_word_iter = *data;
+        ++last_word_iter;
+        ++data;
+        --size;
+    }
+    *last_word_iter = 0x01;
+    *state_iter ^= to_le64(last_word);
+
+    state[(block_size / word_size) - 1] ^= 0x8000000000000000;
+
+    keccakf1600_best(state);
+
+    for (i = 0; i < (hash_size / word_size); ++i)
+        out[i] = to_le64(state[i]);
+}
+
+union ethash_hash256 carmen_keccak256(const void* in, size_t size) noexcept {
+    union ethash_hash256 hash;
+    keccak(hash.word64s, 256, (const uint8_t*)in, size);
+    return hash;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestKeccakC_ProducesSameHashAsGo(t *testing.T) {
+	tests := [][]byte{
+		nil,
+		[]byte{},
+		[]byte{1, 2, 3},
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		make([]byte, 128),
+		make([]byte, 1024),
+	}
+	for _, test := range tests {
+		want := keccak256_Go(test)
+		got := keccak256_C(test)
+		if want != got {
+			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+		}
+	}
+}
+
+func benchmark(b *testing.B, hasher func([]byte)) {
+	for i := 1; i < 1<<22; i <<= 3 {
+		b.Run(fmt.Sprintf("size=%d", i), func(b *testing.B) {
+			data := make([]byte, i)
+			for i := 0; i < b.N; i++ {
+				hasher(data)
+			}
+		})
+	}
+}
+
+func BenchmarkKeccakGo(b *testing.B) {
+	benchmark(b, func(data []byte) {
+		keccak256_Go(data)
+	})
+}
+
+func BenchmarkKeccakC(b *testing.B) {
+	benchmark(b, func(data []byte) {
+		keccak256_C(data)
+	})
+}


### PR DESCRIPTION
Adds a C implementation of keccak256 to replace the Go implementation.

The C-based implementation is more than 25% faster up to 1 KB of input data and more than 20% faster for 2MB:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/38033911-2691-4567-9ec3-e8e2f6b66866)

This results in a ~6% insertion performance improvement:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/1a9758f8-1830-47fd-96a6-f4471245e22a)
