### PR TITLE
Revert "Fix access permissions when flushing nodes"

### DIFF
--- a/go/state/mpt/shared/shared.go
+++ b/go/state/mpt/shared/shared.go
@@ -264,24 +264,6 @@ func (h *WriteHandle[T]) Set(value T) {
 	h.shared.value = value
 }
 
-// AsReadHandle obtains a view on this write handle proving read access to the
-// shared value. Write access is preserved and must still be released. The
-// resulting read access handle must not be released.
-// TODO: split access permission proofs and handles
-// See https://github.com/Fantom-foundation/Carmen/issues/719
-func (h *WriteHandle[T]) AsReadHandle() ReadHandle[T] {
-	return ReadHandle[T]{h.handle}
-}
-
-// AsViewHandle obtains a view on this write handle proving view access to the
-// shared value. Write access is preserved and must still be released. The
-// resulting view access handle must not be released.
-// TODO: split access permission proofs and handles
-// See https://github.com/Fantom-foundation/Carmen/issues/719
-func (h *WriteHandle[T]) AsViewHandle() ViewHandle[T] {
-	return ViewHandle[T]{h.handle}
-}
-
 // Release abandons the access permission on the underlying shared object, allowing
 // other operations to gain access. It must be called eventually on all valid
 // instances to avoid dead-lock situations. After the handle has been released,

--- a/go/state/mpt/write_buffer.go
+++ b/go/state/mpt/write_buffer.go
@@ -190,9 +190,9 @@ func (b *writeBuffer) emptyBuffer() {
 		}
 
 		// Write a snapshot of the node to the disk.
-		handle := node.GetWriteHandle() // write access is needed to clear the dirty flag.
+		handle := node.GetViewHandle()
 		if handle.Get().IsDirty() {
-			if err := b.sink.Write(id, handle.AsViewHandle()); err != nil {
+			if err := b.sink.Write(id, handle); err != nil {
 				b.errsMutex.Lock()
 				b.errs = append(b.errs, err)
 				b.errsMutex.Unlock()


### PR DESCRIPTION
Reverts Fantom-foundation/Carmen#718 since it introduces a potential deadlock (see [CI test run](https://github.com/Fantom-foundation/Carmen/actions/runs/7473023244/job/20336367454)).

This PR is part of #724 