### PR TITLE
Extend root node storage format to 8 byte

### DIFF
--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -302,7 +302,7 @@ func loadRoots(filename string) ([]Root, error) {
 
 func loadRootsFrom(reader io.Reader) ([]Root, error) {
 	res := []Root{}
-	var id [4]byte
+	var id [8]byte
 	var hash common.Hash
 	for {
 		if _, err := io.ReadFull(reader, id[:]); err != nil {
@@ -316,7 +316,7 @@ func loadRootsFrom(reader io.Reader) ([]Root, error) {
 			return nil, fmt.Errorf("invalid root file format: %v", err)
 		}
 
-		id := NodeId(binary.BigEndian.Uint32(id[:]))
+		id := NodeId(binary.BigEndian.Uint64(id[:]))
 		res = append(res, Root{NewNodeReference(id), hash})
 	}
 }
@@ -339,9 +339,9 @@ func StoreRoots(filename string, roots []Root) error {
 
 func storeRootsTo(writer io.Writer, roots []Root) error {
 	// Simple file format: [<node-id><state-hash>]*
-	var buffer [4]byte
+	var buffer [8]byte
 	for _, root := range roots {
-		binary.BigEndian.PutUint32(buffer[:], uint32(root.NodeRef.Id()))
+		binary.BigEndian.PutUint64(buffer[:], uint64(root.NodeRef.Id()))
 		if _, err := writer.Write(buffer[:]); err != nil {
 			return err
 		}

--- a/go/state/mpt/node_id.go
+++ b/go/state/mpt/node_id.go
@@ -108,9 +108,9 @@ func (n NodeId) String() string {
 //                               NodeId Encoder
 // ----------------------------------------------------------------------------
 
-// NodeIdEncoder encode interal 8-byte node IDs using a fixed-length 6-byte disk
-// format ignoring the two most significant bytes which are always zero for any
-// state DB bellow ~1PB.
+// NodeIdEncoder encodes the internal 8-byte node IDs using a fixed-length
+// 6-byte disk format ignoring the two most significant bytes which are always
+// zero for any state DB bellow ~1PB.
 type NodeIdEncoder struct{}
 
 func (NodeIdEncoder) GetEncodedSize() int {
@@ -126,7 +126,6 @@ func (NodeIdEncoder) Store(dst []byte, id *NodeId) error {
 
 func (NodeIdEncoder) Load(src []byte, id *NodeId) error {
 	var buffer [8]byte
-	buffer[0] = src[0]
 	copy(buffer[2:], src)
 	*id = NodeId(binary.BigEndian.Uint64(buffer[:]))
 	return nil

--- a/go/state/mpt/node_id_test.go
+++ b/go/state/mpt/node_id_test.go
@@ -135,3 +135,18 @@ func TestNodeID_EncodingAndDecoding(t *testing.T) {
 		}
 	}
 }
+
+func TestNodeID_EncodingAndDecodingPowerOfTwos(t *testing.T) {
+	var buffer [6]byte
+	encoder := NodeIdEncoder{}
+	for i := 0; i < 6*8; i++ {
+		id := NodeId(uint64(1) << i)
+		if err := encoder.Store(buffer[:], &id); err != nil {
+			t.Fatalf("failed to encode id: %v", err)
+		}
+		restored := NodeId(12345)
+		if err := encoder.Load(buffer[:], &restored); err != nil || restored != id {
+			t.Fatalf("failed to decode id %v: got %v, err %v", id, restored, err)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes the encoding of root nodes used by the MPT archive. Before this PR only 4 bytes got encoded, while after this all 8 bytes are used.

Only using 4 bytes lead to an issue with archives using more than 2 billion branch nodes -- as it was encountered in the Sonic S5 testnet.

This is likely contributing to (and maybe the sole cause of) issue #660.