### PR TITLE
Replace LRU based address and key cache with simpler variant

### DIFF
--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -82,8 +82,8 @@ type Forest struct {
 	hasher hasher
 
 	// Cached hashers for keys and addresses (thread safe).
-	keyHasher     *common.CachedHasher[common.Key]
-	addressHasher *common.CachedHasher[common.Address]
+	keyHasher     CachedHasher[common.Key]
+	addressHasher CachedHasher[common.Address]
 
 	// A buffer for asynchronously writing nodes to files.
 	writeBuffer WriteBuffer
@@ -244,8 +244,8 @@ func makeForest(
 		nodeCache:     NewNodeCache(cacheCapacity),
 		dirty:         map[NodeId]struct{}{},
 		hasher:        config.Hashing.createHasher(),
-		keyHasher:     common.NewCachedHasher[common.Key](hashesCacheCapacity, common.KeySerializer{}),
-		addressHasher: common.NewCachedHasher[common.Address](hashesCacheCapacity, common.AddressSerializer{}),
+		keyHasher:     NewKeyHasher(),
+		addressHasher: NewAddressHasher(),
 	}
 	res.writeBuffer = makeWriteBuffer(writeBufferSink{res}, 1024)
 	return res, nil
@@ -342,11 +342,13 @@ func (s *Forest) getHashFor(ref *NodeReference) (common.Hash, error) {
 }
 
 func (s *Forest) hashKey(key common.Key) common.Hash {
-	return s.keyHasher.Hash(key)
+	hash, _ := s.keyHasher.Hash(key)
+	return hash
 }
 
 func (s *Forest) hashAddress(address common.Address) common.Hash {
-	return s.addressHasher.Hash(address)
+	hash, _ := s.addressHasher.Hash(address)
+	return hash
 }
 
 func (f *Forest) Freeze(ref *NodeReference) error {

--- a/go/state/mpt/hash_cache.go
+++ b/go/state/mpt/hash_cache.go
@@ -1,0 +1,115 @@
+package mpt
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+type CachedHasher[T any] interface {
+	Hash(T) (common.Hash, bool)
+	common.MemoryFootprintProvider
+}
+
+func NewAddressHasher() CachedHasher[common.Address] {
+	return newGenericHasher[common.Address](
+		func(addr common.Address) int { return int(addr[0]) | (int(addr[1]) << 8) | (int(addr[2]) << 16) },
+		func(addr common.Address) common.Hash { return common.Keccak256(addr[:]) },
+	)
+}
+
+func NewKeyHasher() CachedHasher[common.Key] {
+	return newGenericHasher[common.Key](
+		func(key common.Key) int {
+			// Here the last 3 bytes are used since some keys are low-range big-endian values.
+			return int(key[31]) | (int(key[30]) << 8) | (int(key[29]) << 16)
+		},
+		func(key common.Key) common.Hash { return common.Keccak256(key[:]) },
+	)
+}
+
+const hashCacheSize = 1 << 17 // ~128K entries
+
+type genericHasher[T comparable] struct {
+	entries    []cachedHasherEntry[T]
+	simpleHash func(T) int
+	cryptoHash func(T) common.Hash
+}
+
+// newGenericHasher creates a generic hash cache for a fixed type using the
+// given simpleHash function for managing cached instances and the provided
+// cryptoHash function for computing hashes of missing entries.
+func newGenericHasher[T comparable](
+	simpleHash func(T) int,
+	cryptoHash func(T) common.Hash,
+) CachedHasher[T] {
+	return &genericHasher[T]{
+		entries:    make([]cachedHasherEntry[T], hashCacheSize),
+		simpleHash: simpleHash,
+		cryptoHash: cryptoHash,
+	}
+}
+
+func (h *genericHasher[T]) Hash(key T) (common.Hash, bool) {
+	pos := h.simpleHash(key)
+	entry := &h.entries[pos%hashCacheSize]
+	entry.mutex.Lock()
+	if entry.key == key && entry.used {
+		res := entry.hash
+		entry.mutex.Unlock()
+		return res, true
+	}
+	entry.used = true
+	entry.key = key
+	entry.hash = h.cryptoHash(key)
+	res := entry.hash
+	entry.mutex.Unlock()
+	return res, false
+}
+
+func (h *genericHasher[T]) GetMemoryFootprint() *common.MemoryFootprint {
+	selfSize := unsafe.Sizeof(*h)
+	entrySize := unsafe.Sizeof(cachedHasherEntry[T]{})
+	mf := common.NewMemoryFootprint(selfSize + uintptr(len(h.entries))*(entrySize))
+	return mf
+}
+
+type cachedHasherEntry[K comparable] struct {
+	key   K
+	hash  common.Hash
+	mutex sync.Mutex
+	used  bool // TODO: eliminate the used field by initializing the cache
+}
+
+type HitMissTrackingCachedHasher[T any] struct {
+	cache  CachedHasher[T]
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+// NewHitMissTrackingCache wraps the given cache into a version tracking hits and misses.
+func NewHitMissTrackingCache[T any](cache CachedHasher[T]) *HitMissTrackingCachedHasher[T] {
+	return &HitMissTrackingCachedHasher[T]{cache: cache}
+}
+
+func (h *HitMissTrackingCachedHasher[T]) Hash(value T) (common.Hash, bool) {
+	res, hit := h.cache.Hash(value)
+	if hit {
+		h.hits.Add(1)
+	} else {
+		h.misses.Add(1)
+	}
+	return res, hit
+}
+
+func (h *HitMissTrackingCachedHasher[T]) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*h))
+	mf.AddChild("cache", h.cache.GetMemoryFootprint())
+	hits := h.hits.Load()
+	misses := h.misses.Load()
+	mf.SetNote(fmt.Sprintf("(hash-cache, hits %d, misses %d, hit ratio %f)", hits, misses, float64(hits)/float64(hits+misses)))
+	return mf
+}

--- a/go/state/mpt/hash_cache_test.go
+++ b/go/state/mpt/hash_cache_test.go
@@ -1,0 +1,228 @@
+package mpt
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func TestAddressHasher_ProducesCorrectHashes(t *testing.T) {
+	hasher := NewAddressHasher()
+	for _, test := range getRandomAddresses(100) {
+		want := common.Keccak256(test[:])
+		got, _ := hasher.Hash(test)
+		if want != got {
+			t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+		}
+	}
+}
+
+func TestAddressHasher_HitsAndMissesAreIndictedCorretly(t *testing.T) {
+	hasher := NewAddressHasher()
+	if _, hit := hasher.Hash(common.Address{}); hit {
+		t.Errorf("first access should not be a hit")
+	}
+	if _, hit := hasher.Hash(common.Address{}); !hit {
+		t.Errorf("second access should be a hit")
+	}
+}
+
+func TestAddressHasher_AccessesAreRaceConditionFree(t *testing.T) {
+	tests := getRandomAddresses(100)
+	hasher := NewAddressHasher()
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			for _, test := range tests {
+				want := common.Keccak256(test[:])
+				got, _ := hasher.Hash(test)
+				if want != got {
+					t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAddressHasher_GetMemoryFootprint(t *testing.T) {
+	hasher := NewAddressHasher()
+	want := hashCacheSize*uint64(unsafe.Sizeof(cachedHasherEntry[common.Address]{})) + uint64(unsafe.Sizeof(genericHasher[common.Address]{}))
+	got := uint64(hasher.GetMemoryFootprint().Total())
+	if want != got {
+		t.Errorf("unexpected size, wanted %d, got %d", want, got)
+	}
+}
+
+func TestKeyHasher_ProducesCorrectHashes(t *testing.T) {
+	hasher := NewKeyHasher()
+	for _, test := range getRandomKeys(100) {
+		want := common.Keccak256(test[:])
+		got, _ := hasher.Hash(test)
+		if want != got {
+			t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+		}
+	}
+}
+
+func TestKeyHasher_AccessesAreRaceConditionFree(t *testing.T) {
+	tests := getRandomKeys(100)
+	hasher := NewKeyHasher()
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			for _, test := range tests {
+				want := common.Keccak256(test[:])
+				got, _ := hasher.Hash(test)
+				if want != got {
+					t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+func TestKeyHasher_GetMemoryFootprint(t *testing.T) {
+	hasher := NewKeyHasher()
+	want := hashCacheSize*uint64(unsafe.Sizeof(cachedHasherEntry[common.Key]{})) + uint64(unsafe.Sizeof(genericHasher[common.Key]{}))
+	got := uint64(hasher.GetMemoryFootprint().Total())
+	if want != got {
+		t.Errorf("unexpected size, wanted %d, got %d", want, got)
+	}
+}
+
+func TestNewHitMissTrackingCache_ProducesCorrectHashes(t *testing.T) {
+	hasher := NewHitMissTrackingCache(NewKeyHasher())
+	for _, test := range getRandomKeys(100) {
+		want := common.Keccak256(test[:])
+		got, _ := hasher.Hash(test)
+		if want != got {
+			t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+		}
+	}
+}
+
+func TestNewHitMissTrackingCache_AccessesAreRaceConditionFree(t *testing.T) {
+	tests := getRandomKeys(100)
+	hasher := NewHitMissTrackingCache(NewKeyHasher())
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			for _, test := range tests {
+				want := common.Keccak256(test[:])
+				got, _ := hasher.Hash(test)
+				if want != got {
+					t.Errorf("invalid hash of %x, wanted %x, got %x", test, want, got)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestNewHitMissTrackingCache_GetMemoryFootprint(t *testing.T) {
+	hasher := NewHitMissTrackingCache(NewKeyHasher())
+	want := hashCacheSize*uint64(unsafe.Sizeof(cachedHasherEntry[common.Key]{})) +
+		uint64(unsafe.Sizeof(genericHasher[common.Key]{})) +
+		uint64(unsafe.Sizeof(HitMissTrackingCachedHasher[common.Key]{}))
+
+	fp := hasher.GetMemoryFootprint()
+	got := uint64(fp.Total())
+	if want != got {
+		t.Errorf("unexpected size, wanted %d, got %d", want, got)
+	}
+	if !strings.Contains(fp.String(), "hit ratio") {
+		t.Errorf("no hit ratio reported in `%s`", fp.String())
+	}
+}
+
+func TestNewHitMissTrackingCache_CountsHitsAndMissesCorrectly(t *testing.T) {
+	hasher := NewHitMissTrackingCache(NewAddressHasher())
+
+	if got, want := hasher.hits.Load(), uint64(0); got != want {
+		t.Errorf("initial hit counter invalid, want %d, got %d", want, got)
+	}
+	if got, want := hasher.misses.Load(), uint64(0); got != want {
+		t.Errorf("initial miss counter invalid, want %d, got %d", want, got)
+	}
+
+	if _, hit := hasher.Hash(common.Address{}); hit {
+		t.Errorf("first access should not be a hit")
+	}
+
+	if got, want := hasher.hits.Load(), uint64(0); got != want {
+		t.Errorf("hit counter invalid, want %d, got %d", want, got)
+	}
+	if got, want := hasher.misses.Load(), uint64(1); got != want {
+		t.Errorf("miss counter invalid, want %d, got %d", want, got)
+	}
+
+	if _, hit := hasher.Hash(common.Address{}); !hit {
+		t.Errorf("second access should be a hit")
+	}
+
+	if got, want := hasher.hits.Load(), uint64(1); got != want {
+		t.Errorf("hit counter invalid, want %d, got %d", want, got)
+	}
+	if got, want := hasher.misses.Load(), uint64(1); got != want {
+		t.Errorf("miss counter invalid, want %d, got %d", want, got)
+	}
+}
+
+func getRandomAddresses(number int) []common.Address {
+	r := rand.New(rand.NewSource(99))
+	list := []common.Address{}
+	for i := 0; i < number; i++ {
+		cur := common.Address{}
+		r.Read(cur[:])
+		list = append(list, cur)
+	}
+	return list
+}
+
+func getRandomKeys(number int) []common.Key {
+	r := rand.New(rand.NewSource(99))
+	list := []common.Key{}
+	for i := 0; i < number; i++ {
+		cur := common.Key{}
+		r.Read(cur[:])
+		list = append(list, cur)
+	}
+	return list
+}
+
+func BenchmarkHashCache_KeyHasherMiss(b *testing.B) {
+	hasher := NewKeyHasher()
+	key := common.Key{}
+	for i := 0; i < b.N; i++ {
+		key[31] = byte(i)
+		key[30] = byte(i >> 8)
+		key[29] = byte(i >> 16)
+		key[28] = byte(i >> 24)
+		_, hit := hasher.Hash(key)
+		if hit {
+			b.Fatalf("all accesses should be misses")
+		}
+	}
+}
+
+func BenchmarkHashCache_KeyHasherHit(b *testing.B) {
+	hasher := NewKeyHasher()
+	key := common.Key{}
+	for i := 0; i < b.N; i++ {
+		_, hit := hasher.Hash(key)
+		if i > 0 && !hit {
+			b.Fatalf("all accesses should be hits")
+		}
+	}
+}

--- a/go/state/mpt/tool/benchmark.go
+++ b/go/state/mpt/tool/benchmark.go
@@ -245,14 +245,14 @@ func runBenchmark(
 	)
 	for i := 0; i < numBlocks; i++ {
 		for j := 0; j < numReadsPerBlock; j++ {
-			addr := common.Address{byte(counter >> 24), byte(counter >> 16), byte(counter >> 8), byte(counter)}
+			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24)}
 			state.GetBalance(addr)
 			counter++
 		}
 		update := common.Update{}
 		update.CreatedAccounts = make([]common.Address, 0, numInsertsPerBlock)
 		for j := 0; j < numInsertsPerBlock; j++ {
-			addr := common.Address{byte(counter >> 24), byte(counter >> 16), byte(counter >> 8), byte(counter)}
+			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24)}
 			update.CreatedAccounts = append(update.CreatedAccounts, addr)
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(1)})
 			counter++


### PR DESCRIPTION
This PR replaces the general LRU cache for hashes with a specialized version of a 1-way cache offering the following benefits:
- elimination of a cache-global lock and utilization of per-entry locks instead
- preservation of comparable hit rates; tested for first 1M blocks:
  - address hit ratio LRU: 0.999046, new: 0.997758
  - key hit ratio LRU: 0.847923, new: 0.838519
- a customized, efficient hash function for mapping addresses and keys to ways; analysis shows that the last 3 bytes of a key are most significant; for addresses, the hash rate was high enough such that no analysis was conducted;

This change increases the benchmark throughput by ~6%:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/2a5b64de-d9c3-4ffb-a05c-616cf6c8f872)


Todo:
- [x] check hit rate impact
- [x] merge with recent improvements
- [x] benchmark performance impact
