### PR TITLE
Add C specialization for address and key hashing

### DIFF
--- a/go/common/keccak.go
+++ b/go/common/keccak.go
@@ -16,6 +16,14 @@ func Keccak256(data []byte) Hash {
 	return keccak256_C(data)
 }
 
+func Keccak256ForAddress(addr Address) Hash {
+	return keccak256_C_Address(addr)
+}
+
+func Keccak256ForKey(key Key) Hash {
+	return keccak256_C_Key(key)
+}
+
 var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
 
 func keccak256_Go(data []byte) Hash {
@@ -42,4 +50,38 @@ func keccak256_C(data []byte) Hash {
 	}
 	res := C.carmen_keccak256(unsafe.Pointer(&data[0]), C.size_t(len(data)))
 	return Hash(res)
+}
+
+func keccak256_C_Address(addr Address) Hash {
+	// The address is passed as 2x 64-bit and 1 32-bit integer value through
+	// the stack to avoid the need of allocating heap memory for the address.
+	return Hash(C.carmen_keccak256_20byte(
+		C.uint64_t(
+			uint64(addr[7])<<56|uint64(addr[6])<<48|uint64(addr[5])<<40|uint64(addr[4])<<32|
+				uint64(addr[3])<<24|uint64(addr[2])<<16|uint64(addr[1])<<8|uint64(addr[0])<<0),
+		C.uint64_t(
+			uint64(addr[15])<<56|uint64(addr[14])<<48|uint64(addr[13])<<40|uint64(addr[12])<<32|
+				uint64(addr[11])<<24|uint64(addr[10])<<16|uint64(addr[9])<<8|uint64(addr[8])<<0),
+		C.uint32_t(
+			uint64(addr[19])<<24|uint64(addr[18])<<16|uint64(addr[17])<<8|uint64(addr[16])<<0),
+	))
+}
+
+func keccak256_C_Key(key Key) Hash {
+	// The address is passed as 4x 64-bit integer values through the stack to
+	// avoid the need of allocating heap memory for the key.
+	return Hash(C.carmen_keccak256_32byte(
+		C.uint64_t(
+			uint64(key[7])<<56|uint64(key[6])<<48|uint64(key[5])<<40|uint64(key[4])<<32|
+				uint64(key[3])<<24|uint64(key[2])<<16|uint64(key[1])<<8|uint64(key[0])<<0),
+		C.uint64_t(
+			uint64(key[15])<<56|uint64(key[14])<<48|uint64(key[13])<<40|uint64(key[12])<<32|
+				uint64(key[11])<<24|uint64(key[10])<<16|uint64(key[9])<<8|uint64(key[8])<<0),
+		C.uint64_t(
+			uint64(key[23])<<56|uint64(key[22])<<48|uint64(key[21])<<40|uint64(key[20])<<32|
+				uint64(key[19])<<24|uint64(key[18])<<16|uint64(key[17])<<8|uint64(key[16])<<0),
+		C.uint64_t(
+			uint64(key[31])<<56|uint64(key[30])<<48|uint64(key[29])<<40|uint64(key[28])<<32|
+				uint64(key[27])<<24|uint64(key[26])<<16|uint64(key[25])<<8|uint64(key[24])<<0),
+	))
 }

--- a/go/common/keccak.h
+++ b/go/common/keccak.h
@@ -387,6 +387,95 @@ union ethash_hash256 carmen_keccak256(const void *in, size_t size) noexcept {
   return hash;
 }
 
+static inline ALWAYS_INLINE union ethash_hash256
+keccak_20(const uint64_t a, const uint64_t b, const uint32_t c) {
+  static const size_t word_size = sizeof(uint64_t);
+  const size_t bits = 256;
+  const size_t hash_size = bits / 8;
+  const size_t block_size = (1600 - bits * 2) / 8;
+
+  size_t i;
+  uint64_t *state_iter;
+  uint64_t last_word = 0;
+  uint8_t *last_word_iter = (uint8_t *)&last_word;
+  size_t size = 20;
+
+  uint64_t state[25] = {0};
+
+  state_iter = state;
+
+  *state_iter = a;
+  ++state_iter;
+  *state_iter = b;
+  ++state_iter;
+
+  last_word = (uint64_t)(c) | (((uint64_t)(0x01)) << 32);
+  *state_iter ^= to_le64(last_word);
+
+  state[(block_size / word_size) - 1] ^= 0x8000000000000000;
+
+  keccakf1600_best(state);
+
+  union ethash_hash256 res;
+  res.word64s[0] = state[0];
+  res.word64s[1] = state[1];
+  res.word64s[2] = state[2];
+  res.word64s[3] = state[3];
+  return res;
+}
+
+union ethash_hash256 carmen_keccak256_20byte(const uint64_t a, const uint64_t b,
+                                             const uint32_t c) noexcept {
+  return keccak_20(a, b, c);
+}
+
+static inline ALWAYS_INLINE union ethash_hash256 keccak_32(const uint64_t a,
+                                                           const uint64_t b,
+                                                           const uint64_t c,
+                                                           const uint64_t d) {
+  static const size_t word_size = sizeof(uint64_t);
+  const size_t hash_size = 256 / 8;
+  const size_t block_size = (1600 - 256 * 2) / 8;
+
+  size_t i;
+  uint64_t *state_iter;
+  uint64_t last_word = 0;
+  uint8_t *last_word_iter = (uint8_t *)&last_word;
+
+  uint64_t state[25] = {0};
+
+  state_iter = state;
+
+  *state_iter = a;
+  ++state_iter;
+  *state_iter = b;
+  ++state_iter;
+  *state_iter = c;
+  ++state_iter;
+  *state_iter = d;
+  ++state_iter;
+
+  last_word = 0x01;
+  *state_iter ^= to_le64(last_word);
+
+  state[(block_size / word_size) - 1] ^= 0x8000000000000000;
+
+  keccakf1600_best(state);
+
+  union ethash_hash256 res;
+  res.word64s[0] = state[0];
+  res.word64s[1] = state[1];
+  res.word64s[2] = state[2];
+  res.word64s[3] = state[3];
+  return res;
+}
+
+union ethash_hash256 carmen_keccak256_32byte(const uint64_t a, const uint64_t b,
+                                             const uint64_t c,
+                                             const uint64_t d) noexcept {
+  return keccak_32(a, b, c, d);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -17,6 +18,66 @@ func TestKeccakC_ProducesSameHashAsGo(t *testing.T) {
 	for _, test := range tests {
 		want := keccak256_Go(test)
 		got := keccak256_C(test)
+		if want != got {
+			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+		}
+	}
+}
+
+func TestKeccakC_AddressSpecializationProducesSameHashAsGenericVersion(t *testing.T) {
+	tests := []Address{
+		{},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+	}
+
+	// Test each individual bit.
+	for i := 0; i < 20*8; i++ {
+		addr := Address{}
+		addr[i/8] = 1 << i % 8
+		tests = append(tests, addr)
+	}
+
+	// Add some random inputs as well.
+	r := rand.New(rand.NewSource(99))
+	for i := 0; i < 10; i++ {
+		addr := Address{}
+		r.Read(addr[:])
+		tests = append(tests, addr)
+	}
+
+	for _, test := range tests {
+		want := keccak256_Go(test[:])
+		got := keccak256_C_Address(test)
+		if want != got {
+			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+		}
+	}
+}
+
+func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T) {
+	tests := []Key{
+		{},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2},
+	}
+
+	// Test each individual bit.
+	for i := 0; i < 32*8; i++ {
+		key := Key{}
+		key[i/8] = 1 << i % 8
+		tests = append(tests, key)
+	}
+
+	// Add some random inputs as well.
+	r := rand.New(rand.NewSource(99))
+	for i := 0; i < 10; i++ {
+		key := Key{}
+		r.Read(key[:])
+		tests = append(tests, key)
+	}
+
+	for _, test := range tests {
+		want := keccak256_Go(test[:])
+		got := keccak256_C_Key(test)
 		if want != got {
 			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
 		}
@@ -44,4 +105,46 @@ func BenchmarkKeccakC(b *testing.B) {
 	benchmark(b, func(data []byte) {
 		keccak256_C(data)
 	})
+}
+
+func BenchmarkKeccakGoAddressGeneric(b *testing.B) {
+	addr := Address{}
+	for i := 0; i < b.N; i++ {
+		keccak256_Go(addr[:])
+	}
+}
+
+func BenchmarkKeccakCAddressGeneric(b *testing.B) {
+	addr := Address{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C(addr[:])
+	}
+}
+
+func BenchmarkKeccakCAddressSpecialized(b *testing.B) {
+	addr := Address{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C_Address(addr)
+	}
+}
+
+func BenchmarkKeccakGoKeyGeneric(b *testing.B) {
+	key := Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_Go(key[:])
+	}
+}
+
+func BenchmarkKeccakCKeyGeneric(b *testing.B) {
+	key := Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C(key[:])
+	}
+}
+
+func BenchmarkKeccakCKeySpecialized(b *testing.B) {
+	key := Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C_Key(key)
+	}
 }


### PR DESCRIPTION
This PR adds specialized C implementations for hashing Addresses and Keys. 

Besides enabling compilers to generate more efficient code, these versions also eliminate the need for exporting keys and addresses to the heap before calling the C-based hashing methods. The result is a considerable latency reduction of -40% compared to the non-specialized C version and -60% compared to the generic Go version:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/c8db7ea6-dd8c-417b-a741-7e234f97db35)

