### PR TITLE
Track dirty state in nodes

### DIFF
--- a/go/state/mpt/hasher.go
+++ b/go/state/mpt/hasher.go
@@ -105,7 +105,6 @@ func (h directHasher) updateHashesInternal(
 		return hash, err
 	}
 	handle.Get().SetHash(hash)
-	manager.updateHash(ref.Id(), handle)
 	return hash, nil
 }
 
@@ -395,7 +394,6 @@ func (h ethHasher) updateHashesInternal(
 			}
 
 			node.SetHash(hash)
-			manager.updateHash(cur.node.Id(), cur.handle)
 
 			if hashCollector != nil {
 				hashCollector.Add(cur.path, hash)

--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -71,9 +71,6 @@ func TestHasher_ExtensionNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 				nextHashDirty: true,
 			})
 
-			// The node is updated while being hashed.
-			ctxt.EXPECT().updateHash(ref.Id(), gomock.Any())
-
 			hasher := algorithm.createHasher()
 			_, _, err := hasher.updateHashes(&ref, ctxt)
 			if err != nil {
@@ -104,8 +101,8 @@ func TestHasher_BranchNode_GetHash_DirtyHashesAreIgnored(t *testing.T) {
 					0x7: &Account{},
 					0xd: &Account{},
 				},
-				hashDirty: true,
-				dirty:     []int{0x7, 0xd},
+				dirtyHash:        true,
+				dirtyChildHashes: []int{0x7, 0xd},
 			})
 
 			hasher := algorithm.createHasher()
@@ -138,12 +135,10 @@ func TestHasher_BranchNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 					0x7: &Account{},
 					0xd: &Account{},
 				},
-				hashDirty: true,
-				dirty:     []int{0x7, 0xd},
+				dirtyHash:        true,
+				dirtyChildHashes: []int{0x7, 0xd},
 			})
 
-			// The node is updated while being hashed.
-			ctxt.EXPECT().updateHash(ref.Id(), gomock.Any())
 			ctxt.EXPECT().hashAddress(gomock.Any()).MaxTimes(2)
 
 			hasher := algorithm.createHasher()
@@ -176,14 +171,9 @@ func TestHasher_BranchNode_UpdateHash_DirtyFlagsForEmptyChildrenAreClearedButNoU
 					0x7: &Account{},
 					0xd: &Account{},
 				},
-				hashDirty: true,
-				dirty:     []int{1, 2, 3}, // < all empty children
+				dirtyHash:        true,
+				dirtyChildHashes: []int{1, 2, 3}, // < all empty children
 			})
-
-			// Only the branch node is signaled to be updated.
-			hashHandle, _ := ctxt.getHashAccess(&ref)
-			ctxt.EXPECT().updateHash(ref.Id(), hashHandle)
-			hashHandle.Release()
 
 			hasher := algorithm.createHasher()
 			_, _, err := hasher.updateHashes(&ref, ctxt)
@@ -211,7 +201,7 @@ func TestHasher_AccountNode_GetHash_DirtyHashesAreIgnored(t *testing.T) {
 			ctxt := newNodeContext(t, ctrl)
 
 			ref, node := ctxt.Build(&Account{
-				hashDirty:        true,
+				dirtyHash:        true,
 				storageHashDirty: true,
 			})
 
@@ -243,12 +233,10 @@ func TestHasher_AccountNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			ctxt := newNodeContext(t, ctrl)
 
 			ref, node := ctxt.Build(&Account{
-				hashDirty:        true,
+				dirtyHash:        true,
 				storageHashDirty: true,
 			})
 
-			// The node is updated while being hashed.
-			ctxt.EXPECT().updateHash(ref.Id(), gomock.Any())
 			ctxt.EXPECT().hashAddress(gomock.Any()).MaxTimes(1)
 
 			hasher := algorithm.createHasher()

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -154,6 +154,20 @@ func (mr *MockNodeMockRecorder) GetValue(source, key, path interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockNode)(nil).GetValue), source, key, path)
 }
 
+// IsDirty mocks base method.
+func (m *MockNode) IsDirty() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDirty")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDirty indicates an expected call of IsDirty.
+func (mr *MockNodeMockRecorder) IsDirty() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockNode)(nil).IsDirty))
+}
+
 // IsFrozen mocks base method.
 func (m *MockNode) IsFrozen() bool {
 	m.ctrl.T.Helper()
@@ -166,6 +180,18 @@ func (m *MockNode) IsFrozen() bool {
 func (mr *MockNodeMockRecorder) IsFrozen() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFrozen", reflect.TypeOf((*MockNode)(nil).IsFrozen))
+}
+
+// MarkClean mocks base method.
+func (m *MockNode) MarkClean() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkClean")
+}
+
+// MarkClean indicates an expected call of MarkClean.
+func (mr *MockNodeMockRecorder) MarkClean() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkClean", reflect.TypeOf((*MockNode)(nil).MarkClean))
 }
 
 // MarkFrozen mocks base method.
@@ -609,34 +635,6 @@ func (mr *MockNodeManagerMockRecorder) releaseTrieAsynchronous(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "releaseTrieAsynchronous", reflect.TypeOf((*MockNodeManager)(nil).releaseTrieAsynchronous), arg0)
 }
 
-// update mocks base method.
-func (m *MockNodeManager) update(arg0 NodeId, arg1 shared.WriteHandle[Node]) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "update", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// update indicates an expected call of update.
-func (mr *MockNodeManagerMockRecorder) update(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "update", reflect.TypeOf((*MockNodeManager)(nil).update), arg0, arg1)
-}
-
-// updateHash mocks base method.
-func (m *MockNodeManager) updateHash(arg0 NodeId, arg1 shared.HashHandle[Node]) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "updateHash", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// updateHash indicates an expected call of updateHash.
-func (mr *MockNodeManagerMockRecorder) updateHash(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateHash", reflect.TypeOf((*MockNodeManager)(nil).updateHash), arg0, arg1)
-}
-
 // MockleafNode is a mock of leafNode interface.
 type MockleafNode struct {
 	ctrl     *gomock.Controller
@@ -779,6 +777,20 @@ func (mr *MockleafNodeMockRecorder) GetValue(source, key, path interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockleafNode)(nil).GetValue), source, key, path)
 }
 
+// IsDirty mocks base method.
+func (m *MockleafNode) IsDirty() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDirty")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDirty indicates an expected call of IsDirty.
+func (mr *MockleafNodeMockRecorder) IsDirty() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockleafNode)(nil).IsDirty))
+}
+
 // IsFrozen mocks base method.
 func (m *MockleafNode) IsFrozen() bool {
 	m.ctrl.T.Helper()
@@ -791,6 +803,18 @@ func (m *MockleafNode) IsFrozen() bool {
 func (mr *MockleafNodeMockRecorder) IsFrozen() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFrozen", reflect.TypeOf((*MockleafNode)(nil).IsFrozen))
+}
+
+// MarkClean mocks base method.
+func (m *MockleafNode) MarkClean() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkClean")
+}
+
+// MarkClean indicates an expected call of MarkClean.
+func (mr *MockleafNodeMockRecorder) MarkClean() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkClean", reflect.TypeOf((*MockleafNode)(nil).MarkClean))
 }
 
 // MarkFrozen mocks base method.

--- a/go/state/mpt/write_buffer.go
+++ b/go/state/mpt/write_buffer.go
@@ -191,10 +191,14 @@ func (b *writeBuffer) emptyBuffer() {
 
 		// Write a snapshot of the node to the disk.
 		handle := node.GetViewHandle()
-		if err := b.sink.Write(id, handle); err != nil {
-			b.errsMutex.Lock()
-			b.errs = append(b.errs, err)
-			b.errsMutex.Unlock()
+		if handle.Get().IsDirty() {
+			if err := b.sink.Write(id, handle); err != nil {
+				b.errsMutex.Lock()
+				b.errs = append(b.errs, err)
+				b.errsMutex.Unlock()
+			} else {
+				handle.Get().MarkClean()
+			}
 		}
 
 		b.bufferMutex.Lock()


### PR DESCRIPTION
This PR moves the management of dirty nodes from an explicit map in the forest to individual flags in nodes.

Fixes #688 

The change shows a ~12% improvement in insertion benchmarks:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/9cad5c48-f70d-490f-af2b-6b46cf2d6f78)


TODO:
- [x] fix node tests
- [x] extend test coverage of new code sections
- [x] benchmark performance impact
- [x] smoke test on mainnet data (passed up to block 10M)