### PR TITLE
Add warning to bulkload documentation.

### DIFF
--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -379,6 +379,8 @@ type QueryContext interface {
 // It allows for direct insertion of values into the database bypassing all checks.
 // Only one bulk load can run at a time.
 // Methods of this interface are not thread safe.
+// WARNING: One BulkLoad should not exceed 100k updates. Client should
+// break large bulk-loads into smaller ones not exceeding this value.
 type BulkLoad interface {
 
 	// CreateAccount creates a new account with the given address.


### PR DESCRIPTION
This PR adds warning to documentation about #789 
`Bulkload` will become deprecated once we have an official interface for using `genesis files`. Hence fixing the issue is not necessary.