### PR TITLE
extends import to import either Archive only or both Archive and Live

### DIFF
--- a/go/state/mpt/tool/import.go
+++ b/go/state/mpt/tool/import.go
@@ -35,15 +35,29 @@ var ImportArchiveCmd = cli.Command{
 	},
 }
 
+var ImportLiveAndArchiveCmd = cli.Command{
+	Action:    doLiveAndArchiveImport,
+	Name:      "import",
+	Usage:     "imports both LiveDB and Archive instance from a file",
+	ArgsUsage: "<source-file> <target director>",
+	Flags: []cli.Flag{
+		&cpuProfileFlag,
+	},
+}
+
 func doLiveDbImport(context *cli.Context) error {
-	return doImport(context, false)
+	return doImport(context, mptIo.ImportLiveDb)
 }
 
 func doArchiveImport(context *cli.Context) error {
-	return doImport(context, true)
+	return doImport(context, mptIo.ImportArchive)
 }
 
-func doImport(context *cli.Context, isArchive bool) error {
+func doLiveAndArchiveImport(context *cli.Context) error {
+	return doImport(context, mptIo.ImportLiveAndArchive)
+}
+
+func doImport(context *cli.Context, runImport func(directory string, in io.Reader) error) error {
 	if context.Args().Len() != 2 {
 		return fmt.Errorf("missing source file and/or target directory parameter")
 	}
@@ -61,11 +75,6 @@ func doImport(context *cli.Context, isArchive bool) error {
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("error creating output directory: %v", err)
-	}
-
-	runImport := mptIo.ImportLiveDb
-	if isArchive {
-		runImport = mptIo.ImportArchive
 	}
 
 	start := time.Now()

--- a/go/state/mpt/tool/main.go
+++ b/go/state/mpt/tool/main.go
@@ -21,6 +21,7 @@ func main() {
 			&ExportCmd,
 			&ImportLiveDbCmd,
 			&ImportArchiveCmd,
+			&ImportLiveAndArchiveCmd,
 			&Info,
 			&InitArchive,
 			&Verify,


### PR DESCRIPTION
This PR extends import to import either Archive only or both Archive and Live

This feature was enabled by adding one more command called `Import`,
which imports both databases, while the original one `Import-Archive` is unchanged.

This should hopefully make clear that `Import-Archive` import archive only, which was confusing in the past. 