### PR TITLE
Add test coverage for tracking path lengths

### DIFF
--- a/go/state/mpt/nodes.go
+++ b/go/state/mpt/nodes.go
@@ -1485,7 +1485,7 @@ func (n *AccountNode) SetAccount(manager NodeManager, thisRef *NodeReference, th
 
 	thisPath := AddressToNibblePath(n.address, manager)
 	newRoot, err := splitLeafNode(manager, thisRef, thisPath[:], n, this, path, &siblingRef, sibling, handle)
-	return newRoot, false, err
+	return newRoot, !n.frozen && manager.getConfig().TrackSuffixLengthsInLeafNodes, err
 }
 
 type leafNode interface {


### PR DESCRIPTION
This PR adds coverage for testing node operations when the tracking of path lengths is enabled.