### PR TITLE
Prevent license script paths expansion

### DIFF
--- a/scripts/license/add_license_header.sh
+++ b/scripts/license/add_license_header.sh
@@ -70,11 +70,18 @@ add_license_to_files() {
     local license_header="$(extend_license_header "$prefix")"
     local result=0
 
-    # expand list if ignored files to a single string
-    local ignore=$(printf " ! -path *%s" "${ignore_files[@]}")
+    # Create an array for the find command arguments
+    # This approach prevents the shell from expanding the wildcard
+    # characters in the ignore_files array, which would happen if
+    # we called the script from a directory containing files/directories
+    # that match the wildcard characters.
+    local find_args=("$root_dir" -type f -name "*$file_extension")
+    for pattern in "${ignore_files[@]}"; do
+        find_args+=(! -path "*$pattern")
+    done
 
     # Get a list of all files in the project directory
-    local all_files=($(find "$root_dir" -type f -name "*$file_extension" $ignore))
+    local all_files=($(find "${find_args[@]}"))
 
     # Iterate over all files and add the license header if needed
     for f in "${all_files[@]}"; do

--- a/scripts/license/add_license_header.sh
+++ b/scripts/license/add_license_header.sh
@@ -73,7 +73,7 @@ add_license_to_files() {
     # Create an array for the find command arguments
     # This approach prevents the shell from expanding the wildcard
     # characters in the ignore_files array, which would happen if
-    # we called the script from a directory containing files/directories
+    # the script was called from a directory containing files/directories
     # that match the wildcard characters.
     local find_args=("$root_dir" -type f -name "*$file_extension")
     for pattern in "${ignore_files[@]}"; do


### PR DESCRIPTION
This change prevents bash to expand wildcard paths. If the script was run from a directory that contains any of wildcard paths defined in `ignore_files` (`ignore_files=('cpp/third_party/*')`), it led to expansion of those paths and calling the `find` method with wrong argument. In this particular case it expanded as follows:
```
! -path cpp/third_party/crc32c cpp/third_party/ethash cpp/third_party/gperftools cpp/third_party/leveldb cpp/third_party/snappy
```
The correct way of passing `! path` argument to `find` method is
```
! -path <path_1> ! -path <path_2> ...
```

The arguments are passed into `find` function via arguments list, which prematurely prevents the expansion of wildcard paths.