### PR TITLE
Avoid invalid StateDB instances in the pool

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1329,6 +1329,8 @@ type nonCommittableStateDB struct {
 }
 
 func (db *nonCommittableStateDB) Release() {
-	nonCommittableStateDbPool.Put(db.stateDB)
-	db.stateDB = nil
+	if db.stateDB != nil {
+		nonCommittableStateDbPool.Put(db.stateDB)
+		db.stateDB = nil
+	}
 }


### PR DESCRIPTION
@HonzaDajc have reported issue, whose part was following panic caused (probably) by releasing of nil StateDB:

```
Nov 24 08:12:03 xapi400 opera[92723]: panic: runtime error: invalid memory address or nil pointer dereference
Nov 24 08:12:03 xapi400 opera[92723]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xdec397]
Nov 24 08:12:03 xapi400 opera[92723]: goroutine 1942 [running]:
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/Carmen/go/state.(*stateDB).resetBlockContext(0x0)
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/go/pkg/mod/github.com/!fantom-foundation/!carmen/go@v0.0.0-20231122101444-59498c099c54/state/state_db.go:1241 +0x17
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/Carmen/go/state.(*stateDB).resetState(0x0, {0x1c71be8?, 0xc005a18168})
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/go/pkg/mod/github.com/!fantom-foundation/!carmen/go@v0.0.0-20231122101444-59498c099c54/state/state_db.go:1252 +0x2b
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/Carmen/go/state.CreateNonCommittableStateDBUsing({0x1c71be8, 0xc005a18168})
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/go/pkg/mod/github.com/!fantom-foundation/!carmen/go@v0.0.0-20231122101444-59498c099c54/state/state_db.go:364 +0x4b
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/go-opera/statedb.GetTxPoolStateDb({0xe6, 0x59, 0x72, 0x9c, 0xb, 0xda, 0x3c, 0xb4, 0xe5, 0x15, ...}, ...)
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/Norma/statedb/switch.go:188 +0xbb
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/go-opera/gossip.(*EvmStateReader).StateAt(0xffff?, {0xe6, 0x59, 0x72, 0x9c, 0xb, 0xda, 0x3c, 0xb4, 0xe5, ...})
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/Norma/gossip/evm_state_reader.go:143 +0x46
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/go-opera/evmcore.(*TxPool).reset(0xc005a7a5a0, 0xc000358480, 0xc000358540)
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/Norma/evmcore/tx_pool.go:1381 +0x73e
Nov 24 08:12:03 xapi400 opera[92723]: github.com/Fantom-foundation/go-opera/evmcore.(*TxPool).runReorg(0xc005a7a5a0, 0x10000c005ec9290?, 0xc026d6ad10, 0xc0002d2208?, 0xc02a6e1200)
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/Norma/evmcore/tx_pool.go:1240 +0x1dc
Nov 24 08:12:03 xapi400 opera[92723]: created by github.com/Fantom-foundation/go-opera/evmcore.(*TxPool).scheduleReorgLoop in goroutine 1158
Nov 24 08:12:03 xapi400 opera[92723]:   /home/jand/Norma/evmcore/tx_pool.go:1172 +0x192
```
I am not sure how this happens, if we want to make sure Release will be called only when appropriate, we may put if-panic in here and wait where it appears, but I think this solution could be sufficient...