### PR TITLE
Fix multiple flushing of codes

### DIFF
--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/state"
 	"hash"
 	"io"
+	"maps"
 	"os"
 	"sync"
 	"unsafe"
@@ -384,7 +385,10 @@ func (s *MptState) Visit(visitor NodeVisitor) error {
 }
 
 func (s *MptState) GetCodes() (map[common.Hash][]byte, error) {
-	return s.code, nil
+	s.codeMutex.Lock()
+	res := maps.Clone(s.code)
+	s.codeMutex.Unlock()
+	return res, nil
 }
 
 // Flush codes and state trie

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -136,6 +136,7 @@ type MptState struct {
 	lock      common.LockFile
 	trie      *LiveTrie
 	code      map[common.Hash][]byte
+	codeDirty bool
 	codeMutex sync.Mutex
 	codefile  string
 	hasher    hash.Hash
@@ -345,6 +346,7 @@ func (s *MptState) SetCode(address common.Address, code []byte) (err error) {
 	info.CodeHash = codeHash
 	s.codeMutex.Lock()
 	s.code[codeHash] = code
+	s.codeDirty = true
 	s.codeMutex.Unlock()
 	return s.trie.SetAccountInfo(address, info)
 }
@@ -385,11 +387,21 @@ func (s *MptState) GetCodes() (map[common.Hash][]byte, error) {
 	return s.code, nil
 }
 
+// Flush codes and state trie
 func (s *MptState) Flush() error {
-	// Flush codes and state trie.
+	// flush codes
+	var err error
+	s.codeMutex.Lock()
+	if s.codeDirty {
+		err = writeCodes(s.code, s.codefile)
+		if err == nil {
+			s.codeDirty = false
+		}
+	}
+	s.codeMutex.Unlock()
 	return errors.Join(
 		s.trie.forest.CheckErrors(),
-		writeCodes(s.code, s.codefile),
+		err,
 		s.trie.Flush(),
 	)
 }
@@ -430,9 +442,11 @@ func (s *MptState) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
 	mf.AddChild("trie", s.trie.GetMemoryFootprint())
 	var sizeCodes uint
+	s.codeMutex.Lock()
 	for k, v := range s.code {
 		sizeCodes += uint(len(k) + len(v))
 	}
+	s.codeMutex.Unlock()
 	mf.AddChild("codes", common.NewMemoryFootprint(uintptr(sizeCodes)))
 	return mf
 }

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -558,6 +558,21 @@ func TestState_Flush_WriteDirtyCodesOnly(t *testing.T) {
 	if stat1.ModTime() != stat2.ModTime() {
 		t.Errorf("codes written even when not dirty")
 	}
+
+	if err := state.SetCode(common.Address{}, []byte{0x12, 0x34}); err != nil {
+		t.Errorf("SetCode failed: %v", err)
+	}
+	if err := state.Flush(); err != nil {
+		t.Errorf("Flush failed: %v", err)
+	}
+
+	stat3, err := os.Stat(dir + "/codes.dat")
+	if err != nil {
+		t.Errorf("failed to get modtime of codes file after third flush")
+	}
+	if stat2.ModTime() == stat3.ModTime() {
+		t.Errorf("codes not written when dirty")
+	}
 }
 
 func TestState_writeCodes_WriteFailures(t *testing.T) {


### PR DESCRIPTION
Everytime when MptState is being Flushed, the codes file is written to the disk, even when no code have been modified.

This affects event the time of Carmen closing, as the flush is called here several times:

![image](https://github.com/Fantom-foundation/Carmen/assets/3178122/d226d1f6-e85f-47e5-a1c5-600f6bdf18d8)

This PR adds a codeDirty flag, which avoids these unnecessary overrides.

This also adds proper codeMutex locking into the Flush and GetMemoryFootprint.
We may want to use ReadWrite lock in the future, however until now, we just supposed there is no concurrency of Flush/GetMemoryFootprint with code writes.