### PR TITLE
Add query interface support for historic states

### DIFF
--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -73,7 +73,16 @@ type Database interface {
 
 	// GetHistoricStateHash returns state root hash for the input block number.
 	// This value is available only when the archive is enabled.
+	// Deprecated: use QueryHistoricState
 	GetHistoricStateHash(block uint64) (Hash, error)
+
+	// QueryHistoricState provides read-only query access to a historic
+	// state in the block chain in the range [0 .. GetArchiveBlockHeight()].
+	// All operations within the query are guaranteed to be based on a
+	// consistent block state. Multiple queries may be conducted concurrently.
+	// If this call produces an error, the data retrieved in the query should
+	// be considered invalid.
+	QueryHistoricState(block uint64, query func(QueryContext)) error
 
 	// GetHistoricContext returns a block context, which accesses
 	// the world state history as it was for the input block number.

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -221,6 +221,7 @@ func TestDatabase_GetHistoricStateHash_UnderlyingDB_FailsGettingHash(t *testing.
 	injectedErr := fmt.Errorf("injectedErr")
 	subSt := state.NewMockState(ctrl)
 	subSt.EXPECT().GetHash().Return(common.Hash{}, injectedErr)
+	subSt.EXPECT().Check().Times(2).Return(nil)
 
 	st.EXPECT().GetArchiveState(gomock.Any()).Return(subSt, nil)
 

--- a/go/carmen/transaction.go
+++ b/go/carmen/transaction.go
@@ -2,9 +2,10 @@ package carmen
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/state"
-	"math/big"
 )
 
 type transactionContext struct {
@@ -224,6 +225,10 @@ func (t *transactionContext) RevertToSnapshot(snapshot int) {
 	if t.state != nil {
 		t.state.RevertToSnapshot(snapshot)
 	}
+}
+
+func (t *transactionContext) GetStateHash() Hash {
+	return Hash(t.state.GetHash())
 }
 
 func (t *transactionContext) Commit() error {


### PR DESCRIPTION
This PR adds the same light-weight Query support for historic states to the Carmen facade as has been introduced by #805 for the head state.

The implementation, though, is much simpler since it can be mapped to preexisting query infrastructure.