### PR TITLE
Use specialized hashing methods for addresses and keys

### DIFF
--- a/go/state/mpt/hash_cache.go
+++ b/go/state/mpt/hash_cache.go
@@ -17,7 +17,7 @@ type CachedHasher[T any] interface {
 func NewAddressHasher() CachedHasher[common.Address] {
 	return newGenericHasher[common.Address](
 		func(addr common.Address) int { return int(addr[0]) | (int(addr[1]) << 8) | (int(addr[2]) << 16) },
-		func(addr common.Address) common.Hash { return common.Keccak256(addr[:]) },
+		func(addr common.Address) common.Hash { return common.Keccak256ForAddress(addr) },
 	)
 }
 
@@ -27,7 +27,7 @@ func NewKeyHasher() CachedHasher[common.Key] {
 			// Here the last 3 bytes are used since some keys are low-range big-endian values.
 			return int(key[31]) | (int(key[30]) << 8) | (int(key[29]) << 16)
 		},
-		func(key common.Key) common.Hash { return common.Keccak256(key[:]) },
+		func(key common.Key) common.Hash { return common.Keccak256ForKey(key) },
 	)
 }
 


### PR DESCRIPTION
Replaces the generic address and key hashers with specialized implementations.

Result in the performance of cache misses:
```
cpu: AMD Ryzen 9 5950X 16-Core Processor            
                           │   old.log   │               new.log               │
                           │   sec/op    │   sec/op     vs base                │
HashCache_KeyHasherMiss-32   447.7n ± 6%   291.6n ± 3%  -34.87% (p=0.000 n=10)

                           │   old.log   │              new.log               │
                           │    B/op     │    B/op     vs base                │
HashCache_KeyHasherMiss-32   59.000 ± 2%   2.000 ± 0%  -96.61% (p=0.000 n=10)

                           │  old.log   │               new.log               │
                           │ allocs/op  │ allocs/op   vs base                 │
HashCache_KeyHasherMiss-32   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```