### PR TITLE
Add support for recylcing node hash lists

### DIFF
--- a/go/common/releaser.go
+++ b/go/common/releaser.go
@@ -1,0 +1,9 @@
+package common
+
+// Releaser is an interface for types owning resources that should be released
+// after use to facilitate resource re-utilization.
+type Releaser interface {
+	// Release releases bound resources for re-use. The object this function is
+	// called on becomes invalid for any future operation afterwards.
+	Release()
+}

--- a/go/state/go_schema1.go
+++ b/go/state/go_schema1.go
@@ -274,7 +274,7 @@ func (s *GoSchema1) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema1) Apply(block uint64, update common.Update) (archiveUpdateHints any, err error) {
+func (s *GoSchema1) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
 	return nil, update.ApplyTo(s)
 }
 

--- a/go/state/go_schema2.go
+++ b/go/state/go_schema2.go
@@ -260,7 +260,7 @@ func (s *GoSchema2) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema2) Apply(block uint64, update common.Update) (archiveUpdateHints any, err error) {
+func (s *GoSchema2) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
 	return nil, update.ApplyTo(s)
 }
 

--- a/go/state/go_schema3.go
+++ b/go/state/go_schema3.go
@@ -266,7 +266,7 @@ func (s *GoSchema3) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema3) Apply(block uint64, update common.Update) (archiveUpdateHints any, err error) {
+func (s *GoSchema3) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
 	return nil, update.ApplyTo(s)
 }
 

--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -70,7 +70,7 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
-	precomputedHashes, _ := hint.([]nodeHash)
+	precomputedHashes, _ := hint.(*NodeHashes)
 
 	a.addMutex.Lock()
 	defer a.addMutex.Unlock()

--- a/go/state/mpt/archive_trie_test.go
+++ b/go/state/mpt/archive_trie_test.go
@@ -101,7 +101,7 @@ func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 			}
 
 			// Block 4 is empty, with hints.
-			if err := archive.Add(4, common.Update{}, []nodeHash{}); err != nil {
+			if err := archive.Add(4, common.Update{}, nil); err != nil {
 				t.Errorf("failed to add block: %v", err)
 			}
 

--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -321,17 +321,17 @@ func (s *Forest) VisitTrie(rootRef *NodeReference, visitor NodeVisitor) error {
 	return err
 }
 
-func (s *Forest) updateHashesFor(ref *NodeReference) (common.Hash, []nodeHash, error) {
+func (s *Forest) updateHashesFor(ref *NodeReference) (common.Hash, *NodeHashes, error) {
 	return s.hasher.updateHashes(ref, s)
 }
 
-func (s *Forest) setHashesFor(root *NodeReference, hashes []nodeHash) error {
-	for _, cur := range hashes {
-		write, err := s.getMutableNodeByPath(root, cur.path)
+func (s *Forest) setHashesFor(root *NodeReference, hashes *NodeHashes) error {
+	for _, cur := range hashes.GetHashes() {
+		write, err := s.getMutableNodeByPath(root, cur.Path)
 		if err != nil {
 			return err
 		}
-		write.Get().SetHash(cur.hash)
+		write.Get().SetHash(cur.Hash)
 		write.Release()
 	}
 	return nil

--- a/go/state/mpt/hasher_mocks.go
+++ b/go/state/mpt/hasher_mocks.go
@@ -50,11 +50,11 @@ func (mr *MockhasherMockRecorder) getHash(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // updateHashes mocks base method.
-func (m *Mockhasher) updateHashes(root *NodeReference, nodes NodeManager) (common.Hash, []nodeHash, error) {
+func (m *Mockhasher) updateHashes(root *NodeReference, nodes NodeManager) (common.Hash, *NodeHashes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "updateHashes", root, nodes)
 	ret0, _ := ret[0].(common.Hash)
-	ret1, _ := ret[1].([]nodeHash)
+	ret1, _ := ret[1].(*NodeHashes)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/go/state/mpt/live_trie.go
+++ b/go/state/mpt/live_trie.go
@@ -119,11 +119,11 @@ func (s *LiveTrie) ClearStorage(addr common.Address) error {
 	return s.forest.ClearStorage(&s.root, addr)
 }
 
-func (s *LiveTrie) UpdateHashes() (common.Hash, []nodeHash, error) {
+func (s *LiveTrie) UpdateHashes() (common.Hash, *NodeHashes, error) {
 	return s.forest.updateHashesFor(&s.root)
 }
 
-func (s *LiveTrie) setHashes(hashes []nodeHash) error {
+func (s *LiveTrie) setHashes(hashes *NodeHashes) error {
 	return s.forest.setHashesFor(&s.root, hashes)
 }
 

--- a/go/state/mpt/node_hash.go
+++ b/go/state/mpt/node_hash.go
@@ -1,0 +1,56 @@
+package mpt
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+// NodeHash is a utility type linking a path in an MPT to a hash. Its main
+// use case is to transfer computed hashes from LiveDB instances to archives
+// to avoid double-computation and thus improve efficiency.
+type NodeHash struct {
+	Path NodePath
+	Hash common.Hash
+}
+
+// Equal returns true if the given NodeHash is the same as this one.
+func (h *NodeHash) Equal(other *NodeHash) bool {
+	return h == other || (h.Hash == other.Hash && h.Path.Equal(other.Path))
+}
+
+// NodeHashes provides a recyclable list of NodeHash instances. NodeHashes
+// should be created using NewNodeHashes() and released by calling its Release
+// method. It is not an error to fail to release an instance, but it may harm
+// performance and increase memory usage temporarily.
+type NodeHashes struct {
+	hashes []NodeHash
+}
+
+// nodeHashPool is a pool for the repeated reuse of hash lists
+var nodeHashPool = sync.Pool{New: func() any {
+	return &NodeHashes{hashes: make([]NodeHash, 0, 4096)}
+},
+}
+
+// NewNodeHashes obtains an empty instance to be owned by the caller.
+func NewNodeHashes() *NodeHashes {
+	return nodeHashPool.Get().(*NodeHashes)
+}
+
+// Add adds an entry to this node hash collection.
+func (h *NodeHashes) Add(path NodePath, hash common.Hash) {
+	h.hashes = append(h.hashes, NodeHash{path, hash})
+}
+
+// GetHashes retains a (shared) view on the retained hashes.
+func (h *NodeHashes) GetHashes() []NodeHash {
+	return h.hashes
+}
+
+// Release frees internal resources for future reuse and invalidates this object.
+// Release must not be called more than once on a valid NodeHashes instance.
+func (h *NodeHashes) Release() {
+	h.hashes = h.hashes[:0]
+	nodeHashPool.Put(h)
+}

--- a/go/state/mpt/node_hash_test.go
+++ b/go/state/mpt/node_hash_test.go
@@ -1,0 +1,64 @@
+package mpt
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+func TestNodeHashes_ContainsAddedElements(t *testing.T) {
+	equal := func(a, b []NodeHash) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, cur := range a {
+			if !cur.Equal(&b[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	list := NewNodeHashes()
+	want := []NodeHash{}
+	if got := list.GetHashes(); !equal(want, got) {
+		t.Errorf("Invalid list content, wanted %v, got %v", want, got)
+	}
+	list.Add(EmptyPath(), common.Hash{0})
+	want = append(want, NodeHash{EmptyPath(), common.Hash{0}})
+	if got := list.GetHashes(); !equal(want, got) {
+		t.Errorf("Invalid list content, wanted %v, got %v", want, got)
+	}
+	list.Add(EmptyPath().Child(1), common.Hash{1})
+	want = append(want, NodeHash{EmptyPath().Child(1), common.Hash{1}})
+	if got := list.GetHashes(); !equal(want, got) {
+		t.Errorf("Invalid list content, wanted %v, got %v", want, got)
+	}
+	list.Add(EmptyPath().Next(), common.Hash{2})
+	want = append(want, NodeHash{EmptyPath().Next(), common.Hash{2}})
+	if got := list.GetHashes(); !equal(want, got) {
+		t.Errorf("Invalid list content, wanted %v, got %v", want, got)
+	}
+}
+
+func TestNodeHashes_RecycledListsAreEmpty(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		list := NewNodeHashes()
+		if size := len(list.GetHashes()); size != 0 {
+			t.Errorf("new node list is not empty, size: %d", size)
+		}
+		list.Add(EmptyPath(), common.Hash{})
+		if size := len(list.GetHashes()); size != 1 {
+			t.Errorf("invalid size after adding one element: %d", size)
+		}
+		list.Release()
+	}
+}
+
+func BenchmarkNodeHashes_LiveCycle(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		list := NewNodeHashes()
+		list.Add(EmptyPath(), common.Hash{})
+		list.Release()
+	}
+}

--- a/go/state/mpt/node_path.go
+++ b/go/state/mpt/node_path.go
@@ -1,6 +1,7 @@
 package mpt
 
 import (
+	"slices"
 	"strings"
 )
 
@@ -24,6 +25,11 @@ func EmptyPath() NodePath {
 // be zero.
 func CreateNodePath(steps ...Nibble) NodePath {
 	return NodePath{steps}
+}
+
+// Equal returns true if the given path is equal to this path.
+func (p NodePath) Equal(o NodePath) bool {
+	return slices.Equal(p.path, o.path)
 }
 
 // Length returns the length of this path if valid. The result is undefined for

--- a/go/state/mpt/node_path_test.go
+++ b/go/state/mpt/node_path_test.go
@@ -65,6 +65,34 @@ func TestNodePath_StepsCanBeAppended(t *testing.T) {
 	}
 }
 
+func TestNodePath_Equal(t *testing.T) {
+	tests := []struct {
+		a, b  NodePath
+		equal bool
+	}{
+		{EmptyPath(), EmptyPath(), true},
+		{EmptyPath().Child(1), EmptyPath().Child(1), true},
+		{EmptyPath().Next(), EmptyPath().Next(), true},
+		{EmptyPath().Child(1).Child(2), EmptyPath().Child(1).Child(2), true},
+		{EmptyPath().Child(1).Next(), EmptyPath().Child(1).Next(), true},
+		{EmptyPath().Next().Child(2), EmptyPath().Next().Child(2), true},
+
+		{EmptyPath(), EmptyPath().Child(1), false},
+		{EmptyPath().Child(1), EmptyPath(), false},
+		{EmptyPath(), EmptyPath().Next(), false},
+		{EmptyPath().Next(), EmptyPath(), false},
+		{EmptyPath(), EmptyPath().Next().Child(1), false},
+		{EmptyPath().Next().Child(1), EmptyPath(), false},
+	}
+	for _, test := range tests {
+		want := test.equal
+		got := test.a.Equal(test.b)
+		if want != got {
+			t.Errorf("error in equal of %v and %v, wanted %t, got %t", test.a, test.b, want, got)
+		}
+	}
+}
+
 func TestNodePath_ToString(t *testing.T) {
 	tests := []struct {
 		path   NodePath

--- a/go/state/mpt/state.go
+++ b/go/state/mpt/state.go
@@ -209,11 +209,14 @@ func (s *MptState) GetRootId() NodeId {
 }
 
 func (s *MptState) GetHash() (hash common.Hash, err error) {
-	hash, _, err = s.trie.UpdateHashes()
+	hash, hints, err := s.trie.UpdateHashes()
+	if hints != nil {
+		hints.Release()
+	}
 	return hash, err
 }
 
-func (s *MptState) Apply(block uint64, update common.Update) (archiveUpdateHints any, err error) {
+func (s *MptState) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
 	if err := update.ApplyTo(s); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds support for a recyclable list of hash hints to reduce memory allocation overhead during state hashing.