### PR TITLE
Make output targets for node dumps a parameter

### DIFF
--- a/go/state/mpt/forest.go
+++ b/go/state/mpt/forest.go
@@ -517,7 +517,7 @@ func (s *Forest) Dump(rootRef *NodeReference) {
 		return
 	}
 	defer root.Release()
-	root.Get().Dump(s, rootRef, "")
+	root.Get().Dump(os.Stdout, s, rootRef, "")
 }
 
 // Check verifies internal invariants of the Trie instance. If the trie is

--- a/go/state/mpt/nodes_mocks.go
+++ b/go/state/mpt/nodes_mocks.go
@@ -5,6 +5,7 @@
 package mpt
 
 import (
+	io "io"
 	reflect "reflect"
 
 	common "github.com/Fantom-foundation/Carmen/go/common"
@@ -66,15 +67,15 @@ func (mr *MockNodeMockRecorder) ClearStorage(manager, thisRef, this, address, pa
 }
 
 // Dump mocks base method.
-func (m *MockNode) Dump(source NodeSource, thisRef *NodeReference, indent string) {
+func (m *MockNode) Dump(dest io.Writer, source NodeSource, thisRef *NodeReference, indent string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Dump", source, thisRef, indent)
+	m.ctrl.Call(m, "Dump", dest, source, thisRef, indent)
 }
 
 // Dump indicates an expected call of Dump.
-func (mr *MockNodeMockRecorder) Dump(source, thisRef, indent interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) Dump(dest, source, thisRef, indent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dump", reflect.TypeOf((*MockNode)(nil).Dump), source, thisRef, indent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dump", reflect.TypeOf((*MockNode)(nil).Dump), dest, source, thisRef, indent)
 }
 
 // Freeze mocks base method.
@@ -689,15 +690,15 @@ func (mr *MockleafNodeMockRecorder) ClearStorage(manager, thisRef, this, address
 }
 
 // Dump mocks base method.
-func (m *MockleafNode) Dump(source NodeSource, thisRef *NodeReference, indent string) {
+func (m *MockleafNode) Dump(dest io.Writer, source NodeSource, thisRef *NodeReference, indent string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Dump", source, thisRef, indent)
+	m.ctrl.Call(m, "Dump", dest, source, thisRef, indent)
 }
 
 // Dump indicates an expected call of Dump.
-func (mr *MockleafNodeMockRecorder) Dump(source, thisRef, indent interface{}) *gomock.Call {
+func (mr *MockleafNodeMockRecorder) Dump(dest, source, thisRef, indent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dump", reflect.TypeOf((*MockleafNode)(nil).Dump), source, thisRef, indent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dump", reflect.TypeOf((*MockleafNode)(nil).Dump), dest, source, thisRef, indent)
 }
 
 // Freeze mocks base method.


### PR DESCRIPTION
This PR makes the output target for node dump operations a parameter with the following effects:
- the dump operation becomes testable (although not covered in this PR)
- running tests for dump operations does not produce unintended console output