### PR TITLE
Move release of large trie structures to background worker

### DIFF
--- a/go/state/mpt/archive_trie_test.go
+++ b/go/state/mpt/archive_trie_test.go
@@ -126,14 +126,12 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to open live trie: %v", err)
 			}
-			defer live.Close()
 
 			archiveDir := t.TempDir()
 			archive, err := OpenArchiveTrie(archiveDir, config, 1024)
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
-			defer archive.Close()
 
 			addr1 := common.Address{1}
 			addr2 := common.Address{2}

--- a/go/state/mpt/forest_test.go
+++ b/go/state/mpt/forest_test.go
@@ -378,7 +378,6 @@ func TestForest_ConcurrentReadsAreRaceFree(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// Fill in some data (sequentially).
 					root := NewNodeReference(EmptyId())

--- a/go/state/mpt/node_cache_test.go
+++ b/go/state/mpt/node_cache_test.go
@@ -229,13 +229,13 @@ func getForwardLruList(c *nodeCache) ([]NodeId, error) {
 	seen := map[ownerPosition]struct{}{}
 	for cur := c.head; cur != c.tail; cur = c.owners[cur].next {
 		if _, contains := seen[cur]; contains {
-			return nil, fmt.Errorf("detected loop in LRU list after %v followed by %v", res, c.owners[cur].id)
+			return nil, fmt.Errorf("detected loop in LRU list after %v followed by %v", res, c.owners[cur].Id())
 		}
 		seen[cur] = struct{}{}
-		res = append(res, c.owners[cur].id)
+		res = append(res, c.owners[cur].Id())
 	}
 	if c.owners[c.tail].tag.Load() > 0 {
-		res = append(res, c.owners[c.tail].id)
+		res = append(res, c.owners[c.tail].Id())
 	}
 	return res, nil
 }
@@ -245,13 +245,13 @@ func getBackwardLruList(c *nodeCache) ([]NodeId, error) {
 	seen := map[ownerPosition]struct{}{}
 	for cur := c.tail; cur != c.head; cur = c.owners[cur].prev {
 		if _, contains := seen[cur]; contains {
-			return nil, fmt.Errorf("detected loop in LRU list after %v followed by %v", res, c.owners[cur].id)
+			return nil, fmt.Errorf("detected loop in LRU list after %v followed by %v", res, c.owners[cur].Id())
 		}
 		seen[cur] = struct{}{}
-		res = append(res, c.owners[cur].id)
+		res = append(res, c.owners[cur].Id())
 	}
 	if c.owners[c.head].tag.Load() > 0 {
-		res = append(res, c.owners[c.head].id)
+		res = append(res, c.owners[c.head].Id())
 	}
 	return res, nil
 }

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -597,6 +597,18 @@ func (mr *MockNodeManagerMockRecorder) release(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "release", reflect.TypeOf((*MockNodeManager)(nil).release), arg0)
 }
 
+// releaseTrieAsynchronous mocks base method.
+func (m *MockNodeManager) releaseTrieAsynchronous(arg0 NodeReference) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "releaseTrieAsynchronous", arg0)
+}
+
+// releaseTrieAsynchronous indicates an expected call of releaseTrieAsynchronous.
+func (mr *MockNodeManagerMockRecorder) releaseTrieAsynchronous(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "releaseTrieAsynchronous", reflect.TypeOf((*MockNodeManager)(nil).releaseTrieAsynchronous), arg0)
+}
+
 // update mocks base method.
 func (m *MockNodeManager) update(arg0 NodeId, arg1 shared.WriteHandle[Node]) error {
 	m.ctrl.T.Helper()

--- a/go/state/mpt/nodes_test.go
+++ b/go/state/mpt/nodes_test.go
@@ -2501,10 +2501,16 @@ func TestAccountNode_SetAccount_WithMatchingAccount_ZeroInfo(t *testing.T) {
 	info1 := AccountInfo{Nonce: common.Nonce{1}}
 	info2 := AccountInfo{}
 
-	ref, node := ctxt.Build(&Account{address: addr, info: info1})
+	ref, node := ctxt.Build(&Account{
+		address: addr,
+		info:    info1,
+		storage: &Tag{"S", &Value{}},
+	})
 	after, _ := ctxt.Build(Empty{})
 
+	id, _ := ctxt.Get("S")
 	ctxt.EXPECT().release(ref.Id()).Return(nil)
+	ctxt.EXPECT().releaseTrieAsynchronous(RefTo(id.Id()))
 
 	handle := node.GetWriteHandle()
 	if newRoot, changed, err := handle.Get().SetAccount(ctxt, &ref, handle, addr, path[:], info2); !newRoot.Id().IsEmpty() || !changed || err != nil {
@@ -3321,7 +3327,7 @@ func TestAccountNode_ClearStorage(t *testing.T) {
 	})
 
 	storage, _ := ctxt.Get("A")
-	ctxt.EXPECT().release(storage.Id())
+	ctxt.EXPECT().releaseTrieAsynchronous(RefTo(storage.Id()))
 
 	handle := node.GetWriteHandle()
 	path := keyToNibbles(key)


### PR DESCRIPTION
This PR delegates the release of storage tries for Accounts into a background thread. By doing so, the deletion of large accounts is not stalling block processing unless more than 2^16 accounts are deleted at the same time.

During the implementation a race condition in the Node cache was discovered. This is a known property of the employed seq-lock mechanism. However, to avoid raising alarms, additional atomic loads and stores have been added for the relevant parts.

Fixes #663 