### PR TITLE
Fix license header script empty line

### DIFF
--- a/scripts/license/add_license_header.sh
+++ b/scripts/license/add_license_header.sh
@@ -39,7 +39,7 @@ extend_license_header() {
     # Extend each line of the license header with the specified character
     local extended_license_header=""
     while IFS= read -r line; do
-        extended_license_header+="$comment_char $line\n"
+        extended_license_header+="$comment_char${line:+ $line}\n"
     done <<< "$license_header"
 
     # return


### PR DESCRIPTION
This PR adjusts the license generator script, that appended whitespace on empty lines. This caused `clang-format` tool to fail, so the jenkins pipeline always failed.