### PR TITLE
dissables temporarily fuzzing of archive MPT

### DIFF
--- a/go/Jenkinsfile
+++ b/go/Jenkinsfile
@@ -106,20 +106,20 @@ pipeline {
                         sh 'cd go && go test ./state/mpt/ -fuzztime 3h -fuzz FuzzLiveTrie_RandomAccountStorageOps'
                     }
                 }                  
-                stage('Fuzzing Archive MPT - Accounts') {
-                    agent {label 'fuzzing'}
-                    steps {
-                        unstash 'source'
-                        sh 'cd go && go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountOps'
-                    }
-                }                  
-                stage('Fuzzing Archive MPT - Storage') {
-                    agent {label 'fuzzing'}
-                    steps {
-                        unstash 'source'
-                        sh 'cd go && go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountStorageOps'
-                    }
-                }                  
+//                 stage('Fuzzing Archive MPT - Accounts') {
+//                     agent {label 'fuzzing'}
+//                     steps {
+//                         unstash 'source'
+//                         sh 'cd go && go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountOps'
+//                     }
+//                 }
+//                 stage('Fuzzing Archive MPT - Storage') {
+//                     agent {label 'fuzzing'}
+//                     steps {
+//                         unstash 'source'
+//                         sh 'cd go && go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountStorageOps'
+//                     }
+//                 }
             }
         }
     }


### PR DESCRIPTION
This PR temporarily disables fuzzing of Archive MPT, because it is not passing at the moment due to a know issue: https://github.com/Fantom-foundation/Carmen/issues/734 

When the bug is fixed, this PR should be reverted.