### PR TITLE
Add Transient Storage to public API.

### DIFF
--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -269,7 +269,7 @@ type TransactionContext interface {
 
 	// GetTransientState retrieves the value associated with a specific
 	// key within the transient state storage at a given address.
-	// Transient State is quick in memory storage
+	// Transient State is an in-memory storage
 	// that gets reset after each transaction.
 	GetTransientState(Address, Key) Value
 

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -376,6 +376,11 @@ type QueryContext interface {
 	// updated in the current transaction.
 	GetState(Address, Key) Value
 
+	// GetTransientState retrieves the value associated
+	// with a specific key within the transient state
+	// storage at a given address.
+	GetTransientState(Address, Key) Value
+
 	// GetCode returns smart contract byte-code
 	// of an account with the given address.
 	GetCode(Address) []byte

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -267,6 +267,14 @@ type TransactionContext interface {
 	// stored in the account with the given address.
 	SetState(Address, Key, Value)
 
+	// GetTransientState retrieves the value associated with a specific
+	// key within the transient state storage at a given address.
+	GetTransientState(Address, Key) Value
+
+	// SetTransientState sets a value in the transient state
+	//storage for a specific key at a given address.
+	SetTransientState(Address, Key, Value)
+
 	// GetCode returns smart contract byte-code
 	// of an account with the given address.
 	GetCode(Address) []byte

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -269,10 +269,14 @@ type TransactionContext interface {
 
 	// GetTransientState retrieves the value associated with a specific
 	// key within the transient state storage at a given address.
+	// Transient State is quick in memory storage
+	// that gets reset after each transaction.
 	GetTransientState(Address, Key) Value
 
 	// SetTransientState sets a value in the transient state
 	// storage for a specific key at a given address.
+	// Transient State is quick in memory storage
+	// that gets reset after each transaction.
 	SetTransientState(Address, Key, Value)
 
 	// GetCode returns smart contract byte-code
@@ -375,11 +379,6 @@ type QueryContext interface {
 	// This method returns an ongoing value that could be
 	// updated in the current transaction.
 	GetState(Address, Key) Value
-
-	// GetTransientState retrieves the value associated
-	// with a specific key within the transient state
-	// storage at a given address.
-	GetTransientState(Address, Key) Value
 
 	// GetCode returns smart contract byte-code
 	// of an account with the given address.

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -275,7 +275,7 @@ type TransactionContext interface {
 
 	// SetTransientState sets a value in the transient state
 	// storage for a specific key at a given address.
-	// Transient State is quick in memory storage
+	// Transient State is an in-memory storage
 	// that gets reset after each transaction.
 	SetTransientState(Address, Key, Value)
 

--- a/go/carmen/transaction.go
+++ b/go/carmen/transaction.go
@@ -109,6 +109,20 @@ func (t *transactionContext) SetState(address Address, key Key, value Value) {
 	}
 }
 
+func (t *transactionContext) GetTransientState(address Address, key Key) Value {
+	if t.state != nil {
+		return Value(t.state.GetTransientState(common.Address(address), common.Key(key)))
+	}
+
+	return Value{}
+}
+
+func (t *transactionContext) SetTransientState(address Address, key Key, value Value) {
+	if t.state != nil {
+		t.state.SetTransientState(common.Address(address), common.Key(key), common.Value(value))
+	}
+}
+
 func (t *transactionContext) GetCode(address Address) []byte {
 	if t.state != nil {
 		return t.state.GetCode(common.Address(address))

--- a/go/carmen/transaction_test.go
+++ b/go/carmen/transaction_test.go
@@ -11,11 +11,12 @@
 package carmen
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/state"
 	"go.uber.org/mock/gomock"
-	"math/big"
-	"testing"
 )
 
 func TestTransaction_Cannot_Commit_Twice(t *testing.T) {
@@ -142,6 +143,8 @@ func TestTransaction_Operations_Passthrough(t *testing.T) {
 	stateDB.EXPECT().GetCommittedState(gomock.Any(), gomock.Any())
 	stateDB.EXPECT().GetState(gomock.Any(), gomock.Any())
 	stateDB.EXPECT().SetState(gomock.Any(), gomock.Any(), gomock.Any())
+	stateDB.EXPECT().GetTransientState(gomock.Any(), gomock.Any())
+	stateDB.EXPECT().SetTransientState(gomock.Any(), gomock.Any(), gomock.Any())
 	stateDB.EXPECT().GetCode(gomock.Any())
 	stateDB.EXPECT().SetCode(gomock.Any(), gomock.Any())
 	stateDB.EXPECT().GetCodeHash(gomock.Any())
@@ -185,6 +188,8 @@ func TestTransaction_Operations_Passthrough(t *testing.T) {
 	tx.GetCommittedState(address, key)
 	tx.GetState(address, key)
 	tx.SetState(address, key, value)
+	tx.GetTransientState(address, key)
+	tx.SetTransientState(address, key, value)
 	tx.GetCode(address)
 	tx.SetCode(address, []byte{})
 	tx.GetCodeHash(address)
@@ -242,6 +247,8 @@ func TestTransaction_AfterCommitAllOperationsAreNoops(t *testing.T) {
 	tx.GetCommittedState(address, key)
 	tx.GetState(address, key)
 	tx.SetState(address, key, value)
+	tx.GetTransientState(address, key)
+	tx.SetTransientState(address, key, value)
 	tx.GetCode(address)
 	tx.SetCode(address, []byte{})
 	tx.GetCodeHash(address)


### PR DESCRIPTION
This PR exposes both `SetTransientStorage` and `GetTransientStorage` through the API inside `go/carmen`