### PR TITLE
propagates tree root when re-created an account in an archive db

### DIFF
--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -340,15 +340,15 @@ func (s *Forest) SetValue(rootRef *NodeReference, addr common.Address, key commo
 	return newRoot, nil
 }
 
-func (s *Forest) ClearStorage(rootRef *NodeReference, addr common.Address) error {
+func (s *Forest) ClearStorage(rootRef *NodeReference, addr common.Address) (NodeReference, error) {
 	root, err := s.getWriteAccess(rootRef)
 	if err != nil {
-		return err
+		return NodeReference{}, err
 	}
 	defer root.Release()
 	path := AddressToNibblePath(addr, s)
-	_, _, err = root.Get().ClearStorage(s, rootRef, root, addr, path[:])
-	return err
+	newRoot, _, err := root.Get().ClearStorage(s, rootRef, root, addr, path[:])
+	return newRoot, err
 }
 
 func (s *Forest) VisitTrie(rootRef *NodeReference, visitor NodeVisitor) error {

--- a/go/state/mpt/live_trie.go
+++ b/go/state/mpt/live_trie.go
@@ -118,7 +118,12 @@ func (s *LiveTrie) SetValue(addr common.Address, key common.Key, value common.Va
 }
 
 func (s *LiveTrie) ClearStorage(addr common.Address) error {
-	return s.forest.ClearStorage(&s.root, addr)
+	newRoot, err := s.forest.ClearStorage(&s.root, addr)
+	if err != nil {
+		return err
+	}
+	s.root = newRoot
+	return nil
 }
 
 func (s *LiveTrie) UpdateHashes() (common.Hash, *NodeHashes, error) {


### PR DESCRIPTION
This PR fixes propagation of tree root when an account is cleared. 

 Re-creation of an account in the archive DB did not update the root and for this reason the head of the archive still pointed at previous version. 

It fixes issue #710, while it could have other not yet discovered consequences, as the whole archive db head was pointing at a wrong tree after clearing of an account storage