### PR TITLE
Update Jenkins' fuzzer script to build Carmen using make

### DIFF
--- a/go/Jenkinsfile
+++ b/go/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         
         stage('Build') {
             steps {
-                sh 'cd go && go build ./...'
+                sh 'make'
             }
         }
 


### PR DESCRIPTION
This should fix the missing library dependency for the Jenkins fuzzer tests.