### PR TITLE
Fix Jenkins agent label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@
 // of this software will be governed by the GNU Lesser General Public Licence v3
 
 pipeline {
-    agent { label 'db-small-ssd' }
+    agent { label 'db-small-nvme' }
 
     options { 
         timestamps ()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@
 // of this software will be governed by the GNU Lesser General Public Licence v3
 
 pipeline {
-    agent { label 'db-small-nvme' }
+    agent { label 'pullrequest' }
 
     options { 
         timestamps ()


### PR DESCRIPTION
This PR fixes label for jenkins agent, because it has changed. Before this change, new jobs are not started.