### PR TITLE
Kjezek/check trie after fuzzing done

### DIFF
--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -136,7 +136,11 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 	var err error
 	var hash common.Hash
 	if precomputedHashes == nil {
-		hash, _, err = a.head.trie.UpdateHashes()
+		var hashes *NodeHashes
+		hash, hashes, err = a.head.trie.UpdateHashes()
+		if err == nil {
+			hashes.Release()
+		}
 	} else {
 		err = a.head.trie.setHashes(precomputedHashes)
 		if err == nil {


### PR DESCRIPTION
This PR extends fuzzing of archive trie. It verifies the whole history of the trie generated by each fuzzing campaign. It matches the history of the tested Trie against the shadow blockchain. 
Since this verification started to exceed 1s limit of the fuzzer loop, three modifications were enabled:
1. conversions from `tinyAddress` to `common.Address` and `tinyKey` to `common.Key `are cashed
2. generated random operations are filtered out not to contain duplicities in immediately followed sequences
3.  the number of operations is caped to 10k (empirically measured value) 