### PR TITLE
Add transient storage

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -837,13 +837,12 @@ func (s *stateDB) GetTransientState(addr common.Address, key common.Key) common.
 
 func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value common.Value) {
 	sid := slotId{addr, key}
-	if entry, exists := s.transientStorage.Get(sid); exists {
-		if entry == value {
+	if currentValue, exists := s.transientStorage.Get(sid); exists {
+		if currentValue == value {
 			return
 		}
 		// Save previous value for rollbacks
-		oldValue := entry
-		entry = value
+		oldValue := currentValue
 		s.undo = append(s.undo, func() {
 			s.transientStorage.Put(sid, oldValue)
 		})

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -836,16 +836,14 @@ func (s *stateDB) GetTransientState(addr common.Address, key common.Key) common.
 }
 
 func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value common.Value) {
-	var oldValue common.Value
 	sid := slotId{addr, key}
-	if currentValue, exists := s.transientStorage.Get(sid); exists {
-		if currentValue == value {
-			return
-		}
-		// Save previous value for rollbacks
-		oldValue = currentValue
+	currentValue, _ := s.transientStorage.Get(sid)
+	if currentValue == value {
+		return
 	}
 
+	// Save previous value for rollbacks
+	oldValue := currentValue
 	s.undo = append(s.undo, func() {
 		s.transientStorage.Put(sid, oldValue)
 	})

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -52,6 +52,8 @@ type VmStateDB interface {
 	GetCommittedState(common.Address, common.Key) common.Value
 	GetState(common.Address, common.Key) common.Value
 	SetState(common.Address, common.Key, common.Value)
+	GetTransientState(common.Address, common.Key) common.Value
+	SetTransientState(common.Address, common.Key, common.Value)
 
 	// Code management.
 	GetCode(common.Address) []byte
@@ -192,6 +194,9 @@ type stateDB struct {
 	// A transaction local cache of storage values to avoid double-fetches and support rollbacks.
 	data *common.FastMap[slotId, *slotValue]
 
+	// Transient storage
+	transientData *common.FastMap[slotId, common.Value]
+
 	// A transaction local cache of contract codes and their properties.
 	codes map[common.Address]*codeValue
 
@@ -203,6 +208,9 @@ type stateDB struct {
 
 	// A list of operations undoing modifications applied on the inner state if a snapshot revert needs to be performed.
 	undo []func()
+
+	// A list of operations undoing modifications applied on the inner state if a snapshot revert needs to be performed.
+	transientUndo []func()
 
 	// The refund accumulated in the current transaction.
 	refund uint64
@@ -436,6 +444,7 @@ func createStateDBWith(state State, storedDataCacheCapacity int, canApplyChanges
 		balances:          map[common.Address]*balanceValue{},
 		nonces:            map[common.Address]*nonceValue{},
 		data:              common.NewFastMap[slotId, *slotValue](slotHasher{}),
+		transientData:     common.NewFastMap[slotId, common.Value](slotHasher{}),
 		storedDataCache:   common.NewLruCache[slotId, storedDataCacheValue](storedDataCacheCapacity),
 		reincarnation:     map[common.Address]uint64{},
 		codes:             map[common.Address]*codeValue{},
@@ -445,6 +454,7 @@ func createStateDBWith(state State, storedDataCacheCapacity int, canApplyChanges
 		writtenSlots:      map[*slotValue]bool{},
 		accountsToDelete:  make([]common.Address, 0, 100),
 		undo:              make([]func(), 0, 100),
+		transientUndo:     make([]func(), 0, 100),
 		clearedAccounts:   make(map[common.Address]accountClearingState),
 		emptyCandidates:   make([]common.Address, 0, 100),
 		canApplyChanges:   canApplyChanges,
@@ -519,6 +529,17 @@ func (s *stateDB) CreateAccount(addr common.Address) {
 			value.committed = common.Value{}
 			value.committedKnown = true
 			value.current = common.Value{}
+		}
+	})
+
+	// Reset transient storage.
+	s.transientData.ForEach(func(slot slotId, value common.Value) {
+		if slot.addr == addr {
+			// Support rollback of account creation.
+			s.transientUndo = append(s.transientUndo, func() {
+				s.transientData.Put(slot, value)
+			})
+			s.transientData.Remove(slot)
 		}
 	})
 
@@ -820,6 +841,36 @@ func (s *stateDB) SetState(addr common.Address, key common.Key, value common.Val
 	if oldState == cleared {
 		s.clearedAccounts[addr] = clearedAndTainted
 		s.undo = append(s.undo, func() { s.clearedAccounts[addr] = oldState })
+	}
+}
+
+func (s *stateDB) GetTransientState(addr common.Address, key common.Key) common.Value {
+	sid := slotId{addr, key}
+	val, _ := s.transientData.Get(sid)
+	return val
+}
+
+func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value common.Value) {
+	if s.createAccountIfNotExists(addr) {
+		// The account was implicitly created and may have to be removed at the end of the block.
+		s.emptyCandidates = append(s.emptyCandidates, addr)
+	}
+	sid := slotId{addr, key}
+	if entry, exists := s.transientData.Get(sid); exists {
+		if entry == value {
+			return
+		}
+		oldValue := entry
+		entry = value
+		s.transientUndo = append(s.transientUndo, func() {
+			s.transientData.Put(sid, oldValue)
+		})
+
+	} else {
+		s.transientData.Put(sid, value)
+		s.transientUndo = append(s.transientUndo, func() {
+			s.transientData.Remove(sid)
+		})
 	}
 }
 
@@ -1310,7 +1361,9 @@ func (s *stateDB) GetArchiveBlockHeight() (uint64, bool, error) {
 func (s *stateDB) resetTransactionContext() {
 	s.refund = 0
 	s.ClearAccessList()
+	s.transientData.Clear()
 	s.undo = s.undo[0:0]
+	s.transientUndo = s.transientUndo[0:0]
 	s.emptyCandidates = s.emptyCandidates[0:0]
 	s.logs = s.logs[0:0]
 }

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -841,6 +841,7 @@ func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value c
 		if entry == value {
 			return
 		}
+		// Save previous value for rollbacks
 		oldValue := entry
 		entry = value
 		s.undo = append(s.undo, func() {
@@ -848,11 +849,12 @@ func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value c
 		})
 
 	} else {
-		s.transientStorage.Put(sid, value)
 		s.undo = append(s.undo, func() {
 			s.transientStorage.Remove(sid)
 		})
 	}
+
+	s.transientStorage.Put(sid, value)
 }
 
 func (s *stateDB) GetCode(addr common.Address) []byte {
@@ -1343,7 +1345,6 @@ func (s *stateDB) resetTransactionContext() {
 	s.refund = 0
 	s.ClearAccessList()
 	s.transientStorage.Clear()
-	s.undo = s.undo[0:0]
 	s.undo = s.undo[0:0]
 	s.emptyCandidates = s.emptyCandidates[0:0]
 	s.logs = s.logs[0:0]

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -836,22 +836,19 @@ func (s *stateDB) GetTransientState(addr common.Address, key common.Key) common.
 }
 
 func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value common.Value) {
+	var oldValue common.Value
 	sid := slotId{addr, key}
 	if currentValue, exists := s.transientStorage.Get(sid); exists {
 		if currentValue == value {
 			return
 		}
 		// Save previous value for rollbacks
-		oldValue := currentValue
-		s.undo = append(s.undo, func() {
-			s.transientStorage.Put(sid, oldValue)
-		})
-
-	} else {
-		s.undo = append(s.undo, func() {
-			s.transientStorage.Remove(sid)
-		})
+		oldValue = currentValue
 	}
+
+	s.undo = append(s.undo, func() {
+		s.transientStorage.Put(sid, oldValue)
+	})
 
 	s.transientStorage.Put(sid, value)
 }

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -367,6 +367,20 @@ func (mr *MockVmStateDBMockRecorder) GetTransactionChanges() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionChanges", reflect.TypeOf((*MockVmStateDB)(nil).GetTransactionChanges))
 }
 
+// GetTransientState mocks base method.
+func (m *MockVmStateDB) GetTransientState(arg0 common.Address, arg1 common.Key) common.Value {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransientState", arg0, arg1)
+	ret0, _ := ret[0].(common.Value)
+	return ret0
+}
+
+// GetTransientState indicates an expected call of GetTransientState.
+func (mr *MockVmStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockVmStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
 // HasSuicided mocks base method.
 func (m *MockVmStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -456,6 +470,18 @@ func (m *MockVmStateDB) SetState(arg0 common.Address, arg1 common.Key, arg2 comm
 func (mr *MockVmStateDBMockRecorder) SetState(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockVmStateDB)(nil).SetState), arg0, arg1, arg2)
+}
+
+// SetTransientState mocks base method.
+func (m *MockVmStateDB) SetTransientState(arg0 common.Address, arg1 common.Key, arg2 common.Value) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTransientState", arg0, arg1, arg2)
+}
+
+// SetTransientState indicates an expected call of SetTransientState.
+func (mr *MockVmStateDBMockRecorder) SetTransientState(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTransientState", reflect.TypeOf((*MockVmStateDB)(nil).SetTransientState), arg0, arg1, arg2)
 }
 
 // Snapshot mocks base method.
@@ -970,6 +996,20 @@ func (mr *MockStateDBMockRecorder) GetTransactionChanges() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionChanges", reflect.TypeOf((*MockStateDB)(nil).GetTransactionChanges))
 }
 
+// GetTransientState mocks base method.
+func (m *MockStateDB) GetTransientState(arg0 common.Address, arg1 common.Key) common.Value {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransientState", arg0, arg1)
+	ret0, _ := ret[0].(common.Value)
+	return ret0
+}
+
+// GetTransientState indicates an expected call of GetTransientState.
+func (mr *MockStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
 // HasSuicided mocks base method.
 func (m *MockStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -1071,6 +1111,18 @@ func (m *MockStateDB) SetState(arg0 common.Address, arg1 common.Key, arg2 common
 func (mr *MockStateDBMockRecorder) SetState(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockStateDB)(nil).SetState), arg0, arg1, arg2)
+}
+
+// SetTransientState mocks base method.
+func (m *MockStateDB) SetTransientState(arg0 common.Address, arg1 common.Key, arg2 common.Value) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTransientState", arg0, arg1, arg2)
+}
+
+// SetTransientState indicates an expected call of SetTransientState.
+func (mr *MockStateDBMockRecorder) SetTransientState(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTransientState", reflect.TypeOf((*MockStateDB)(nil).SetTransientState), arg0, arg1, arg2)
 }
 
 // Snapshot mocks base method.
@@ -1492,6 +1544,20 @@ func (mr *MockNonCommittableStateDBMockRecorder) GetTransactionChanges() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionChanges", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetTransactionChanges))
 }
 
+// GetTransientState mocks base method.
+func (m *MockNonCommittableStateDB) GetTransientState(arg0 common.Address, arg1 common.Key) common.Value {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransientState", arg0, arg1)
+	ret0, _ := ret[0].(common.Value)
+	return ret0
+}
+
+// GetTransientState indicates an expected call of GetTransientState.
+func (mr *MockNonCommittableStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
 // HasSuicided mocks base method.
 func (m *MockNonCommittableStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -1593,6 +1659,18 @@ func (m *MockNonCommittableStateDB) SetState(arg0 common.Address, arg1 common.Ke
 func (mr *MockNonCommittableStateDBMockRecorder) SetState(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockNonCommittableStateDB)(nil).SetState), arg0, arg1, arg2)
+}
+
+// SetTransientState mocks base method.
+func (m *MockNonCommittableStateDB) SetTransientState(arg0 common.Address, arg1 common.Key, arg2 common.Value) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTransientState", arg0, arg1, arg2)
+}
+
+// SetTransientState indicates an expected call of SetTransientState.
+func (mr *MockNonCommittableStateDBMockRecorder) SetTransientState(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTransientState", reflect.TypeOf((*MockNonCommittableStateDB)(nil).SetTransientState), arg0, arg1, arg2)
 }
 
 // Snapshot mocks base method.

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4307,6 +4307,7 @@ func TestNonCommittableStateDB_TransientStorage_DoesNotLeakBetweenInstances(t *t
 		t.Errorf("unexpected value, wanted %v, got %v", want, got)
 	}
 
+	db.Release()
 	// TransientStorage must be cleared
 	db2 := CreateNonCommittableStateDBUsing(mock)
 	if got, want := db2.GetTransientState(address1, key1), valEmpty; got != want {

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4297,6 +4297,23 @@ func TestStateDB_SetTransientState_RollbackWithMultipleSteps(t *testing.T) {
 	}
 }
 
+func TestNonCommittableStateDB_TransientStorage_DoesNotLeakBetweenInstances(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockState(ctrl)
+	db := CreateNonCommittableStateDBUsing(mock)
+
+	db.SetTransientState(address1, key1, val1)
+	if got, want := db.GetTransientState(address1, key1), val1; got != want {
+		t.Errorf("unexpected value, wanted %v, got %v", want, got)
+	}
+
+	// TransientStorage must be cleared
+	db2 := CreateNonCommittableStateDBUsing(mock)
+	if got, want := db2.GetTransientState(address1, key1), valEmpty; got != want {
+		t.Errorf("unexpected value, wanted %v, got %v", want, got)
+	}
+}
+
 type sameEffectAs struct {
 	want common.Update
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4257,8 +4257,6 @@ func TestStateDB_SetTransientState_SettingSameValueReturnsEarly(t *testing.T) {
 		t.Errorf("unexpected undo len, wanted: 1, got: %v", len(db.undo))
 	}
 
-	undo := db.undo[0]
-
 	db.SetTransientState(address1, key1, val1)
 	if got, want := db.GetTransientState(address1, key1), val1; got != want {
 		t.Errorf("unexpected value, wanted %v, got %v", want, got)
@@ -4266,10 +4264,6 @@ func TestStateDB_SetTransientState_SettingSameValueReturnsEarly(t *testing.T) {
 
 	if got, want := len(db.undo), 1; got != want {
 		t.Errorf("unexpected undo len, wanted: 1, got: %v", len(db.undo))
-	}
-
-	if got, want := reflect.ValueOf(db.undo[0]), reflect.ValueOf(undo); got != want {
-		t.Errorf("undo func was changed")
 	}
 }
 

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4227,22 +4227,6 @@ func TestStateDB_SetTransientState_NewestValueCanBeObtained(t *testing.T) {
 	}
 }
 
-func TestStateDB_SetTransientState_ValueIsNotSetIfSame(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mock := NewMockState(ctrl)
-	db := CreateStateDBUsing(mock)
-
-	db.SetTransientState(address1, key1, val1)
-	if got, want := db.GetTransientState(address1, key1), val1; got != want {
-		t.Errorf("unexpected value, wanted %v, got %v", want, got)
-	}
-
-	db.SetTransientState(address1, key1, val2)
-	if got, want := db.GetTransientState(address1, key1), val2; got != want {
-		t.Errorf("unexpected value, wanted %v, got %v", want, got)
-	}
-}
-
 func TestStateDB_SetTransientState_SettingSameValueReturnsEarly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)
@@ -4297,7 +4281,7 @@ func TestStateDB_SetTransientState_RollbackWithMultipleSteps(t *testing.T) {
 	}
 }
 
-func TestNonCommittableStateDB_TransientStorage_DoesNotLeakBetweenInstances(t *testing.T) {
+func TestNonCommittableStateDB_resetState_ClearsTransientStorage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)
 	db := CreateNonCommittableStateDBUsing(mock)
@@ -4307,10 +4291,9 @@ func TestNonCommittableStateDB_TransientStorage_DoesNotLeakBetweenInstances(t *t
 		t.Errorf("unexpected value, wanted %v, got %v", want, got)
 	}
 
-	db.Release()
+	db.(*nonCommittableStateDB).resetState(mock)
 	// TransientStorage must be cleared
-	db2 := CreateNonCommittableStateDBUsing(mock)
-	if got, want := db2.GetTransientState(address1, key1), valEmpty; got != want {
+	if got, want := db.GetTransientState(address1, key1), valEmpty; got != want {
 		t.Errorf("unexpected value, wanted %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
This PR adds `TransientStorage` to `stateDB` with `Get/SetTransientStorage` to the `VMStateDB` interface.
Fixes #858 