### PR TITLE
Fix a data race in the nodes' error forwarding test

### DIFF
--- a/go/state/mpt/nodes_test.go
+++ b/go/state/mpt/nodes_test.go
@@ -7172,15 +7172,16 @@ func testActions_AllErrorsAreForwarded(t *testing.T, frozen bool) {
 
 func testActions_AllErrorsAreForwardedInternal(t *testing.T, frozen bool, config MptConfig) {
 	for _, action := range getTestActions() {
+
+		if config.TrackSuffixLengthsInLeafNodes {
+			fixPrefixLength(action.input, 0)
+		}
+
 		action := action
 		t.Run(action.description, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			ctxt := newNiceNodeContextWithConfig(t, ctrl, config)
-
-			if config.TrackSuffixLengthsInLeafNodes {
-				fixPrefixLength(action.input, 0)
-			}
 
 			input, _ := ctxt.Build(action.input)
 			if frozen {


### PR DESCRIPTION
This PR fixes a data race in the test code recently introduced to Carmen.