### PR TITLE
Add protection to state directories to avoid concurrent use

### DIFF
--- a/go/state/mpt/archive_trie.go
+++ b/go/state/mpt/archive_trie.go
@@ -30,6 +30,10 @@ type ArchiveTrie struct {
 }
 
 func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*ArchiveTrie, error) {
+	lock, err := LockDirectory(directory)
+	if err != nil {
+		return nil, err
+	}
 	rootfile := directory + "/roots.dat"
 	roots, err := loadRoots(rootfile)
 	if err != nil {
@@ -45,7 +49,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 		forest.Close()
 		return nil, err
 	}
-	state, err := newMptState(directory, head)
+	state, err := newMptState(directory, lock, head)
 	if err != nil {
 		head.Close()
 		return nil, err

--- a/go/state/mpt/archive_trie_test.go
+++ b/go/state/mpt/archive_trie_test.go
@@ -36,6 +36,33 @@ func TestArchiveTrie_OpenAndClose(t *testing.T) {
 	}
 }
 
+func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
+	dir := t.TempDir()
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	if err != nil {
+		t.Fatalf("failed to open test archive: %v", err)
+	}
+	if _, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+		t.Fatalf("archive should not be accessible by more than one instance")
+	}
+	if err := archive.Close(); err != nil {
+		t.Errorf("failed to close the archive: %v", err)
+	}
+}
+
+func TestArchiveTrie_CanBeReOpened(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+		if err != nil {
+			t.Fatalf("failed to open test archive: %v", err)
+		}
+		if err := archive.Close(); err != nil {
+			t.Errorf("failed to close the archive: %v", err)
+		}
+	}
+}
+
 func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {

--- a/go/state/mpt/directory_lock.go
+++ b/go/state/mpt/directory_lock.go
@@ -1,0 +1,29 @@
+package mpt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
+
+const lockFileName = "~lock"
+
+// LockDirectory acquires a lock on the given directory. If needed,
+// the directory is implicitly created. The operation fails if the
+// lock can not be acquired due to some other thread or process holding
+// the lock or due to an IO error.
+//
+// Note: if successful, the acquired lock needs to be explicitly released.
+// The lock is not automatically released when the process is terminated.
+func LockDirectory(directory string) (common.LockFile, error) {
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
+	lock, err := common.CreateLockFile(filepath.Join(directory, lockFileName))
+	if err != nil {
+		return nil, fmt.Errorf("unable to gain exclusive access to %s: %w", directory, err)
+	}
+	return lock, nil
+}

--- a/go/state/mpt/directory_lock_test.go
+++ b/go/state/mpt/directory_lock_test.go
@@ -1,0 +1,44 @@
+package mpt
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDirectoryLock_AcquireAndRelease(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		lock, err := LockDirectory(dir)
+		if err != nil {
+			t.Fatalf("failed to acquire lock: %v", err)
+		}
+		if err := lock.Release(); err != nil {
+			t.Fatalf("failed to release lock: %v", err)
+		}
+	}
+}
+
+func TestDirectoryLock_LockIsExclusive(t *testing.T) {
+	dir := t.TempDir()
+
+	lockA, err := LockDirectory(dir)
+	if err != nil {
+		t.Fatalf("failed to lock directory: %v", err)
+	}
+
+	lockB, err := LockDirectory(dir)
+	if err == nil {
+		t.Fatalf("should not be able to acquire a second lock")
+	}
+
+	want := fmt.Sprintf("unable to gain exclusive access to %s: failed to acquire file lock: file exists", dir)
+	if got := err.Error(); want != got {
+		t.Errorf("unexpected error message, wanted '%s', got '%s'", want, got)
+	}
+
+	if lockB != nil {
+		t.Errorf("unexpected non-nil lock result in error case: %v", lockB)
+	}
+
+	lockA.Release()
+}

--- a/go/state/mpt/visitor.go
+++ b/go/state/mpt/visitor.go
@@ -46,7 +46,7 @@ func VisitForestNodes(directory string, config MptConfig, visitor NodeVisitor) e
 	if err != nil {
 		return err
 	}
-	defer source.close()
+	defer source.Close()
 	return source.forAllNodes(func(id NodeId, node Node) error {
 		visitor.Visit(node, NodeInfo{Id: id})
 		return nil


### PR DESCRIPTION
This PR introduces lock protection for state directories to facilitate the mutual exclusion data access between multiple processes.

Fixes #662 