### PR TITLE
Kjezek/add archive verification pipeline

### DIFF
--- a/go/state/mpt/tool/Jenkinsfile
+++ b/go/state/mpt/tool/Jenkinsfile
@@ -83,7 +83,9 @@ pipeline {
 
         stage('Continue Synchronise Blocks') {
             steps {
+                // continue with liveDB only as the Import/Export tool does not cover Archive
                 sh "cp ${params.tmpDb}/state_db_carmen_go-file_${params.firstBlockHeight}/statedb_info.json ${params.tmpDb}/state_db_carmen_go-file_${params.firstBlockHeight}-recov/"
+                sh "sed -i -r 's/\"archiveMode\": true,/\"archiveMode\": false,/' ${params.tmpDb}/state_db_carmen_go-file_${params.firstBlockHeight}-recov/statedb_info.json"
                 script {nextBlock=params.firstBlockHeight.toInteger()+1}
                 sh "build/aida-vm-sdb substate --aida-db ${params.aidaDb} --db-tmp ${params.tmpDb} --db-src ${params.tmpDb}/state_db_carmen_go-file_${params.firstBlockHeight}-recov/ --vm-impl=lfvm --db-impl carmen --db-variant go-file --carmen-schema 5 --keep-db --validate-state-hash ${nextBlock} ${params.secondBlockHeight}"
             }


### PR DESCRIPTION
This PR extends the Pipeline for the toolchain verification. 
* It switches the synchronisation from LiveDB to ArchiveDB
* Adds verification of the Archive DB (as a complement to already existing LiveDB verification)
* Continues next already existing steps as LiveDB only as import/export tool does not support the Archive DB 