### PR TITLE
update carmen go readme

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -22,7 +22,7 @@ go get github.com/Fantom-foundation/Carmen/go/
 
 For development purposes, it may come handy to execute all tests. It needs build of c++ parts.
 
-Either install c++ build environment, see [C++ build environment instructions](../cpp/README.md),
+Either install C++ build environment, see [C++ build environment instructions](../cpp/README.md),
 or have [Docker installation](https://www.docker.com)
 
 Execute in the root directory: 


### PR DESCRIPTION
This PR updates `go/Readme`. 

It includes the most basic information at the moment and can be extended later. 