### PR TITLE
Fix invalid reuse of global variable in LevelDB store

### DIFF
--- a/cpp/backend/store/file/store.h
+++ b/cpp/backend/store/file/store.h
@@ -88,9 +88,8 @@ class FileStoreBase {
 
   // Retrieves the value associated to the given key. If no values has
   // been previously set using the Set(..) function above, a zero-initialized
-  // value is returned. The returned reference is only valid until the next
-  // operation on the store.
-  StatusOrRef<const V> Get(const K& key) const;
+  // value is returned.
+  absl::StatusOr<V> Get(const K& key) const;
 
   // Computes a hash over the full content of this store.
   absl::StatusOr<Hash> GetHash() const;
@@ -228,9 +227,8 @@ FileStoreBase<K, V, F, page_size, eager_hashing>::Set(const K& key, V value) {
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-    StatusOrRef<const V> FileStoreBase<K, V, F, page_size, eager_hashing>::Get(
-        const K& key)
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> absl::StatusOr<V>
+FileStoreBase<K, V, F, page_size, eager_hashing>::Get(const K& key)
 const {
   static const V kDefault{};
   auto page_id = key / kNumElementsPerPage;

--- a/cpp/backend/store/leveldb/store.h
+++ b/cpp/backend/store/leveldb/store.h
@@ -64,16 +64,15 @@ class LevelDbStore {
 
   // Retrieves the value associated to the given key. If no values has
   // been previously set using the Set(..) function above, default value
-  // is returned. The result is valid until the next call to this function.
-  StatusOrRef<const V> Get(const K& key) const {
+  // is returned.
+  absl::StatusOr<V> Get(const K& key) const {
     constexpr static const V default_value{};
-    static V result;
     auto buffer = db_->Get(AsChars(key));
     if (absl::IsNotFound(buffer.status())) {
       return default_value;
     }
     RETURN_IF_ERROR(buffer.status());
-    ASSIGN_OR_RETURN(result, FromChars<V>(*buffer));
+    ASSIGN_OR_RETURN(V result, FromChars<V>(*buffer));
     return result;
   }
 

--- a/cpp/backend/store/memory/store.h
+++ b/cpp/backend/store/memory/store.h
@@ -71,7 +71,7 @@ class InMemoryStore {
   // Retrieves the value associated to the given key. If no values has
   // been previously set using the Set(..) function above, the default
   // value defined during the construction of a store instance is returned.
-  StatusOrRef<const V> Get(const K& key) const {
+  absl::StatusOr<V> Get(const K& key) const {
     constexpr static const V default_value{};
     auto page_number = key / elements_per_page;
     if (page_number >= pages_->size()) {

--- a/cpp/backend/store/store.h
+++ b/cpp/backend/store/store.h
@@ -52,7 +52,7 @@ concept Store = requires(S a, const S b) {
   // next operation on the store.
   {
     b.Get(std::declval<typename S::key_type>())
-    } -> std::same_as<StatusOrRef<const typename S::value_type>>;
+    } -> std::same_as<absl::StatusOr<typename S::value_type>>;
 }
 // Stores must satisfy the requirements for backend data structures.
 &&HashableStructure<S>;


### PR DESCRIPTION
This PR fixes #778 by eliminating the invalid shared reuse of a static buffer in the LevelDB store implementation.