### PR TITLE
Add unknown hash status

### DIFF
--- a/go/state/mpt/hasher_test.go
+++ b/go/state/mpt/hasher_test.go
@@ -43,7 +43,7 @@ func TestHasher_ExtensionNode_GetHash_DirtyHashesAreIgnored(t *testing.T) {
 			// The dirty flag is cleared.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if !handle.Get().(*ExtensionNode).hashDirty {
+			if handle.Get().(*ExtensionNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should not be cleared")
 			}
 			if !handle.Get().(*ExtensionNode).nextHashDirty {
@@ -80,7 +80,7 @@ func TestHasher_ExtensionNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			// The dirty flag is cleared.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if handle.Get().(*ExtensionNode).hashDirty {
+			if !handle.Get().(*ExtensionNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should be cleared")
 			}
 			if handle.Get().(*ExtensionNode).nextHashDirty {
@@ -114,7 +114,7 @@ func TestHasher_BranchNode_GetHash_DirtyHashesAreIgnored(t *testing.T) {
 			// The dirty flag is not touched.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if !handle.Get().(*BranchNode).hashDirty {
+			if handle.Get().(*BranchNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should not be cleared")
 			}
 			if handle.Get().(*BranchNode).dirtyHashes != ((1 << 0x7) | (1 << 0xd)) {
@@ -150,7 +150,7 @@ func TestHasher_BranchNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			// The dirty flag is cleared.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if handle.Get().(*BranchNode).hashDirty {
+			if !handle.Get().(*BranchNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should be cleared")
 			}
 			if handle.Get().(*BranchNode).dirtyHashes != 0 {
@@ -184,7 +184,7 @@ func TestHasher_BranchNode_UpdateHash_DirtyFlagsForEmptyChildrenAreClearedButNoU
 			// The dirty flag is cleared.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if handle.Get().(*BranchNode).hashDirty {
+			if !handle.Get().(*BranchNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should be cleared")
 			}
 			if handle.Get().(*BranchNode).dirtyHashes != 0 {
@@ -216,7 +216,7 @@ func TestHasher_AccountNode_GetHash_DirtyHashesAreIgnored(t *testing.T) {
 			// The dirty flag is not changed.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if !handle.Get().(*AccountNode).hashDirty {
+			if handle.Get().(*AccountNode).hasCleanHash() {
 				t.Errorf("dirty hash flags should not be changed")
 			}
 			if !handle.Get().(*AccountNode).storageHashDirty {
@@ -248,7 +248,7 @@ func TestHasher_AccountNode_UpdateHash_DirtyHashesAreRefreshed(t *testing.T) {
 			// The dirty flag is cleared.
 			handle := node.GetReadHandle()
 			defer handle.Release()
-			if handle.Get().(*AccountNode).hashDirty {
+			if !handle.Get().(*AccountNode).hasCleanHash() {
 				t.Errorf("dirty hash flag should be cleared")
 			}
 			if handle.Get().(*AccountNode).storageHashDirty {


### PR DESCRIPTION
This PR updates the tracking of the hash status to support three different values
- "clean" - the hash stored in the node is correct, matching the content of the node
- "dirty" - the hash is invalid, the content of the node was updated
- "unknown" - the hash is to be considered missing; the content of the node was loaded from the disk and is clean, but no hash was stored as part of the node;

This fixes #734