### PR TITLE
removes check of last block from history queries

### DIFF
--- a/go/carmen/database.go
+++ b/go/carmen/database.go
@@ -201,10 +201,6 @@ func (db *database) GetHistoricContext(block uint64) (HistoricBlockContext, erro
 		return nil, errDbClosed
 	}
 
-	if db.lastBlock < int64(block) {
-		return nil, fmt.Errorf("block does not exist: lastBlock: %d block: %d", db.lastBlock, block)
-	}
-
 	s, err := db.db.GetArchiveState(block)
 	if err != nil {
 		return nil, err

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -176,7 +176,7 @@ func (s *ArchiveState) GetArchiveState(block uint64) (state.State, error) {
 		return nil, errors.Join(fmt.Errorf("failed to get block height from the archive: %w", s.archiveError))
 	}
 	if empty || block > height {
-		return nil, fmt.Errorf("block %d is not present in the archive (height %d)", block, height)
+		return nil, fmt.Errorf("block %d is not present in the archive (empty: %v, height %d)", block, empty, height)
 	}
 	return &ArchiveState{
 		archive:      s.archive,

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -311,7 +311,7 @@ func (s *GoState) GetArchiveState(block uint64) (as state.State, err error) {
 		return nil, fmt.Errorf("block %d is not present in the archive (archive is empty)", block)
 	}
 	if block > lastBlock {
-		return nil, fmt.Errorf("block %d is not present in the archive (last block %d)", block, lastBlock)
+		return nil, fmt.Errorf("block %d is not present in the archive (non-empty archive, last block %d)", block, lastBlock)
 	}
 	return &ArchiveState{
 		archive: s.archive,


### PR DESCRIPTION
this PR removes check for the `lastBlock` from the archive query of the Carmen facade.

this check used to cause error: https://github.com/Fantom-foundation/Carmen/issues/845

the problem was that while the head state block is being committed, the block may be already available in the archive, before the `lastBlock` counter is incremented.  It was fixed the way that this check is removed as it  serves rather for sequencing new head state blocks. 

Another approach would be to capture this counter in the same lock as the one managing the head state, though it would unnecessarily block running parallel archive queries. I.e. such an approach was not taken. 