### PR TITLE
Increase limit on level of parallelism in CI testing

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -17,7 +17,7 @@ jobs:
     name: Formatting Check
     runs-on: [self-hosted, Linux, X64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: get current path
         run: pwd && ls
 

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -21,11 +21,11 @@ jobs:
         CXX: clang++
     steps:
       - name: Collect Workflow Telemetry
-        uses: runforesight/workflow-telemetry-action@v1
+        uses: catchpoint/workflow-telemetry-action@v2
         with:
           comment_on_pr: false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run tests
         working-directory: ./cpp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,11 +22,11 @@ jobs:
       GOMEMLIMIT: "5GiB"
     steps:
     - name: Collect Workflow Telemetry
-      uses: runforesight/workflow-telemetry-action@v1
+      uses: catchpoint/workflow-telemetry-action@v2
       with:
         comment_on_pr: false
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check Go sources formatting
       working-directory: ./go


### PR DESCRIPTION
Since we are running on self-hosted test servers now with 64GB of memory, the limit on parallel tests can be increased.

The PR is also updating dependencies to other scripts as the previous versions are signalled as being deprecated.

Fixes #817 