### PR TITLE
wipe out fuzzing workspace before the stage starts

### DIFF
--- a/go/Jenkinsfile
+++ b/go/Jenkinsfile
@@ -23,13 +23,6 @@ pipeline {
             }
         }
 
-        stage('Clean Workspace') {
-            steps {
-                cleanWs() 
-            }
-        }
-
-
         stage('Fuzzing') {
             parallel {
                 stage('Parallelism Test') {
@@ -49,6 +42,7 @@ pipeline {
                 stage('FastMap') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./common -fuzztime 3h -fuzz=FuzzMapOperations'
                     }
@@ -56,6 +50,7 @@ pipeline {
                 stage('Fuzzing NWays Cache') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./common/ -fuzztime 3h -fuzz FuzzLruCache_RandomOps'
                     }
@@ -63,6 +58,7 @@ pipeline {
                 stage('Fuzzing LRU Cache') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./common/ -fuzztime 3h -fuzz FuzzNWays_RandomOps'
                     }
@@ -70,6 +66,7 @@ pipeline {
                 stage('Fuzzing Buffered File') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./backend/utils -fuzztime 3h -fuzz FuzzBufferedFile_RandomOps'
                     }
@@ -77,6 +74,7 @@ pipeline {
                 stage('Fuzzing Buffered Fil - data') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./backend/utils -fuzztime 3h -fuzz FuzzBufferedFile_ReadWrite'
                     }
@@ -84,6 +82,7 @@ pipeline {
                 stage('Fuzzing Stack') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./backend/stock/file -fuzztime 3h -fuzz FuzzStack_RandomOps'
                     }
@@ -91,6 +90,7 @@ pipeline {
                 stage('Fuzzing Stock - file') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./backend/stock/file -fuzztime 3h -fuzz FuzzFileStock_RandomOps'
                     }
@@ -98,6 +98,7 @@ pipeline {
                 stage('Fuzzing Stock - synced') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./backend/stock/memory -fuzztime 3h -fuzz FuzzSyncStock_RandomOps'
                     }
@@ -105,6 +106,7 @@ pipeline {
                 stage('Fuzzing Live MPT - Accounts') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./state/mpt/ -fuzztime 3h -fuzz FuzzLiveTrie_RandomAccountOps'
                     }
@@ -112,6 +114,7 @@ pipeline {
                 stage('Fuzzing Live MPT - Storage') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./state/mpt/ -fuzztime 3h -fuzz FuzzLiveTrie_RandomAccountStorageOps'
                     }
@@ -119,6 +122,7 @@ pipeline {
                 stage('Fuzzing Archive MPT - Accounts') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountOps'
                     }
@@ -126,6 +130,7 @@ pipeline {
                 stage('Fuzzing Archive MPT - Storage') {
                     agent {label 'fuzzing'}
                     steps {
+                        deleteDir()
                         unstash 'source'
                         sh 'go test ./state/mpt/ -fuzztime 3h -fuzz FuzzArchiveTrie_RandomAccountStorageOps'
                     }


### PR DESCRIPTION
This PR deletes Jenkins workspace before each parallel stage of fuzzing.

Jenkins generally does not clean-up its workspace between job runs. It happened in the fuzzing pipeline  that some old files caused access-denied error when new files were moved (using stash/unstash) from the coordinator to fuzzing nodes.    