### PR TITLE
fix memory leak in tests

### DIFF
--- a/go/carmen/carmen_test.go
+++ b/go/carmen/carmen_test.go
@@ -32,8 +32,14 @@ var testNonArchiveConfig = Configuration{
 	Archive: Archive(state.NoArchive),
 }
 
+var testProperties = Properties{
+	LiveDBCache:  "2000",
+	ArchiveCache: "2000",
+	StorageCache: "100",
+}
+
 func TestCarmen_DatabaseLiveCycle(t *testing.T) {
-	db, err := OpenDatabase(t.TempDir(), testConfig, nil)
+	db, err := openTestDatabase(t)
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
 	}
@@ -43,7 +49,7 @@ func TestCarmen_DatabaseLiveCycle(t *testing.T) {
 }
 
 func TestCarmen_BlockProcessing(t *testing.T) {
-	db, err := OpenDatabase(t.TempDir(), testConfig, nil)
+	db, err := openTestDatabase(t)
 
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
@@ -85,10 +91,15 @@ func TestCarmen_BlockProcessing(t *testing.T) {
 }
 
 func TestCarmen_HeadBlockQuery(t *testing.T) {
-	db, err := OpenDatabase(t.TempDir(), testConfig, nil)
+	db, err := openTestDatabase(t)
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("cannot close db: %v", err)
+		}
+	}()
 
 	getNonce := func() uint64 {
 		res := uint64(0)
@@ -134,10 +145,15 @@ func TestCarmen_HeadBlockQuery(t *testing.T) {
 }
 
 func TestCarmen_ArchiveQuery(t *testing.T) {
-	db, err := OpenDatabase(t.TempDir(), testConfig, nil)
+	db, err := openTestDatabase(t)
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("cannot close db: %v", err)
+		}
+	}()
 
 	// Insert content into DB using functional interface.
 	err = errors.Join(

--- a/go/carmen/configurations_test.go
+++ b/go/carmen/configurations_test.go
@@ -41,7 +41,7 @@ func TestConfiguration_RegisteredConfigurationsCanBeUsed(t *testing.T) {
 		config := config
 		t.Run(config.String(), func(t *testing.T) {
 			t.Parallel()
-			db, err := OpenDatabase(t.TempDir(), config, nil)
+			db, err := OpenDatabase(t.TempDir(), config, testProperties)
 			if err != nil {
 				t.Fatalf("failed to open database: %v", err)
 			}

--- a/go/carmen/database.go
+++ b/go/carmen/database.go
@@ -38,6 +38,10 @@ func openDatabase(
 	if err != nil {
 		return nil, err
 	}
+	storageCache, err := properties.GetInteger(StorageCache, 0)
+	if err != nil {
+		return nil, err
+	}
 	params := state.Parameters{
 		Directory:    directory,
 		Variant:      state.Variant(configuration.Variant),
@@ -50,7 +54,7 @@ func openDatabase(
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
-	statedb := state.CreateStateDBUsing(db)
+	statedb := state.CreateCustomStateDBUsing(db, storageCache)
 	return openStateDb(db, statedb)
 }
 
@@ -212,7 +216,6 @@ func (db *database) GetHistoricContext(block uint64) (HistoricBlockContext, erro
 		commonContext: commonContext{
 			db: db,
 		},
-
 		state: state.CreateNonCommittableStateDBUsing(s)}, err
 }
 

--- a/go/carmen/property.go
+++ b/go/carmen/property.go
@@ -27,6 +27,13 @@ const (
 	// ArchiveCache is a configuration property defining an approximate upper
 	// limit for the in-memory node-cache size of the Archive in bytes.
 	ArchiveCache = Property("ArchiveCache")
+	// StorageCache is the size of cache used for account storages.
+	// This cache is utilized everytime a storage slot of an account is accessed.
+	// Before expanding expensive data structures, it is checked if the storage slot
+	// is available in this cache, and obtained there if it exists.
+	// If the storage slot is updated, it is updated in this cache first,
+	// before being flushed into underlying structures later.
+	StorageCache = Property("StorageCache")
 )
 
 // Properties are optional settings which may influence the

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1330,6 +1330,7 @@ func (s *stateDB) resetState(state State) {
 	s.ResetBlockContext()
 	s.storedDataCache.Clear()
 	s.reincarnation = map[common.Address]uint64{}
+	s.errors = s.errors[0:0]
 	s.state = state
 }
 

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1330,7 +1330,6 @@ func (s *stateDB) resetState(state State) {
 	s.ResetBlockContext()
 	s.storedDataCache.Clear()
 	s.reincarnation = map[common.Address]uint64{}
-	s.errors = s.errors[0:0]
 	s.state = state
 }
 


### PR DESCRIPTION
this PR removes memory leak in tests caused by failing `Close()` of database in tests. 

furthermore it reduces size of caches. 

It fixes #833 