### PR TITLE
Codes verification

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -76,10 +76,6 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 }
 
 func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) (res error) {
-	if observer == nil {
-		observer = NilVerificationObserver{}
-	}
-
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err
@@ -87,23 +83,7 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 	if len(roots) == 0 {
 		return nil
 	}
-	observer.StartVerification()
-	defer func() {
-		if r := recover(); r != nil {
-			panic(r)
-		}
-		observer.EndVerification(res)
-	}()
-
-	// Open stock data structures for content verification.
-	observer.Progress("Obtaining read access to files ...")
-	source, err := openVerificationNodeSource(directory, config)
-	if err != nil {
-		return err
-	}
-	defer source.Close()
-
-	return verifyFileForest(directory, config, roots, source, observer)
+	return VerifyMptState(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -86,7 +86,7 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 	if len(roots) == 0 {
 		return nil
 	}
-	return VerifyMptState(directory, config, roots, observer)
+	return VerifyCodesAndForest(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -77,7 +77,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 
 // VerifyArchive validates file-based archive stored in the given directory.
 // If the test passes, the data stored in the respective directory
-// can be considered to be a valid Live Trie of the given configuration.
+// can be considered a valid archive database of the given configuration.
 func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) error {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -78,7 +78,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 // VerifyArchive validates file-based archive stored in the given directory.
 // If the test passes, the data stored in the respective directory
 // can be considered to be a valid Live Trie of the given configuration.
-func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) (res error) {
+func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) error {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -75,7 +75,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 	}, nil
 }
 
-func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) error {
+func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) (res error) {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 	if len(roots) == 0 {
 		return nil
 	}
-	return VerifyFileForest(directory, config, roots, observer)
+	return VerifyMptState(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -75,10 +75,10 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 	}, nil
 }
 
-// VerifyArchive validates file-based archive stored in the given directory.
+// VerifyArchiveTrie validates file-based archive stored in the given directory.
 // If the test passes, the data stored in the respective directory
 // can be considered a valid archive database of the given configuration.
-func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) error {
+func VerifyArchiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 	if len(roots) == 0 {
 		return nil
 	}
-	return VerifyCodesAndForest(directory, config, roots, observer)
+	return VerifyMptState(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -75,11 +75,10 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 	}, nil
 }
 
-// VerifyMptStateWithArchive validates Mpt state with file-based archive trie stored
-// in the given directory. If the test passes, the data stored in the respective
-// directory can be considered to be a valid Mpt state of the given configuration.
-// This validation contains both Forest and contract codes checks.
-func VerifyMptStateWithArchive(directory string, config MptConfig, observer VerificationObserver) error {
+// VerifyArchive validates file-based archive stored in the given directory.
+// If the test passes, the data stored in the respective directory
+// can be considered to be a valid Live Trie of the given configuration.
+func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) (res error) {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err
@@ -88,20 +87,6 @@ func VerifyMptStateWithArchive(directory string, config MptConfig, observer Veri
 		return nil
 	}
 	return VerifyMptState(directory, config, roots, observer)
-}
-
-// VerifyArchiveTrie validates a file-based archive trie stored in the given
-// directory. If the test passes, the data stored in the respective directory
-// can be considered to be a valid Live Trie of the given configuration.
-func VerifyArchiveTrie(directory string, config MptConfig, observer VerificationObserver) (res error) {
-	roots, err := loadRoots(directory + "/roots.dat")
-	if err != nil {
-		return err
-	}
-	if len(roots) == 0 {
-		return nil
-	}
-	return verifyFileForest(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -75,7 +75,11 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 	}, nil
 }
 
-func VerifyArchive(directory string, config MptConfig, observer VerificationObserver) (res error) {
+// VerifyMptStateWithArchive validates Mpt state with file-based archive trie stored
+// in the given directory. If the test passes, the data stored in the respective
+// directory can be considered to be a valid Mpt state of the given configuration.
+// This validation contains both Forest and contract codes checks.
+func VerifyMptStateWithArchive(directory string, config MptConfig, observer VerificationObserver) error {
 	roots, err := loadRoots(directory + "/roots.dat")
 	if err != nil {
 		return err
@@ -84,6 +88,20 @@ func VerifyArchive(directory string, config MptConfig, observer VerificationObse
 		return nil
 	}
 	return VerifyMptState(directory, config, roots, observer)
+}
+
+// VerifyArchiveTrie validates a file-based archive trie stored in the given
+// directory. If the test passes, the data stored in the respective directory
+// can be considered to be a valid Live Trie of the given configuration.
+func VerifyArchiveTrie(directory string, config MptConfig, observer VerificationObserver) (res error) {
+	roots, err := loadRoots(directory + "/roots.dat")
+	if err != nil {
+		return err
+	}
+	if len(roots) == 0 {
+		return nil
+	}
+	return verifyFileForest(directory, config, roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -304,7 +304,7 @@ func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if err := VerifyArchiveTrie(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
+	if err := VerifyArchive(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
 		t.Errorf("verification should fail")
 	}
 }
@@ -389,7 +389,7 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 				t.Fatalf("failed to close resources: %v", err)
 			}
 
-			if err := VerifyArchiveTrie(archiveDir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchive(archiveDir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("failed to verify archive: %v", err)
 			}
 		})
@@ -400,7 +400,7 @@ func TestArchiveTrie_VerificationOfEmptyDirectoryPasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("an empty directory should be fine, got: %v", err)
 			}
 		})
@@ -450,7 +450,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 				t.Fatalf("failed to close archive: %v", err)
 			}
 
-			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("a freshly closed archive should be fine, got: %v", err)
 			}
 		})
@@ -1081,7 +1081,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 				t.Fatalf("failed to delete file")
 			}
 
-			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("missing file should be detected")
 			}
 		})
@@ -1128,7 +1128,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 				t.Fatalf("failed to modify file")
 			}
 
-			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("corrupted file should have been detected")
 			}
 		})

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -389,11 +389,6 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 				t.Fatalf("failed to close resources: %v", err)
 			}
 
-			// create dummy codes.dat file
-			if err := writeCodes(nil, filepath.Join(archiveDir, "codes.dat")); err != nil {
-				t.Fatalf("failed to write dummy code file: %v", err)
-			}
-
 			if err := VerifyArchive(archiveDir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("failed to verify archive: %v", err)
 			}
@@ -453,11 +448,6 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 
 			if err := archive.Close(); err != nil {
 				t.Fatalf("failed to close archive: %v", err)
-			}
-
-			// create dummy codes.dat file
-			if err := writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
-				t.Fatalf("failed to write dummy code file: %v", err)
 			}
 
 			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -389,6 +389,11 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 				t.Fatalf("failed to close resources: %v", err)
 			}
 
+			// create dummy codes.dat file
+			if err := writeCodes(nil, filepath.Join(archiveDir, "codes.dat")); err != nil {
+				t.Fatalf("failed to write dummy code file: %v", err)
+			}
+
 			if err := VerifyArchive(archiveDir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("failed to verify archive: %v", err)
 			}
@@ -448,6 +453,11 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 
 			if err := archive.Close(); err != nil {
 				t.Fatalf("failed to close archive: %v", err)
+			}
+
+			// create dummy codes.dat file
+			if err := writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
+				t.Fatalf("failed to write dummy code file: %v", err)
 			}
 
 			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -15,8 +15,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/backend/archive"
-	"golang.org/x/exp/maps"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -25,6 +23,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/backend/archive"
+	"golang.org/x/exp/maps"
 
 	"go.uber.org/mock/gomock"
 
@@ -303,7 +304,7 @@ func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if err := VerifyArchive(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
+	if err := VerifyArchiveTrie(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
 		t.Errorf("verification should fail")
 	}
 }
@@ -388,7 +389,7 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 				t.Fatalf("failed to close resources: %v", err)
 			}
 
-			if err := VerifyArchive(archiveDir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(archiveDir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("failed to verify archive: %v", err)
 			}
 		})
@@ -399,7 +400,7 @@ func TestArchiveTrie_VerificationOfEmptyDirectoryPasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("an empty directory should be fine, got: %v", err)
 			}
 		})
@@ -449,7 +450,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 				t.Fatalf("failed to close archive: %v", err)
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("a freshly closed archive should be fine, got: %v", err)
 			}
 		})
@@ -1080,7 +1081,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 				t.Fatalf("failed to delete file")
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("missing file should be detected")
 			}
 		})
@@ -1127,7 +1128,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 				t.Fatalf("failed to modify file")
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("corrupted file should have been detected")
 			}
 		})

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -304,7 +304,7 @@ func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if err := VerifyArchive(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
+	if err := VerifyArchiveTrie(dir, S5ArchiveConfig, NilVerificationObserver{}); err == nil {
 		t.Errorf("verification should fail")
 	}
 }
@@ -389,7 +389,7 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 				t.Fatalf("failed to close resources: %v", err)
 			}
 
-			if err := VerifyArchive(archiveDir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(archiveDir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("failed to verify archive: %v", err)
 			}
 		})
@@ -400,7 +400,7 @@ func TestArchiveTrie_VerificationOfEmptyDirectoryPasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("an empty directory should be fine, got: %v", err)
 			}
 		})
@@ -450,7 +450,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 				t.Fatalf("failed to close archive: %v", err)
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err != nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("a freshly closed archive should be fine, got: %v", err)
 			}
 		})
@@ -1081,7 +1081,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 				t.Fatalf("failed to delete file")
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("missing file should be detected")
 			}
 		})
@@ -1128,7 +1128,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 				t.Fatalf("failed to modify file")
 			}
 
-			if err := VerifyArchive(dir, config, NilVerificationObserver{}); err == nil {
+			if err := VerifyArchiveTrie(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("corrupted file should have been detected")
 			}
 		})

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -56,7 +56,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
-	if err := mpt.VerifyArchiveTrie(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchive(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
@@ -140,7 +140,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 		t.Errorf("head root hashes do not match: got: %v != want: %v", got, want)
 	}
 
-	if err := mpt.VerifyArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchive(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -56,7 +56,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
-	if err := mpt.VerifyArchive(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchiveTrie(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
@@ -140,7 +140,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 		t.Errorf("head root hashes do not match: got: %v != want: %v", got, want)
 	}
 
-	if err := mpt.VerifyArchive(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -62,7 +62,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
-	if err := mpt.VerifyArchive(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchiveTrie(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -62,7 +62,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
-	if err := mpt.VerifyArchiveTrie(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
+	if err := mpt.VerifyArchive(targetDir, mpt.S5ArchiveConfig, nil); err != nil {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -63,7 +63,7 @@ func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*L
 // VerifyFileLiveTrie validates a file-based live trie stored in the given
 // directory. If the test passes, the data stored in the respective directory
 // can be considered to be a valid Live Trie of the given configuration.
-func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
+func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) (res error) {
 	metadata, exists, err := readMetadata(directory + "/meta.json")
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	return VerifyFileForest(directory, config, []Root{{
+	return VerifyMptState(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -60,11 +60,11 @@ func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*L
 	return makeTrie(directory, forest)
 }
 
-// VerifyMptStateWithLiveTrie validates Mpt state with file-based live trie stored
+// VerifyFileLiveTrie validates Mpt state with file-based live trie stored
 // in the given directory. If the test passes, the data stored in the respective
 // directory can be considered to be a valid Mpt state of the given configuration.
 // This validation contains both Forest and contract codes checks.
-func VerifyMptStateWithLiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
+func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
 	metadata, exists, err := readMetadata(directory + "/meta.json")
 	if err != nil {
 		return err
@@ -73,23 +73,6 @@ func VerifyMptStateWithLiveTrie(directory string, config MptConfig, observer Ver
 		return nil
 	}
 	return VerifyMptState(directory, config, []Root{{
-		NewNodeReference(metadata.RootNode),
-		metadata.RootHash,
-	}}, observer)
-}
-
-// VerifyFileLiveTrie validates a file-based live trie stored in the given
-// directory. If the test passes, the data stored in the respective directory
-// can be considered to be a valid Live Trie of the given configuration.
-func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) (res error) {
-	metadata, exists, err := readMetadata(directory + "/meta.json")
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return nil
-	}
-	return verifyFileForest(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -64,10 +64,6 @@ func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*L
 // directory. If the test passes, the data stored in the respective directory
 // can be considered to be a valid Live Trie of the given configuration.
 func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) (res error) {
-	if observer == nil {
-		observer = NilVerificationObserver{}
-	}
-
 	metadata, exists, err := readMetadata(directory + "/meta.json")
 	if err != nil {
 		return err
@@ -75,26 +71,10 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	observer.StartVerification()
-	defer func() {
-		if r := recover(); r != nil {
-			panic(r)
-		}
-		observer.EndVerification(res)
-	}()
-
-	// Open stock data structures for content verification.
-	observer.Progress("Obtaining read access to files ...")
-	source, err := openVerificationNodeSource(directory, config)
-	if err != nil {
-		return err
-	}
-	defer source.Close()
-
-	return verifyFileForest(directory, config, []Root{{
+	return VerifyMptState(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
-	}}, source, observer)
+	}}, observer)
 }
 
 func makeTrie(

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -60,6 +60,24 @@ func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*L
 	return makeTrie(directory, forest)
 }
 
+// VerifyMptStateWithLiveTrie validates Mpt state with file-based live trie stored
+// in the given directory. If the test passes, the data stored in the respective
+// directory can be considered to be a valid Mpt state of the given configuration.
+// This validation contains both Forest and contract codes checks.
+func VerifyMptStateWithLiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
+	metadata, exists, err := readMetadata(directory + "/meta.json")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	return VerifyMptState(directory, config, []Root{{
+		NewNodeReference(metadata.RootNode),
+		metadata.RootHash,
+	}}, observer)
+}
+
 // VerifyFileLiveTrie validates a file-based live trie stored in the given
 // directory. If the test passes, the data stored in the respective directory
 // can be considered to be a valid Live Trie of the given configuration.
@@ -71,7 +89,7 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	return VerifyMptState(directory, config, []Root{{
+	return verifyFileForest(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -71,7 +71,7 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	return VerifyCodesAndForest(directory, config, []Root{{
+	return VerifyMptState(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -71,7 +71,7 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	return VerifyMptState(directory, config, []Root{{
+	return verifyFileForest(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -71,7 +71,7 @@ func VerifyFileLiveTrie(directory string, config MptConfig, observer Verificatio
 	if !exists {
 		return nil
 	}
-	return VerifyMptState(directory, config, []Root{{
+	return VerifyCodesAndForest(directory, config, []Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
 	}}, observer)

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -60,10 +60,9 @@ func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*L
 	return makeTrie(directory, forest)
 }
 
-// VerifyFileLiveTrie validates Mpt state with file-based live trie stored
-// in the given directory. If the test passes, the data stored in the respective
-// directory can be considered to be a valid Mpt state of the given configuration.
-// This validation contains both Forest and contract codes checks.
+// VerifyFileLiveTrie validates a file-based live trie stored in the given
+// directory. If the test passes, the data stored in the respective directory
+// can be considered to be a valid Live Trie of the given configuration.
 func VerifyFileLiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
 	metadata, exists, err := readMetadata(directory + "/meta.json")
 	if err != nil {

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -777,9 +777,9 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 			}
 
 			// Add some data.
-			trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1)})
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2)})
-			trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3)})
+			trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1), CodeHash: emptyCodeHash})
+			trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2), CodeHash: emptyCodeHash})
+			trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3), CodeHash: emptyCodeHash})
 
 			trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1})
 
@@ -795,6 +795,11 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 
 			if err := trie.Close(); err != nil {
 				t.Fatalf("failed to close trie: %v", err)
+			}
+
+			// create dummy codes.dat file
+			if err := writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
+				t.Fatalf("failed to write dummy code file: %v", err)
 			}
 
 			if err := VerifyFileLiveTrie(dir, config, NilVerificationObserver{}); err != nil {

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -797,11 +797,6 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 				t.Fatalf("failed to close trie: %v", err)
 			}
 
-			// create dummy codes.dat file
-			if err := writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
-				t.Fatalf("failed to write dummy code file: %v", err)
-			}
-
 			if err := VerifyFileLiveTrie(dir, config, NilVerificationObserver{}); err != nil {
 				t.Errorf("a freshly closed LiveTrie should be fine, got: %v", err)
 			}

--- a/go/database/mpt/tool/verify.go
+++ b/go/database/mpt/tool/verify.go
@@ -57,7 +57,7 @@ func verify(context *cli.Context) error {
 	observer := &verificationObserver{}
 
 	if info.Mode == mpt.Immutable {
-		return mpt.VerifyArchive(dir, info.Config, observer)
+		return mpt.VerifyArchiveTrie(dir, info.Config, observer)
 	}
 	return mpt.VerifyFileLiveTrie(dir, info.Config, observer)
 }

--- a/go/database/mpt/tool/verify.go
+++ b/go/database/mpt/tool/verify.go
@@ -57,9 +57,9 @@ func verify(context *cli.Context) error {
 	observer := &verificationObserver{}
 
 	if info.Mode == mpt.Immutable {
-		return mpt.VerifyMptStateWithArchive(dir, info.Config, observer)
+		return mpt.VerifyArchive(dir, info.Config, observer)
 	}
-	return mpt.VerifyMptStateWithLiveTrie(dir, info.Config, observer)
+	return mpt.VerifyFileLiveTrie(dir, info.Config, observer)
 }
 
 type verificationObserver struct {

--- a/go/database/mpt/tool/verify.go
+++ b/go/database/mpt/tool/verify.go
@@ -57,9 +57,9 @@ func verify(context *cli.Context) error {
 	observer := &verificationObserver{}
 
 	if info.Mode == mpt.Immutable {
-		return mpt.VerifyArchive(dir, info.Config, observer)
+		return mpt.VerifyMptStateWithArchive(dir, info.Config, observer)
 	}
-	return mpt.VerifyFileLiveTrie(dir, info.Config, observer)
+	return mpt.VerifyMptStateWithLiveTrie(dir, info.Config, observer)
 }
 
 type verificationObserver struct {

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -42,7 +42,7 @@ func (NilVerificationObserver) StartVerification()        {}
 func (NilVerificationObserver) Progress(msg string)       {}
 func (NilVerificationObserver) EndVerification(res error) {}
 
-// VerifyMptState runs validation checks on the forest and code hashes
+// VerifyCodesAndForest runs validation checks on the forest and code hashes
 // stored in the given directory.
 // Forest checks:
 //   - all required files are present and can be read
@@ -55,7 +55,7 @@ func (NilVerificationObserver) EndVerification(res error) {}
 //     - all byte-codes within the code file matches their hashed representation in accounts
 //  2. Non-fatal checks
 //     - there are no extra Code Hashes not referenced by any account
-func VerifyMptState(directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
+func VerifyCodesAndForest(directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -95,12 +95,7 @@ func VerifyFileForest(directory string, config MptConfig, roots []Root, observer
 	}
 
 	observer.StartVerification()
-	defer func() {
-		if r := recover(); r != nil {
-			panic(r)
-		}
-		observer.EndVerification(res)
-	}()
+	defer observer.EndVerification(res)
 
 	// Open stock data structures for content verification.
 	observer.Progress("Obtaining read access to files ...")

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -61,7 +61,9 @@ func VerifyCodesAndForest(directory string, config MptConfig, roots []Root, obse
 	}
 
 	observer.StartVerification()
-	defer observer.EndVerification(res)
+	defer func() {
+		observer.EndVerification(res)
+	}()
 
 	// Open stock data structures for content verification.
 	observer.Progress("Obtaining read access to files ...")
@@ -95,7 +97,9 @@ func VerifyFileForest(directory string, config MptConfig, roots []Root, observer
 	}
 
 	observer.StartVerification()
-	defer observer.EndVerification(res)
+	defer func() {
+		observer.EndVerification(res)
+	}()
 
 	// Open stock data structures for content verification.
 	observer.Progress("Obtaining read access to files ...")

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -15,6 +15,7 @@ package mpt
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/stock"
@@ -130,12 +131,16 @@ func VerifyFileForest(directory string, config MptConfig, roots []Root, observer
 	}
 
 	// ----------------- Second Pass: check Contract Codes --------------------
+
 	codeFile := directory + "/codes.dat"
+	// make sure the file exists
+	if _, err := os.Stat(codeFile); err != nil {
+		return fmt.Errorf("code file %v does not exist", codeFile)
+	}
 	codes, err := readCodes(codeFile)
 	if err != nil {
 		return err
 	}
-
 	err = verifyContractCodes(codes, source, observer)
 	if err != nil {
 		return err

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -623,7 +623,7 @@ func verifyContractCodes(codes map[common.Hash][]byte, source *verificationNodeS
 	observer.Progress(fmt.Sprintf("There are %d contracts not referenced by any account:", len(codes)))
 
 	for h, bc := range codes {
-		observer.Progress(fmt.Sprintf("%v\n", h))
+		observer.Progress(fmt.Sprintf("%x\n", h))
 		if got, want := common.Keccak256(bc), &h; got.Compare(want) != 0 {
 			return fmt.Errorf("unexpected code hash, got: %x want: %x", got, want)
 		}

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -636,7 +636,7 @@ func verifyContractCodes(directory string, source *verificationNodeSource, obser
 			return nil
 		}
 		// no need to check the hash correctness more than once
-		if _, isChecked := checkedHashes[codeHash]; isChecked {
+		if _, exists := checkedHashes[codeHash]; exists {
 			return nil
 		}
 		// mark an already checked hash
@@ -647,8 +647,8 @@ func verifyContractCodes(directory string, source *verificationNodeSource, obser
 			return fmt.Errorf("hash %x is missing in code file", codeHash)
 		}
 		// check correctness of the code hash
-		if got, want := common.Keccak256(byteCode), &codeHash; got.Compare(want) != 0 {
-			return fmt.Errorf("unexpected code hash for address, got: %x want: %x", got, want)
+		if got, want := common.Keccak256(byteCode), codeHash; got.Compare(&want) != 0 {
+			return fmt.Errorf("unexpected code hash, got: %x want: %x", got, want)
 		}
 		return nil
 	}

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -15,7 +15,7 @@ package mpt
 import (
 	"errors"
 	"fmt"
-	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/stock"
@@ -632,11 +632,7 @@ func verifyHashesStoredWithParents[N any](
 func verifyContractCodes(directory string, source *verificationNodeSource, observer VerificationObserver) error {
 	observer.Progress(fmt.Sprintf("Checking contract codes ..."))
 
-	codeFile := directory + "/codes.dat"
-	// make sure the file exists
-	if _, err := os.Stat(codeFile); err != nil {
-		return fmt.Errorf("code file %v does not exist", codeFile)
-	}
+	codeFile := filepath.Join(directory, "codes.dat")
 	codes, err := readCodes(codeFile)
 	if err != nil {
 		return err

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -42,7 +42,7 @@ func (NilVerificationObserver) StartVerification()        {}
 func (NilVerificationObserver) Progress(msg string)       {}
 func (NilVerificationObserver) EndVerification(res error) {}
 
-// VerifyCodesAndForest runs validation checks on the forest and code hashes
+// VerifyMptState runs validation checks on the forest and code hashes
 // stored in the given directory.
 // Forest checks:
 //   - all required files are present and can be read
@@ -55,7 +55,7 @@ func (NilVerificationObserver) EndVerification(res error) {}
 //     - all byte-codes within the code file matches their hashed representation in accounts
 //  2. Non-fatal checks
 //     - there are no extra Code Hashes not referenced by any account
-func VerifyCodesAndForest(directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
+func VerifyMptState(directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -32,7 +32,6 @@ var forestFiles = []string{
 	"branches/freelist.dat",
 	"branches/meta.json",
 	"branches/values.dat",
-	"codes.dat",
 	"extensions",
 	"extensions/freelist.dat",
 	"extensions/meta.json",
@@ -43,7 +42,7 @@ var forestFiles = []string{
 	"values/values.dat",
 }
 
-func TestVerification_VerifyValidMptState(t *testing.T) {
+func TestVerification_VerifyValidForest(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -417,13 +417,6 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 
 func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		testHash := common.Keccak256([]byte{1})
-		encoder, _, _, _ := getEncoder(config)
-
-		modifyFirstNode(t, filepath.Join(dir, "accounts"), encoder, func(node *AccountNode) {
-			node.info.CodeHash = testHash
-		})
-
 		if err := VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("missing hash in code file should have been detected")
 		}

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -502,10 +502,15 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 		t.Fatalf("failed to start empty forest: %v", err)
 	}
 
+	err = writeCodes(nil, dir+"/codes.dat")
+	if err != nil {
+		t.Fatalf("failed to create codes file: %v", err)
+	}
+
 	root := NewNodeReference(EmptyId())
 
 	addr := common.Address{}
-	root, err = forest.SetAccountInfo(&root, addr, AccountInfo{Nonce: common.ToNonce(1)})
+	root, err = forest.SetAccountInfo(&root, addr, AccountInfo{Nonce: common.ToNonce(1), CodeHash: emptyCodeHash})
 	if err != nil {
 		t.Fatalf("failed to create account: %v", err)
 	}

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -26,6 +26,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const N = 100
+
 var forestFiles = []string{
 	"",
 	"accounts",
@@ -48,7 +50,7 @@ var forestFiles = []string{
 
 func TestVerification_VerifyValidForest(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err != nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -66,7 +68,7 @@ func TestVerification_VerificationObserverIsKeptUpdatedOnEvents(t *testing.T) {
 			observer.EXPECT().EndVerification(nil),
 		)
 
-		if err := VerifyFileForest(dir, config, roots, observer); err != nil {
+		if err := verifyFileForest(dir, config, roots, observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -79,7 +81,7 @@ func TestVerification_MissingFileIsDetected(t *testing.T) {
 				if err := os.RemoveAll(dir + "/" + file); err != nil {
 					t.Fatalf("failed to delete file %v: %v", file, err)
 				}
-				if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 					t.Errorf("The missing file %v should have been detected", file)
 				}
 			})
@@ -113,7 +115,7 @@ func TestVerification_ModifiedFileIsDetected(t *testing.T) {
 					t.Fatalf("failed to write modified file content: %v", err)
 				}
 
-				if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 					t.Errorf("Modified file %v should have been detected", file)
 				}
 			})
@@ -162,7 +164,7 @@ func TestVerification_ModifiedRootIsDetected(t *testing.T) {
 			t.Fatalf("failed to close stock: %v", err)
 		}
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified root node should have been detected")
 		}
 	})
@@ -176,7 +178,7 @@ func TestVerification_AccountBalanceModificationIsDetected(t *testing.T) {
 			node.info.Balance[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -190,7 +192,7 @@ func TestVerification_AccountNonceModificationIsDetected(t *testing.T) {
 			node.info.Nonce[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -204,7 +206,7 @@ func TestVerification_AccountCodeHashModificationIsDetected(t *testing.T) {
 			node.info.CodeHash[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -218,7 +220,7 @@ func TestVerification_AccountStorageModificationIsDetected(t *testing.T) {
 			node.storage = NewNodeReference(ValueId(123456789)) // invalid in test forest
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -235,7 +237,7 @@ func TestVerification_AccountNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[3]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -252,7 +254,7 @@ func TestVerification_AccountStorageHashModificationIsDetected(t *testing.T) {
 			node.storageHash[3]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -266,7 +268,7 @@ func TestVerification_BranchChildIdModificationIsDetected(t *testing.T) {
 			node.children[8] = NewNodeReference(ValueId(123456789)) // does not exist in test forest
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -283,7 +285,7 @@ func TestVerification_BranchNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[4]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -305,7 +307,7 @@ func TestVerification_BranchChildHashModificationIsDetected(t *testing.T) {
 			}
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -319,7 +321,7 @@ func TestVerification_ExtensionPathModificationIsDetected(t *testing.T) {
 			node.path.path[0] = ^node.path.path[0]
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -333,7 +335,7 @@ func TestVerification_ExtensionNextModificationIsDetected(t *testing.T) {
 			node.next = NewNodeReference(BranchId(123456789))
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -350,7 +352,7 @@ func TestVerification_ExtensionNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[24]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -367,7 +369,7 @@ func TestVerification_ExtensionNextHashModificationIsDetected(t *testing.T) {
 			node.nextHash[24]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -381,7 +383,7 @@ func TestVerification_ValueKeyModificationIsDetected(t *testing.T) {
 			node.key[5]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -395,7 +397,7 @@ func TestVerification_ValueModificationIsDetected(t *testing.T) {
 			node.value[12]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -412,7 +414,7 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[12]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -420,13 +422,21 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 
 func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		encoder, _, _, _ := getEncoder(config)
+
+		missingHash := common.Keccak256([]byte{2})
+
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+			node.info.CodeHash = missingHash
+		})
+
 		err := VerifyMptState(dir, config, roots, NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("missing hash in code file should have been detected")
 			return
 		}
 		got := err.Error()
-		want := fmt.Sprintf("hash %x is missing in code file", common.Keccak256([]byte{1}))
+		want := fmt.Sprintf("hash %x is missing in code file", missingHash)
 		if !strings.Contains(got, want) {
 			t.Errorf("unexpected error, got: %v, want: %v", got, want)
 		}
@@ -533,7 +543,7 @@ func TestVerification_PassingNilAsObserverDoesNotFail(t *testing.T) {
 
 func TestVerifyFileForest_PassingNilAsObserverDoesNotFail(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := VerifyFileForest(dir, config, roots, nil); err != nil {
+		if err := verifyFileForest(dir, config, roots, nil); err != nil {
 			t.Errorf("found unexpected error in verification: %v", err)
 		}
 	})
@@ -549,8 +559,16 @@ func TestVerification_DifferentExtraHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
+		err := VerifyMptState(dir, config, roots, NilVerificationObserver{})
+		if err == nil {
 			t.Errorf("different extra hash in code file should have been detected")
+			return
+		}
+		got := err.Error()
+		want := fmt.Sprintf("unexpected code hash, got: %x want: %x", common.Keccak256([]byte{2}), testHash)
+
+		if !strings.Contains(got, want) {
+			t.Errorf("unexpected error, got: %v, want: %v", got, want)
 		}
 	})
 }
@@ -603,7 +621,7 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 	}
 
 	// Run the verification for the trie (which includes embedded nodes).
-	if err := VerifyFileForest(dir, S5LiveConfig, []Root{{root, hash}}, NilVerificationObserver{}); err != nil {
+	if err := verifyFileForest(dir, S5LiveConfig, []Root{{root, hash}}, NilVerificationObserver{}); err != nil {
 		t.Errorf("Unexpected verification error: %v", err)
 	}
 }
@@ -626,7 +644,7 @@ func TestVerification_ForestVerificationObserverReportsError(t *testing.T) {
 			node.info.Balance[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, observer); err == nil {
+		if err := verifyFileForest(dir, config, roots, observer); err == nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -655,6 +673,14 @@ func TestVerification_VerificationObserverReportsError(t *testing.T) {
 	})
 }
 
+func TestVerification_VerifyValidMptState(t *testing.T) {
+	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err != nil {
+			t.Errorf("found unexpected error in fresh mpt: %v", err)
+		}
+	})
+}
+
 func runVerificationTest(t *testing.T, verify func(t *testing.T, dir string, config MptConfig, roots []Root)) {
 	t.Helper()
 	for _, config := range allMptConfigs {
@@ -668,9 +694,20 @@ func runVerificationTest(t *testing.T, verify func(t *testing.T, dir string, con
 				t.Fatalf("failed to create example forest: %v", err)
 			}
 
+			err = fillTestCodeFile(filepath.Join(dir, "codes.dat"))
+			if err != nil {
+				t.Fatalf("failed to create example codes file: %v", err)
+			}
+
 			verify(t, dir, config, roots)
 		})
 	}
+}
+
+func fillTestCodeFile(filename string) error {
+	codes := make(map[common.Hash][]byte)
+	codes[common.Keccak256([]byte{1})] = []byte{1}
+	return writeCodes(codes, filename)
 }
 
 func modifyNode[N any](t *testing.T, directory string, encoder stock.ValueEncoder[N], modify func(n *N)) {
@@ -707,7 +744,7 @@ func modifyNode[N any](t *testing.T, directory string, encoder stock.ValueEncode
 }
 
 func fillTestForest(dir string, config MptConfig) (roots []Root, err error) {
-	const N = 100
+
 	forestConfig := ForestConfig{Mode: Immutable, CacheCapacity: 1024}
 	forest, err := OpenFileForest(dir, config, forestConfig)
 	if err != nil {

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -420,7 +420,7 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 
 func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		err := VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{})
+		err := VerifyMptState(dir, config, roots, NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("missing hash in code file should have been detected")
 			return
@@ -444,7 +444,7 @@ func TestVerification_DifferentHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		err := VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{})
+		err := VerifyMptState(dir, config, roots, NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("different hash in code file should have been detected")
 			return
@@ -484,7 +484,7 @@ func TestVerification_ExtraCodeHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		if err := VerifyCodesAndForest(dir, config, roots, observer); err != nil {
+		if err := VerifyMptState(dir, config, roots, observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 
@@ -512,7 +512,7 @@ func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 			t.Fatalf("failed to close codes file: %v", err)
 		}
 
-		if err = VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err = VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("unreadable code file should have been detected")
 			return
 		}
@@ -527,7 +527,7 @@ func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 
 func TestVerification_PassingNilAsObserverDoesNotFail(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		_ = VerifyCodesAndForest(dir, config, roots, nil)
+		_ = VerifyMptState(dir, config, roots, nil)
 	})
 }
 
@@ -549,7 +549,7 @@ func TestVerification_DifferentExtraHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		if err := VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("different extra hash in code file should have been detected")
 		}
 	})
@@ -649,7 +649,7 @@ func TestVerification_VerificationObserverReportsError(t *testing.T) {
 			node.info.Balance[2]++
 		})
 
-		if err := VerifyCodesAndForest(dir, config, roots, observer); err == nil {
+		if err := VerifyMptState(dir, config, roots, observer); err == nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -512,6 +512,13 @@ func TestVerification_PassingNilAsObserverDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestVerifyFileForest_PassingNilAsObserverDoesNotPanic(t *testing.T) {
+	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		if err := VerifyFileForest(dir, config, roots, nil); err != nil {
+			t.Errorf("found unexpected error in verification: %v", err)
+		}
+	})
+}
 func TestVerification_CodesAreNotCheckedTwice(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		testHash := common.Keccak256([]byte{1})

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -486,7 +486,7 @@ func TestVerification_ContractCodeVerification_ExtraHashInCodeFileIsDetected(t *
 			observer.EXPECT().Progress(fmt.Sprintf("There are %d contracts not referenced by any account:", len(codes))),
 			observer.EXPECT().Progress(fmt.Sprintf("%x\n", testHash)),
 			observer.EXPECT().Progress(gomock.Any()).MinTimes(1),
-			observer.EXPECT().EndVerification(gomock.Any()),
+			observer.EXPECT().EndVerification(nil),
 		)
 
 		if err := writeCodes(codes, dir+"/codes.dat"); err != nil {

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -43,7 +43,7 @@ var forestFiles = []string{
 	"values/values.dat",
 }
 
-func TestVerification_VerifyValidMpt(t *testing.T) {
+func TestVerification_VerifyValidMptState(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
@@ -415,20 +415,6 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 	})
 }
 
-func TestVerification_CodeHashNotContainedInMptIsDetected(t *testing.T) {
-	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		encoder, _, _, _ := getEncoder(config)
-
-		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
-			node.info.CodeHash = common.Hash{1}
-		})
-
-		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
-			t.Errorf("Hash not present in a file should have been detected")
-		}
-	})
-}
-
 func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		testHash := common.Keccak256([]byte{1})
@@ -439,12 +425,12 @@ func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 		})
 
 		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
-			t.Errorf("Missing hash in code file should have been detected")
+			t.Errorf("missing hash in code file should have been detected")
 		}
 	})
 }
 
-func TestVerification_ContractCodeVerification_DifferentHashInCodeFileIsDetected(t *testing.T) {
+func TestVerification_DifferentHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		testHash := common.Keccak256([]byte{1})
 		codes := map[common.Hash][]byte{
@@ -461,7 +447,7 @@ func TestVerification_ContractCodeVerification_DifferentHashInCodeFileIsDetected
 		})
 
 		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
-			t.Errorf("Different hash in code file should have been detected")
+			t.Errorf("different hash in code file should have been detected")
 		}
 	})
 }
@@ -480,7 +466,7 @@ func TestVerification_ExtraCodeHashInCodeFileIsDetected(t *testing.T) {
 			observer.EXPECT().StartVerification(),
 			observer.EXPECT().Progress("Obtaining read access to files ..."),
 			observer.EXPECT().Progress(fmt.Sprintf("Checking contract codes ...")),
-			observer.EXPECT().Progress(fmt.Sprintf("There are %d contracts not referenced by any account:", len(codes))),
+			observer.EXPECT().Progress(fmt.Sprintf("There are %d contracts not referenced by any accounts:", len(codes))),
 			observer.EXPECT().Progress(fmt.Sprintf("%x\n", testHash)),
 			observer.EXPECT().Progress(gomock.Any()).MinTimes(1),
 			observer.EXPECT().EndVerification(nil),

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -43,9 +43,9 @@ var forestFiles = []string{
 	"values/values.dat",
 }
 
-func TestVerification_VerifyValidForest(t *testing.T) {
+func TestVerification_VerifyValidMpt(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err != nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -63,7 +63,7 @@ func TestVerification_VerificationObserverIsKeptUpdatedOnEvents(t *testing.T) {
 			observer.EXPECT().EndVerification(nil),
 		)
 
-		if err := VerifyFileForest(dir, config, roots, observer); err != nil {
+		if err := VerifyMptState(dir, config, roots, observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -76,7 +76,7 @@ func TestVerification_MissingFileIsDetected(t *testing.T) {
 				if err := os.RemoveAll(dir + "/" + file); err != nil {
 					t.Fatalf("failed to delete file %v: %v", file, err)
 				}
-				if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 					t.Errorf("The missing file %v should have been detected", file)
 				}
 			})
@@ -110,7 +110,7 @@ func TestVerification_ModifiedFileIsDetected(t *testing.T) {
 					t.Fatalf("failed to write modified file content: %v", err)
 				}
 
-				if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 					t.Errorf("Modified file %v should have been detected", file)
 				}
 			})
@@ -159,7 +159,7 @@ func TestVerification_ModifiedRootIsDetected(t *testing.T) {
 			t.Fatalf("failed to close stock: %v", err)
 		}
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified root node should have been detected")
 		}
 	})
@@ -173,7 +173,7 @@ func TestVerification_AccountBalanceModificationIsDetected(t *testing.T) {
 			node.info.Balance[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -187,7 +187,7 @@ func TestVerification_AccountNonceModificationIsDetected(t *testing.T) {
 			node.info.Nonce[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -201,7 +201,7 @@ func TestVerification_AccountCodeHashModificationIsDetected(t *testing.T) {
 			node.info.CodeHash[2]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -215,7 +215,7 @@ func TestVerification_AccountStorageModificationIsDetected(t *testing.T) {
 			node.storage = NewNodeReference(ValueId(123456789)) // invalid in test forest
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -232,7 +232,7 @@ func TestVerification_AccountNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[3]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -249,7 +249,7 @@ func TestVerification_AccountStorageHashModificationIsDetected(t *testing.T) {
 			node.storageHash[3]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -263,7 +263,7 @@ func TestVerification_BranchChildIdModificationIsDetected(t *testing.T) {
 			node.children[8] = NewNodeReference(ValueId(123456789)) // does not exist in test forest
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -280,7 +280,7 @@ func TestVerification_BranchNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[4]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -302,7 +302,7 @@ func TestVerification_BranchChildHashModificationIsDetected(t *testing.T) {
 			}
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -316,7 +316,7 @@ func TestVerification_ExtensionPathModificationIsDetected(t *testing.T) {
 			node.path.path[0] = ^node.path.path[0]
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -330,7 +330,7 @@ func TestVerification_ExtensionNextModificationIsDetected(t *testing.T) {
 			node.next = NewNodeReference(BranchId(123456789))
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -347,7 +347,7 @@ func TestVerification_ExtensionNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[24]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -364,7 +364,7 @@ func TestVerification_ExtensionNextHashModificationIsDetected(t *testing.T) {
 			node.nextHash[24]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -378,7 +378,7 @@ func TestVerification_ValueKeyModificationIsDetected(t *testing.T) {
 			node.key[5]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -392,7 +392,7 @@ func TestVerification_ValueModificationIsDetected(t *testing.T) {
 			node.value[12]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -409,13 +409,13 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[12]++
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
 }
 
-func TestVerification_ContractCodeVerification_HashNotContainedIsDetected(t *testing.T) {
+func TestVerification_CodeHashNotContainedInMptIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		encoder, _, _, _ := getEncoder(config)
 
@@ -423,13 +423,13 @@ func TestVerification_ContractCodeVerification_HashNotContainedIsDetected(t *tes
 			node.info.CodeHash = common.Hash{1}
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Hash not present in a file should have been detected")
 		}
 	})
 }
 
-func TestVerification_ContractCodeVerification_MissingHashInCodeFileIsDetected(t *testing.T) {
+func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		testHash := common.Keccak256([]byte{1})
 		encoder, _, _, _ := getEncoder(config)
@@ -438,7 +438,7 @@ func TestVerification_ContractCodeVerification_MissingHashInCodeFileIsDetected(t
 			node.info.CodeHash = testHash
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Missing hash in code file should have been detected")
 		}
 	})
@@ -460,13 +460,13 @@ func TestVerification_ContractCodeVerification_DifferentHashInCodeFileIsDetected
 			node.info.CodeHash = testHash
 		})
 
-		if err := VerifyFileForest(dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := VerifyMptState(dir, config, roots, NilVerificationObserver{}); err == nil {
 			t.Errorf("Different hash in code file should have been detected")
 		}
 	})
 }
 
-func TestVerification_ContractCodeVerification_ExtraHashInCodeFileIsDetected(t *testing.T) {
+func TestVerification_ExtraCodeHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		ctrl := gomock.NewController(t)
 		observer := NewMockVerificationObserver(ctrl)
@@ -478,10 +478,7 @@ func TestVerification_ContractCodeVerification_ExtraHashInCodeFileIsDetected(t *
 
 		gomock.InOrder(
 			observer.EXPECT().StartVerification(),
-			observer.EXPECT().Progress(fmt.Sprintf("Checking forest stored in %s ...", dir)),
-			observer.EXPECT().Progress("Checking meta-data ..."),
 			observer.EXPECT().Progress("Obtaining read access to files ..."),
-			observer.EXPECT().Progress("Checking node references ..."),
 			observer.EXPECT().Progress(fmt.Sprintf("Checking contract codes ...")),
 			observer.EXPECT().Progress(fmt.Sprintf("There are %d contracts not referenced by any account:", len(codes))),
 			observer.EXPECT().Progress(fmt.Sprintf("%x\n", testHash)),
@@ -493,7 +490,7 @@ func TestVerification_ContractCodeVerification_ExtraHashInCodeFileIsDetected(t *
 			t.Fatalf("failed to write code file")
 		}
 
-		if err := VerifyFileForest(dir, config, roots, observer); err != nil {
+		if err := VerifyMptState(dir, config, roots, observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -552,7 +549,7 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 	}
 
 	// Run the verification for the trie (which includes embedded nodes).
-	if err := VerifyFileForest(dir, S5LiveConfig, []Root{{root, hash}}, NilVerificationObserver{}); err != nil {
+	if err := VerifyMptState(dir, S5LiveConfig, []Root{{root, hash}}, NilVerificationObserver{}); err != nil {
 		t.Errorf("Unexpected verification error: %v", err)
 	}
 }

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -169,7 +169,7 @@ func TestVerification_AccountBalanceModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.info.Balance[2]++
 		})
 
@@ -183,7 +183,7 @@ func TestVerification_AccountNonceModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.info.Nonce[2]++
 		})
 
@@ -197,7 +197,7 @@ func TestVerification_AccountCodeHashModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.info.CodeHash[2]++
 		})
 
@@ -211,7 +211,7 @@ func TestVerification_AccountStorageModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.storage = NewNodeReference(ValueId(123456789)) // invalid in test forest
 		})
 
@@ -228,7 +228,7 @@ func TestVerification_AccountNodeHashModificationIsDetected(t *testing.T) {
 		}
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.hash[3]++
 		})
 
@@ -245,7 +245,7 @@ func TestVerification_AccountStorageHashModificationIsDetected(t *testing.T) {
 		}
 		encoder, _, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
+		modifyNode(t, dir+"/accounts", encoder, func(node *AccountNode) {
 			node.storageHash[3]++
 		})
 
@@ -259,7 +259,7 @@ func TestVerification_BranchChildIdModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		_, encoder, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/branches", encoder, func(node *BranchNode) {
+		modifyNode(t, dir+"/branches", encoder, func(node *BranchNode) {
 			node.children[8] = NewNodeReference(ValueId(123456789)) // does not exist in test forest
 		})
 
@@ -276,7 +276,7 @@ func TestVerification_BranchNodeHashModificationIsDetected(t *testing.T) {
 		}
 		_, encoder, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/branches", encoder, func(node *BranchNode) {
+		modifyNode(t, dir+"/branches", encoder, func(node *BranchNode) {
 			node.hash[4]++
 		})
 
@@ -293,7 +293,7 @@ func TestVerification_BranchChildHashModificationIsDetected(t *testing.T) {
 		}
 		_, encoder, _, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/branches", encoder, func(node *BranchNode) {
+		modifyNode(t, dir+"/branches", encoder, func(node *BranchNode) {
 			for i, child := range node.children {
 				if !child.Id().IsEmpty() {
 					node.hashes[i][4]++
@@ -312,7 +312,7 @@ func TestVerification_ExtensionPathModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		_, _, encoder, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
+		modifyNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
 			node.path.path[0] = ^node.path.path[0]
 		})
 
@@ -326,7 +326,7 @@ func TestVerification_ExtensionNextModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		_, _, encoder, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
+		modifyNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
 			node.next = NewNodeReference(BranchId(123456789))
 		})
 
@@ -343,7 +343,7 @@ func TestVerification_ExtensionNodeHashModificationIsDetected(t *testing.T) {
 		}
 		_, _, encoder, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
+		modifyNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
 			node.hash[24]++
 		})
 
@@ -360,7 +360,7 @@ func TestVerification_ExtensionNextHashModificationIsDetected(t *testing.T) {
 		}
 		_, _, encoder, _ := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
+		modifyNode(t, dir+"/extensions", encoder, func(node *ExtensionNode) {
 			node.nextHash[24]++
 		})
 
@@ -374,7 +374,7 @@ func TestVerification_ValueKeyModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		_, _, _, encoder := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/values", encoder, func(node *ValueNode) {
+		modifyNode(t, dir+"/values", encoder, func(node *ValueNode) {
 			node.key[5]++
 		})
 
@@ -388,7 +388,7 @@ func TestVerification_ValueModificationIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 		_, _, _, encoder := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/values", encoder, func(node *ValueNode) {
+		modifyNode(t, dir+"/values", encoder, func(node *ValueNode) {
 			node.value[12]++
 		})
 
@@ -405,7 +405,7 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 		}
 		_, _, _, encoder := getEncoder(config)
 
-		modifyFirstNode(t, dir+"/values", encoder, func(node *ValueNode) {
+		modifyNode(t, dir+"/values", encoder, func(node *ValueNode) {
 			node.hash[12]++
 		})
 
@@ -474,16 +474,15 @@ func TestVerification_ExtraCodeHashInCodeFileIsDetected(t *testing.T) {
 
 func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		// create code file
+		if err := writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
+			t.Fatalf("failed to create codes file: %v", err)
+		}
+		// corrupt it
 		f, err := os.OpenFile(filepath.Join(dir, "codes.dat"), os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 		if err != nil {
 			t.Fatalf("failed to open codes file: %v", err)
 		}
-		// create code file
-		if err = writeCodes(nil, filepath.Join(dir, "codes.dat")); err != nil {
-			t.Fatalf("failed to create codes file: %v", err)
-		}
-		// corrupt it
-
 		if _, err = f.Write([]byte{1}); err != nil {
 			t.Fatalf("failed to open write to codes file: %v", err)
 		}
@@ -510,27 +509,10 @@ func TestVerifyFileForest_PassingNilAsObserverDoesNotFail(t *testing.T) {
 		}
 	})
 }
-func TestVerification_CodesAreNotCheckedTwice(t *testing.T) {
-	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		testHash := common.Keccak256([]byte{1})
-		codes := map[common.Hash][]byte{
-			testHash: {1},
-		}
-		if err := writeCodes(codes, filepath.Join(dir, "codes.dat")); err != nil {
-			t.Fatalf("failed to write code file")
-		}
-
-		// TODO - this got broken, but it's not clear what the test is supposed to do
-		// how does it ensure that codes are not checked twice?
-		if err := VerifyCodesAndForest(dir, config, roots, NilVerificationObserver{}); err == nil {
-			t.Errorf("modified node should have been detected")
-		}
-	})
-}
 
 func TestVerification_DifferentExtraHashInCodeFileIsDetected(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		testHash := common.Keccak256([]byte{1})
+		testHash := common.Keccak256([]byte{3})
 		codes := map[common.Hash][]byte{
 			testHash: {2},
 		}
@@ -615,7 +597,7 @@ func runVerificationTest(t *testing.T, verify func(t *testing.T, dir string, con
 	}
 }
 
-func modifyFirstNode[N any](t *testing.T, directory string, encoder stock.ValueEncoder[N], modify func(n *N)) {
+func modifyNode[N any](t *testing.T, directory string, encoder stock.ValueEncoder[N], modify func(n *N)) {
 	t.Helper()
 	stock, err := file.OpenStock[uint64](encoder, directory)
 	if err != nil {
@@ -632,10 +614,6 @@ func modifyFirstNode[N any](t *testing.T, directory string, encoder stock.ValueE
 		t.SkipNow()
 	}
 
-	modifyNode(t, stock, idx, modify)
-}
-
-func modifyNode[N any](t *testing.T, stock stock.Stock[uint64, N], idx uint64, modify func(n *N)) {
 	node, err := stock.Get(idx)
 	if err != nil {
 		t.Fatalf("failed to load node from stock: %v", err)
@@ -700,15 +678,6 @@ func isDirectory(path string) bool {
 
 func getFirstElementInSet(set stock.IndexSet[uint64]) (uint64, bool) {
 	for i := set.GetLowerBound(); i < set.GetUpperBound(); i++ {
-		if set.Contains(i) {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-func getLastElementInSet(set stock.IndexSet[uint64]) (uint64, bool) {
-	for i := set.GetUpperBound(); i >= set.GetLowerBound(); i-- {
 		if set.Contains(i) {
 			return i, true
 		}

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -645,7 +645,7 @@ func TestVerification_ForestVerificationObserverReportsError(t *testing.T) {
 		})
 
 		if err := verifyFileForest(dir, config, roots, observer); err == nil {
-			t.Errorf("found unexpected error in fresh forest: %v", err)
+			t.Errorf("Modified node should have been detected")
 		}
 	})
 }
@@ -668,7 +668,7 @@ func TestVerification_VerificationObserverReportsError(t *testing.T) {
 		})
 
 		if err := VerifyMptState(dir, config, roots, observer); err == nil {
-			t.Errorf("found unexpected error in fresh forest: %v", err)
+			t.Errorf("Modified node should have been detected")
 		}
 	})
 }


### PR DESCRIPTION
This PR adds contract codes verification.

1. Verifies that byte code and inside `codes.dat` match
2. Verifies that any `CodeHash` within a `Forest` is contained within `codes.dat`
3. Warns if there are any codes inside `codes.dat` that are not present within a `Forest`

Fixes #736 