### PR TITLE
Add support for configurable StateDB cache size

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -367,7 +367,7 @@ func CreateStateDBUsing(state State) StateDB {
 	return CreateCustomStateDBUsing(state, defaultStoredDataCacheSize)
 }
 
-// CreateCustomStateDBUsing is the same as CreateStateDBUsing but allows to specify
+// CreateCustomStateDBUsing is the same as CreateStateDBUsing but allows the caller to specify
 // the capacity of the stored Data cache used in the resulting instance. The default
 // cache size used by CreateCustomStateDBUsing may be too large if StateDB instances
 // only have a short live time. In such cases, the initialization and destruction of


### PR DESCRIPTION
This PR enables the configuration of the cache used inside the StateDB by the code creating the StateDB.

In some cases where StateDB instances are only used for a short period of time, the initialization and destruction of the StateDB's cache may be dominating execution time. For those cases, providing means to reduce its capacity can significantly help reducing overall processing time.

This contributes to the resolution of issue #756 