### PR TITLE
Add benchmark for flushing MPT States

### DIFF
--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -709,3 +709,78 @@ func TestEstimatePerNodeMemoryUsage(t *testing.T) {
 		t.Errorf("Estimated nodes size is too big, wanted at most %d, got %d", upperLimit, got)
 	}
 }
+
+func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
+	numAccounts := 100_000
+	state, err := OpenGoFileState(b.TempDir(), config, numAccounts)
+	if err != nil {
+		b.Fatalf("failed to open state, err %v", err)
+	}
+
+	// Create some content in the MPT large enough to
+	// fill the full node cache.
+	addrs := getTestAddresses(numAccounts)
+	for j, addr := range addrs {
+		if j%(numAccounts/2) == 0 && j > 0 {
+			if _, _, err = state.UpdateHashes(); err != nil {
+				b.Fatalf("failed to update hashes: %v", err)
+			}
+		}
+		err = state.CreateAccount(addr)
+		if err != nil {
+			b.Fatalf("failed to create account: %v", err)
+		}
+	}
+	if _, _, err = state.UpdateHashes(); err != nil {
+		b.Fatalf("failed to update hashes: %v", err)
+	}
+
+	// Add some codes to be flushed.
+	for i := 0; i < numAccounts; i++ {
+		state.code[common.Hash{byte(i >> 8), byte(i)}] = make([]byte, 100)
+	}
+
+	if err = state.Flush(); err != nil {
+		b.Fatalf("failed to flush state: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if forceDirtyNodes {
+			// Mark all nodes in the cache as dirty.
+			state.trie.forest.(*Forest).nodeCache.ForEach(func(id NodeId, node *shared.Shared[Node]) {
+				handle := node.GetWriteHandle()
+				switch node := handle.Get().(type) {
+				case *BranchNode:
+					node.clean = false
+				case *ExtensionNode:
+					node.clean = false
+				case *ValueNode:
+					node.clean = false
+				case *AccountNode:
+					node.clean = false
+				}
+				handle.Release()
+			})
+			state.codeDirty = true
+		}
+		if err = state.Flush(); err != nil {
+			b.Fatalf("failed to flush state: %v", err)
+		}
+	}
+
+	if err = state.Close(); err != nil {
+		b.Fatalf("failed to close state: %v", err)
+	}
+
+}
+
+// To run these benchmarks, use the following command:
+// go test ./database/mpt -run none -bench BenchmarkMptState_ArchiveFlush --benchtime 10s
+
+func BenchmarkMptState_ArchiveFlush(b *testing.B) {
+	runFlushBenchmark(b, S5ArchiveConfig, false)
+}
+
+func BenchmarkMptState_ArchiveFlushForcedDirty(b *testing.B) {
+	runFlushBenchmark(b, S5ArchiveConfig, true)
+}


### PR DESCRIPTION
This benchmark is designed to measure the costs for flush operations.

To run the benchmark use the following command:
```
go test ./database/mpt -run none -bench BenchmarkMptState_ArchiveFlush --benchtime 10s
```

This command will produce benchmark results like this:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Carmen/go/database/mpt
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkMptState_ArchiveFlush-12               	      56	 178799258 ns/op
BenchmarkMptState_ArchiveFlushForcedDirty-12    	      48	 224348680 ns/op
PASS
ok  	github.com/Fantom-foundation/Carmen/go/database/mpt	41.867s
```