### PR TITLE
Fix ordering bug in node cache LRU list

### DIFF
--- a/go/state/mpt/node_cache.go
+++ b/go/state/mpt/node_cache.go
@@ -216,10 +216,10 @@ func (c *nodeCache) Touch(r *NodeReference) {
 	}
 	if c.tail == pos {
 		c.tail = target.prev
+	} else {
+		c.owners[target.next].prev = target.prev
 	}
-
 	c.owners[target.prev].next = target.next
-	c.owners[target.next].prev = target.prev
 
 	c.owners[c.head].prev = pos
 	target.next = c.head


### PR DESCRIPTION
This PR fixes a bug in the NodeCache implementation causing the LRU list causing shifts where the last element is moved to the front to be faulty.