### PR TITLE
Add support for configurable node cache capacity

### DIFF
--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -48,7 +48,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S4",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig)
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig, mpt.DefaultMptStateCapacity)
 				if err != nil {
 					tb.Fatalf("failed to open S4 archive: %v", err)
 				}
@@ -59,7 +59,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S5",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig)
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig, mpt.DefaultMptStateCapacity)
 				if err != nil {
 					tb.Fatalf("failed to open S5 archive: %v", err)
 				}

--- a/go/state/go_schema4.go
+++ b/go/state/go_schema4.go
@@ -30,7 +30,7 @@ func newS4State(params Parameters, state *mpt.MptState) (State, error) {
 }
 
 func newGoMemoryS4State(params Parameters) (State, error) {
-	state, err := mpt.OpenGoMemoryState(params.Directory, mpt.S4LiveConfig)
+	state, err := mpt.OpenGoMemoryState(params.Directory, mpt.S4LiveConfig, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func newGoMemoryS4State(params Parameters) (State, error) {
 }
 
 func newGoFileS4State(params Parameters) (State, error) {
-	state, err := mpt.OpenGoFileState(params.Directory, mpt.S4LiveConfig)
+	state, err := mpt.OpenGoFileState(params.Directory, mpt.S4LiveConfig, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/go_schema5.go
+++ b/go/state/go_schema5.go
@@ -30,7 +30,7 @@ func newS5State(params Parameters, state *mpt.MptState) (State, error) {
 }
 
 func newGoMemoryS5State(params Parameters) (State, error) {
-	state, err := mpt.OpenGoMemoryState(params.Directory, mpt.S5LiveConfig)
+	state, err := mpt.OpenGoMemoryState(params.Directory, mpt.S5LiveConfig, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func newGoMemoryS5State(params Parameters) (State, error) {
 }
 
 func newGoFileS5State(params Parameters) (State, error) {
-	state, err := mpt.OpenGoFileState(params.Directory, mpt.S5LiveConfig)
+	state, err := mpt.OpenGoFileState(params.Directory, mpt.S5LiveConfig, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -31,13 +31,14 @@ type ArchiveTrie struct {
 	addMutex   sync.Mutex // a mutex to make sure that at any time only one thread is adding new blocks
 }
 
-func OpenArchiveTrie(directory string, config MptConfig) (archive.Archive, error) {
+func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (archive.Archive, error) {
 	rootfile := directory + "/roots.dat"
 	roots, err := loadRoots(rootfile)
 	if err != nil {
 		return nil, err
 	}
-	forest, err := OpenFileForest(directory, config, Immutable)
+	forestConfig := ForestConfig{Mode: Immutable, CacheCapacity: cacheCapacity}
+	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/mpt/archive_trie_test.go
+++ b/go/state/mpt/archive_trie_test.go
@@ -21,7 +21,7 @@ import (
 func TestArchiveTrie_OpenAndClose(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -35,7 +35,7 @@ func TestArchiveTrie_OpenAndClose(t *testing.T) {
 func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -73,7 +73,7 @@ func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -121,14 +121,14 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 			continue
 		}
 		t.Run(config.Name, func(t *testing.T) {
-			live, err := OpenGoMemoryState(t.TempDir(), config)
+			live, err := OpenGoMemoryState(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open live trie: %v", err)
 			}
 			defer live.Close()
 
 			archiveDir := t.TempDir()
-			archive, err := OpenArchiveTrie(archiveDir, config)
+			archive, err := OpenArchiveTrie(archiveDir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -219,7 +219,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config)
+			archive, err := OpenArchiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -269,7 +269,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config)
+			archive, err := OpenArchiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -309,7 +309,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config)
+			archive, err := OpenArchiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}

--- a/go/state/mpt/io/io.go
+++ b/go/state/mpt/io/io.go
@@ -57,7 +57,7 @@ func Export(directory string, out io.Writer) error {
 		return fmt.Errorf("can only support export of LiveDB instances, found %v in directory", info.Mode)
 	}
 
-	db, err := mpt.OpenGoFileState(directory, info.Config)
+	db, err := mpt.OpenGoFileState(directory, info.Config, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to open LiveDB: %v", err)
 	}
@@ -173,7 +173,7 @@ func runImport(directory string, in io.Reader, config mpt.MptConfig) (root mpt.N
 	}
 
 	// Create a state.
-	db, err := mpt.OpenGoFileState(directory, config)
+	db, err := mpt.OpenGoFileState(directory, config, mpt.DefaultMptStateCapacity)
 	if err != nil {
 		return root, hash, fmt.Errorf("failed to create empty state: %v", err)
 	}

--- a/go/state/mpt/io/io_test.go
+++ b/go/state/mpt/io/io_test.go
@@ -22,7 +22,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 
-	db, err := mpt.OpenGoFileState(targetDir, mpt.S5LiveConfig)
+	db, err := mpt.OpenGoFileState(targetDir, mpt.S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 
-	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig)
+	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
@@ -88,7 +88,7 @@ func exportExampleState(t *testing.T) ([]byte, common.Hash) {
 	sourceDir := t.TempDir()
 
 	// Create a small LiveDB.
-	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig)
+	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to create test DB: %v", err)
 	}

--- a/go/state/mpt/live_trie.go
+++ b/go/state/mpt/live_trie.go
@@ -27,8 +27,9 @@ type LiveTrie struct {
 // OpenInMemoryLiveTrie loads trie information from the given directory and
 // creates a LiveTrie instance retaining all information in memory. If the
 // directory is empty, an empty trie is created.
-func OpenInMemoryLiveTrie(directory string, config MptConfig) (*LiveTrie, error) {
-	forest, err := OpenInMemoryForest(directory, config, Mutable)
+func OpenInMemoryLiveTrie(directory string, config MptConfig, cacheCapacity int) (*LiveTrie, error) {
+	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: cacheCapacity}
+	forest, err := OpenInMemoryForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +40,9 @@ func OpenInMemoryLiveTrie(directory string, config MptConfig) (*LiveTrie, error)
 // creates a LiveTrie instance using a fixed-size cache for retaining nodes in
 // memory, backed by a file-based storage automatically kept in sync. If the
 // directory is empty, an empty trie is created.
-func OpenFileLiveTrie(directory string, config MptConfig) (*LiveTrie, error) {
-	forest, err := OpenFileForest(directory, config, Mutable)
+func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*LiveTrie, error) {
+	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: cacheCapacity}
+	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/mpt/live_trie_test.go
+++ b/go/state/mpt/live_trie_test.go
@@ -11,7 +11,7 @@ import (
 func TestLiveTrie_EmptyTrieIsConsistent(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -27,7 +27,7 @@ func TestLiveTrie_EmptyTrieIsConsistent(t *testing.T) {
 func TestLiveTrie_NonExistingAccountsHaveEmptyInfo(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -48,7 +48,7 @@ func TestLiveTrie_NonExistingAccountsHaveEmptyInfo(t *testing.T) {
 func TestLiveTrie_SetAndGetSingleAccountInformationWorks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -89,7 +89,7 @@ func TestLiveTrie_SetAndGetSingleAccountInformationWorks(t *testing.T) {
 func TestLiveTrie_SetAndGetMultipleAccountInformationWorks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -133,7 +133,7 @@ func TestLiveTrie_SetAndGetMultipleAccountInformationWorks(t *testing.T) {
 func TestLiveTrie_NonExistingValueHasZeroValue(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -161,7 +161,7 @@ func TestLiveTrie_NonExistingValueHasZeroValue(t *testing.T) {
 func TestLiveTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -196,11 +196,11 @@ func TestLiveTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
 func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie1, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie1, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
-			trie2, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie2, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -256,7 +256,7 @@ func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -293,7 +293,7 @@ func TestLiveTrie_InsertLotsOfData(t *testing.T) {
 			t.Parallel()
 			const N = 30
 
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024*1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -356,7 +356,7 @@ func TestLiveTrie_InsertLotsOfValues(t *testing.T) {
 			t.Parallel()
 			const N = 500
 
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -452,7 +452,7 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config)
+			trie, err := OpenFileLiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -489,7 +489,7 @@ func TestLiveTrie_VerificationOfLiveTrieWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config)
+			trie, err := OpenFileLiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -530,7 +530,7 @@ func TestLiveTrie_VerificationOfLiveTrieWithCorruptedFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config)
+			trie, err := OpenFileLiveTrie(dir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -612,7 +612,7 @@ func BenchmarkValueInsertionInMemoryTrie(b *testing.B) {
 	for _, config := range allMptConfigs {
 		b.Run(config.Name, func(b *testing.B) {
 			b.StopTimer()
-			trie, err := OpenInMemoryLiveTrie(b.TempDir(), config)
+			trie, err := OpenInMemoryLiveTrie(b.TempDir(), config, 1024)
 			if err != nil {
 				b.Fatalf("failed to open trie: %v", err)
 			}
@@ -628,7 +628,7 @@ func BenchmarkValueInsertionInFileTrie(b *testing.B) {
 	for _, config := range allMptConfigs {
 		b.Run(config.Name, func(b *testing.B) {
 			b.StopTimer()
-			trie, err := OpenFileLiveTrie(b.TempDir(), config)
+			trie, err := OpenFileLiveTrie(b.TempDir(), config, 1024)
 			if err != nil {
 				b.Fatalf("failed to open trie: %v", err)
 			}

--- a/go/state/mpt/root_hash_test.go
+++ b/go/state/mpt/root_hash_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestS5RootHash_EmptyTrie(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestS5RootHash_EmptyTrie(t *testing.T) {
 
 func TestS5RootHash_SingleAccount(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestS5RootHash_SingleAccount(t *testing.T) {
 
 func TestS5RootHash_SingleAccountWithSingleValue(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestS5RootHash_SingleAccountWithSingleValue(t *testing.T) {
 
 func TestS5RootHash_TwoAccounts(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestS5RootHash_TwoAccounts(t *testing.T) {
 
 func TestS5RootHash_TwoAccountsWithValues(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithEvenLength(t *testing.T) {
 		t.Fatalf("invalid setup, addresses do not have common prefix")
 	}
 
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithOddLength(t *testing.T) {
 		t.Fatalf("invalid setup, addresses do not have single prefix bit prefix")
 	}
 
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestS5RootHash_AddressAndKeys(t *testing.T) {
 
 	const N = 100
 
-	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open trie: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestS5RootHash_Values(t *testing.T) {
 		return res
 	}
 
-	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig)
+	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to open trie: %v", err)
 	}

--- a/go/state/mpt/state.go
+++ b/go/state/mpt/state.go
@@ -29,6 +29,8 @@ type MptState struct {
 	hasher    hash.Hash
 }
 
+const DefaultMptStateCapacity = 10_000_000
+
 var emptyCodeHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})
 
 func newMptState(directory string, trie *LiveTrie) (*MptState, error) {
@@ -46,16 +48,16 @@ func newMptState(directory string, trie *LiveTrie) (*MptState, error) {
 
 // OpenGoMemoryState loads state information from the given directory and
 // creates a Trie entirely retained in memory.
-func OpenGoMemoryState(directory string, config MptConfig) (*MptState, error) {
-	trie, err := OpenInMemoryLiveTrie(directory, config)
+func OpenGoMemoryState(directory string, config MptConfig, cacheCapacity int) (*MptState, error) {
+	trie, err := OpenInMemoryLiveTrie(directory, config, cacheCapacity)
 	if err != nil {
 		return nil, err
 	}
 	return newMptState(directory, trie)
 }
 
-func OpenGoFileState(directory string, config MptConfig) (*MptState, error) {
-	trie, err := OpenFileLiveTrie(directory, config)
+func OpenGoFileState(directory string, config MptConfig, cacheCapacity int) (*MptState, error) {
+	trie, err := OpenFileLiveTrie(directory, config, cacheCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/mpt/state_test.go
+++ b/go/state/mpt/state_test.go
@@ -18,7 +18,7 @@ func BenchmarkStorageChanges(b *testing.B) {
 				mode = "with_hashing"
 			}
 			b.Run(fmt.Sprintf("%s/%s", config.Name, mode), func(b *testing.B) {
-				state, err := OpenGoMemoryState(b.TempDir(), config)
+				state, err := OpenGoMemoryState(b.TempDir(), config, 1024)
 				if err != nil {
 					b.Fail()
 				}

--- a/go/state/mpt/tool/info.go
+++ b/go/state/mpt/tool/info.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/Carmen/go/state/mpt/io"
 
 	"github.com/Fantom-foundation/Carmen/go/state/mpt"
@@ -46,7 +47,7 @@ func info(context *cli.Context) error {
 
 	// attempt to open the MPT
 	if mptInfo.Mode == mpt.Mutable {
-		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.Config)
+		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.Config, mpt.DefaultMptStateCapacity)
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil
@@ -68,7 +69,7 @@ func info(context *cli.Context) error {
 			return fmt.Errorf("error closing forest: %v", err)
 		}
 	} else {
-		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config)
+		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config, mpt.DefaultMptStateCapacity)
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil

--- a/go/state/mpt/verification_test.go
+++ b/go/state/mpt/verification_test.go
@@ -416,7 +416,8 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 	v1[len(v1)-1] = 1
 
 	dir := t.TempDir()
-	forest, err := OpenFileForest(dir, S5LiveConfig, Mutable)
+	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: 1024}
+	forest, err := OpenFileForest(dir, S5LiveConfig, forestConfig)
 	if err != nil {
 		t.Fatalf("failed to start empty forest: %v", err)
 	}
@@ -507,7 +508,8 @@ func modifyNode[N any](t *testing.T, directory string, encoder stock.ValueEncode
 
 func fillTestForest(dir string, config MptConfig) (roots []Root, err error) {
 	const N = 100
-	forest, err := OpenFileForest(dir, config, Immutable)
+	forestConfig := ForestConfig{Mode: Immutable, CacheCapacity: 1024}
+	forest, err := OpenFileForest(dir, config, forestConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/mpt/visitor_test.go
+++ b/go/state/mpt/visitor_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
-	trie, err := OpenInMemoryLiveTrie(t.TempDir(), S4LiveConfig)
+	trie, err := OpenInMemoryLiveTrie(t.TempDir(), S4LiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
 
 func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 		t.Errorf("invalid stats for empty archive: %v", stats)
 	}
 
-	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig)
+	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
 	if err != nil {
 		t.Fatalf("failed to re-open empty archive: %v", err)
 	}

--- a/go/state/state_configs.go
+++ b/go/state/state_configs.go
@@ -930,7 +930,7 @@ func openArchive(params Parameters) (archive archive.Archive, cleanup func(), er
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig)
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, mpt.DefaultMptStateCapacity)
 		return arch, nil, err
 
 	case S5Archive:
@@ -938,7 +938,7 @@ func openArchive(params Parameters) (archive archive.Archive, cleanup func(), er
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig)
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, mpt.DefaultMptStateCapacity)
 		return arch, nil, err
 	}
 	return nil, nil, fmt.Errorf("unknown archive type: %v", params.Archive)


### PR DESCRIPTION
This PR introduces support for instantiating forests with configurable node cache sizes.

The aim is to enable test cases with smaller cache sizes to reproduce situations in which changes of a single block do not fit into the node cache. Also, it facilitates experimenting with different cache sizes and allows tests to be more memory efficient.