### PR TITLE
extends cache size for fuzzing tests

### DIFF
--- a/go/state/mpt/archive_trie_fuzzing_test.go
+++ b/go/state/mpt/archive_trie_fuzzing_test.go
@@ -951,7 +951,7 @@ func (c *archiveTrieAccountFuzzingCampaign[T, C]) Init() []fuzzing.OperationSequ
 // the created context.
 func (c *archiveTrieAccountFuzzingCampaign[T, C]) CreateContext(t fuzzing.TestingT) *C {
 	path := t.TempDir()
-	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, 10_000)
+	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, 100_000)
 	if err != nil {
 		t.Fatalf("failed to open archive trie: %v", err)
 	}


### PR DESCRIPTION
this PR extends the size of the node cache for fuzzing tests. Previous cache size caused failures for some fuzzing runs.  