### PR TITLE
tests how standard slice grows

### DIFF
--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -529,7 +529,7 @@ func TestArchive_RootsGrowSubLinearly(t *testing.T) {
 			// Golang slices grow by the factor of 2 when they are small,
 			// while they grow slower when they become huge.
 			// The slice 'archive.roots' contains millions of elements
-			// printed as GiBs in memory.
+			// stored as GiBs in memory.
 			// This test verifies that the slices grow slower for huge arrays
 			// to ensure that memory consumption is not doubled every time
 			// the slice grows.


### PR DESCRIPTION
This PR verifies that huge slices of hash roots are growing sub linearly.  

It is to avoid situation where this slice consumes already GiBs of memory as a consequence of storing minions of roots, and suddenly doubles memory consumption caused by expanded capacity of this slice. 

It basically tests only how current golang behaves, but should serve as a validation that further versions or configurations do not change. 