### PR TITLE
exposes Log only as a public api

### DIFF
--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -373,4 +373,16 @@ type Value common.Value
 type Hash common.Hash
 
 // Log summarizes a log message recorded during the execution of a contract.
-type Log common.Log
+type Log struct {
+	// -- payload --
+	// Address of the contract that generated the event.
+	Address Address
+	// List of topics the log message should be tagged by.
+	Topics []Hash
+	// The actual log message.
+	Data []byte
+
+	// -- metadata --
+	// Index of the log in the block.
+	Index uint
+}

--- a/go/carmen/transaction.go
+++ b/go/carmen/transaction.go
@@ -2,10 +2,9 @@ package carmen
 
 import (
 	"fmt"
-	"math/big"
-
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/state"
+	"math/big"
 )
 
 type transactionContext struct {
@@ -146,17 +145,36 @@ func (t *transactionContext) GetRefund() uint64 {
 }
 
 func (t *transactionContext) AddLog(log *Log) {
-	if t.state != nil {
-		t.state.AddLog((*common.Log)(log))
+	if t.state != nil && log != nil {
+		topics := make([]common.Hash, 0, len(log.Topics))
+		for _, topic := range log.Topics {
+			topics = append(topics, common.Hash(topic))
+		}
+		t.state.AddLog(&common.Log{
+			Address: common.Address(log.Address),
+			Topics:  topics,
+			Data:    log.Data,
+			Index:   log.Index,
+		})
 	}
 }
 
 func (t *transactionContext) GetLogs() []*Log {
 	if t.state != nil {
 		logs := t.state.GetLogs()
-		res := make([]*Log, len(logs))
-		for i := 0; i < len(logs); i++ {
-			res[i] = (*Log)(logs[i])
+		res := make([]*Log, 0, len(logs))
+		for _, log := range logs {
+			topics := make([]Hash, 0, len(log.Topics))
+			for _, topic := range log.Topics {
+				topics = append(topics, Hash(topic))
+			}
+
+			res = append(res, &Log{
+				Address: Address(log.Address),
+				Topics:  topics,
+				Data:    log.Data,
+				Index:   log.Index,
+			})
 		}
 		return res
 	}

--- a/go/carmen/transaction_test.go
+++ b/go/carmen/transaction_test.go
@@ -172,6 +172,7 @@ func TestTransaction_Operations_Passthrough(t *testing.T) {
 	tx.SubRefund(100)
 	tx.GetRefund()
 	tx.AddLog(nil)
+	tx.AddLog(&Log{})
 	tx.GetLogs()
 	tx.ClearAccessList()
 	tx.AddAddressToAccessList(address)


### PR DESCRIPTION
This PR wraps `common.Log` into `carmen Log` to expose the log only as a public carmen API. 

This fixes #795 