### PR TITLE
Add live trie test for large number of nodes

### DIFF
--- a/go/common/mem_utils.go
+++ b/go/common/mem_utils.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// MemUsageClb is a callback function that will be called with the current memory stats
+type MemUsageClb func(*runtime.MemStats)
+
+// GetMemUsage returns the memory usage statistics.
+// If runGc is true, it will run the garbage collector before getting the stats.
+// This will return the memory usage at the time of the call.
+func GetMemUsage(runGc bool) runtime.MemStats {
+	if runGc {
+		runtime.GC()
+	}
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m
+}
+
+// SampleMemUsageForCall samples the memory usage statistics while the function is running.
+// It will call the callback function with the memory stats at the specified interval in seconds.
+func SampleMemUsageForCall(interval float32, runGc bool, f func(), clb MemUsageClb) {
+	// start go-routine that will sample memory usage
+	// while the function is running
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(time.Duration(interval) * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				m := GetMemUsage(runGc)
+				clb(&m)
+			}
+		}
+	}()
+	// run the function
+	f()
+	// stop the go-routine
+	close(done)
+}
+
+// SampleAndPrintMemUsageForCall samples the memory usage statistics while the function is running.
+func SampleAndPrintMemUsageForCall(interval float32, runGc bool, f func()) {
+	SampleMemUsageForCall(interval, runGc, f, printMemUsage)
+}
+
+// PrintMemUsage outputs the current, total and OS memory being used. As well as the number of garage collection cycles completed.
+// It will output the memory usage in the time of the call.
+func PrintMemUsage(runGc bool) {
+	m := GetMemUsage(runGc)
+	printMemUsage(&m)
+}
+
+func printMemUsage(stats *runtime.MemStats) {
+	sb := strings.Builder{}
+	sb.WriteString("Alloc = ")
+	memoryAmountToString(&sb, uintptr(stats.Alloc))
+	sb.WriteString("\tTotalAlloc = ")
+	memoryAmountToString(&sb, uintptr(stats.TotalAlloc))
+	sb.WriteString("\tSys = ")
+	memoryAmountToString(&sb, uintptr(stats.Sys))
+	sb.WriteString(fmt.Sprintf("\tNumGC = %v", stats.NumGC))
+	fmt.Println(sb.String())
+}


### PR DESCRIPTION
This PR adds test for inserting large number of nodes to observe write buffer behavior.

The trie's node cache is set to 1 milion. As the cache becomes full, evicted nodes are being passed into write buffer cache. The default write buffer's cache size is 1024. As this cache also starts being full, an asynchronous go-routine starts flushing the buffer into file.

Observation: The write buffer emptying process throttles, thus the cache size is increasing, because new entities are added faster than old ones being cleared. 

To reproduce: Debug the test and observe buffer's size in [emptyBuffer](https://github.com/Fantom-foundation/Carmen/blob/b294c6e5666dca8c95597fa61ae465b24db81f3a/go/database/mpt/write_buffer.go#L171) method 