### PR TITLE
Simplify node touches in forest

### DIFF
--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -204,7 +204,6 @@ type NodeSource interface {
 	getConfig() MptConfig
 	getReadAccess(*NodeReference) (shared.ReadHandle[Node], error)
 	getViewAccess(*NodeReference) (shared.ViewHandle[Node], error)
-	touch(*NodeReference)
 	getHashFor(*NodeReference) (common.Hash, error)
 	hashKey(common.Key) common.Hash
 	hashAddress(address common.Address) common.Hash
@@ -400,7 +399,6 @@ func (n *BranchNode) setNextNode(
 	path []Nibble,
 	createSubTree func(*NodeReference, shared.WriteHandle[Node], []Nibble) (NodeReference, bool, error),
 ) (NodeReference, bool, error) {
-	manager.touch(thisRef)
 	// Forward call to child node.
 	child := &n.children[path[0]]
 	node, err := manager.getWriteAccess(child)
@@ -817,7 +815,6 @@ func (n *ExtensionNode) setNextNode(
 	valueIsEmpty bool,
 	createSubTree func(*NodeReference, shared.WriteHandle[Node], []Nibble) (NodeReference, bool, error),
 ) (NodeReference, bool, error) {
-	manager.touch(thisRef)
 	// Check whether the updates targets the node referenced by this extension.
 	if n.path.IsPrefixOf(path) {
 		handle, err := manager.getWriteAccess(&n.next)
@@ -1203,7 +1200,6 @@ func (n *AccountNode) GetSlot(source NodeSource, address common.Address, path []
 }
 
 func (n *AccountNode) SetAccount(manager NodeManager, thisRef *NodeReference, this shared.WriteHandle[Node], address common.Address, path []Nibble, info AccountInfo) (NodeReference, bool, error) {
-	manager.touch(thisRef)
 	// Check whether this is the correct account.
 	if n.address == address {
 		if info == n.info {
@@ -1628,7 +1624,6 @@ func (n *ValueNode) SetAccount(NodeManager, *NodeReference, shared.WriteHandle[N
 }
 
 func (n *ValueNode) SetValue(manager NodeManager, thisRef *NodeReference, this shared.WriteHandle[Node], key common.Key, path []Nibble, value common.Value) (NodeReference, bool, error) {
-	manager.touch(thisRef)
 	// Check whether this is the correct value node.
 	if n.key == key {
 		if value == n.value {

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -379,18 +379,6 @@ func (mr *MockNodeSourceMockRecorder) hashKey(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashKey", reflect.TypeOf((*MockNodeSource)(nil).hashKey), arg0)
 }
 
-// touch mocks base method.
-func (m *MockNodeSource) touch(arg0 *NodeReference) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "touch", arg0)
-}
-
-// touch indicates an expected call of touch.
-func (mr *MockNodeSourceMockRecorder) touch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "touch", reflect.TypeOf((*MockNodeSource)(nil).touch), arg0)
-}
-
 // MockNodeManager is a mock of NodeManager interface.
 type MockNodeManager struct {
 	ctrl     *gomock.Controller
@@ -607,18 +595,6 @@ func (m *MockNodeManager) release(arg0 NodeId) error {
 func (mr *MockNodeManagerMockRecorder) release(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "release", reflect.TypeOf((*MockNodeManager)(nil).release), arg0)
-}
-
-// touch mocks base method.
-func (m *MockNodeManager) touch(arg0 *NodeReference) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "touch", arg0)
-}
-
-// touch indicates an expected call of touch.
-func (mr *MockNodeManagerMockRecorder) touch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "touch", reflect.TypeOf((*MockNodeManager)(nil).touch), arg0)
 }
 
 // update mocks base method.

--- a/go/state/mpt/nodes_test.go
+++ b/go/state/mpt/nodes_test.go
@@ -4318,7 +4318,6 @@ func newNodeContextWithConfig(t *testing.T, ctrl *gomock.Controller, config MptC
 	}
 	res.EXPECT().getConfig().AnyTimes().Return(config)
 	res.EXPECT().getHashFor(gomock.Any()).AnyTimes().Return(common.Hash{}, nil)
-	res.EXPECT().touch(gomock.Any()).AnyTimes() // TODO: restrict usage
 
 	// The empty node is always present.
 	res.Build(Empty{})

--- a/go/state/mpt/state.go
+++ b/go/state/mpt/state.go
@@ -29,6 +29,11 @@ type MptState struct {
 	hasher    hash.Hash
 }
 
+// The capacity of an MPT's node cache must be at least as large as the maximum
+// number of nodes modified in a block. Evaluations show that most blocks
+// modify less than 2000 nodes. However, one block, presumably the one handling
+// the opera fork at ~4.5M, modifies 434.589 nodes. Thus, the cache size of a
+// MPT processing Fantom's history should be at least ~500.000 nodes.
 const DefaultMptStateCapacity = 10_000_000
 
 var emptyCodeHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})


### PR DESCRIPTION
This PR simplifies the way nodes are marked as being modified during a block. Instead of requesting node implementations to notify the NodeManager about modifications, touches are now triggered implicitly when acquiring write access to a node.