### PR TITLE
Fix access permissions when flushing nodes

### DIFF
--- a/go/state/mpt/shared/shared.go
+++ b/go/state/mpt/shared/shared.go
@@ -264,6 +264,24 @@ func (h *WriteHandle[T]) Set(value T) {
 	h.shared.value = value
 }
 
+// AsReadHandle obtains a view on this write handle proving read access to the
+// shared value. Write access is preserved and must still be released. The
+// resulting read access handle must not be released.
+// TODO: split access permission proofs and handles
+// See https://github.com/Fantom-foundation/Carmen/issues/719
+func (h *WriteHandle[T]) AsReadHandle() ReadHandle[T] {
+	return ReadHandle[T]{h.handle}
+}
+
+// AsViewHandle obtains a view on this write handle proving view access to the
+// shared value. Write access is preserved and must still be released. The
+// resulting view access handle must not be released.
+// TODO: split access permission proofs and handles
+// See https://github.com/Fantom-foundation/Carmen/issues/719
+func (h *WriteHandle[T]) AsViewHandle() ViewHandle[T] {
+	return ViewHandle[T]{h.handle}
+}
+
 // Release abandons the access permission on the underlying shared object, allowing
 // other operations to gain access. It must be called eventually on all valid
 // instances to avoid dead-lock situations. After the handle has been released,

--- a/go/state/mpt/write_buffer.go
+++ b/go/state/mpt/write_buffer.go
@@ -193,9 +193,9 @@ func (b *writeBuffer) emptyBuffer() {
 		}
 
 		// Write a snapshot of the node to the disk.
-		handle := node.GetViewHandle()
+		handle := node.GetWriteHandle() // write access is needed to clear the dirty flag.
 		if handle.Get().IsDirty() {
-			if err := b.sink.Write(id, handle); err != nil {
+			if err := b.sink.Write(id, handle.AsViewHandle()); err != nil {
 				b.errsMutex.Lock()
 				b.errs = append(b.errs, err)
 				b.errsMutex.Unlock()


### PR DESCRIPTION
When flushing nodes the dirty flag is reset. This requires write access to the node. So far, only view access was acquired, leading to a data race.

This fixes #717 and re-does #718, undoing #720.

This also introduced the need for an improvement in the shared value package: #719 