### PR TITLE
Has empty storage

### DIFF
--- a/go/backend/archive/archive.go
+++ b/go/backend/archive/archive.go
@@ -27,6 +27,9 @@ type Archive interface {
 	// Add adds the changes of the given block to this archive.
 	Add(block uint64, update common.Update, hints any) error
 
+	// HasEmptyStorage returns true if account has empty storage in given block.
+	HasEmptyStorage(block uint64, address common.Address) (bool, error)
+
 	// GetBlockHeight gets the maximum block height inserted so far. If there
 	// is no block in the archive, the empty flag is set instead.
 	GetBlockHeight() (block uint64, empty bool, err error)

--- a/go/backend/archive/archive_mock.go
+++ b/go/backend/archive/archive_mock.go
@@ -225,3 +225,18 @@ func (mr *MockArchiveMockRecorder) GetStorage(block, account, slot any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockArchive)(nil).GetStorage), block, account, slot)
 }
+
+// HasEmptyStorage mocks base method.
+func (m *MockArchive) HasEmptyStorage(block uint64, address common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", block, address)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockArchiveMockRecorder) HasEmptyStorage(block, address any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockArchive)(nil).HasEmptyStorage), block, address)
+}

--- a/go/backend/archive/ldb/archive.go
+++ b/go/backend/archive/ldb/archive.go
@@ -13,9 +13,10 @@ package ldb
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/backend"
 	"sync"
 	"unsafe"
+
+	"github.com/Fantom-foundation/Carmen/go/backend"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/archive"
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -299,6 +300,10 @@ func (a *Archive) GetStorage(block uint64, account common.Address, slot common.K
 		return value, nil
 	}
 	return common.Value{}, it.Error()
+}
+func (a *Archive) HasEmptyStorage(block uint64, address common.Address) (bool, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (a *Archive) GetHash(block uint64) (hash common.Hash, err error) {

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -12,6 +12,7 @@ package carmen
 
 import (
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
@@ -265,6 +266,9 @@ type TransactionContext interface {
 	// stored in the account with the given address.
 	SetState(Address, Key, Value)
 
+	// HasEmptyStorage returns true if account has empty storage.
+	HasEmptyStorage(Address) tribool.Tribool
+
 	// GetTransientState retrieves the value associated with a specific
 	// key within the transient state storage at a given address.
 	// Transient State is an in-memory storage
@@ -377,6 +381,9 @@ type QueryContext interface {
 	// This method returns an ongoing value that could be
 	// updated in the current transaction.
 	GetState(Address, Key) Value
+
+	// HasEmptyStorage returns true if account has empty storage.
+	HasEmptyStorage(Address) tribool.Tribool
 
 	// GetCode returns smart contract byte-code
 	// of an account with the given address.

--- a/go/carmen/query.go
+++ b/go/carmen/query.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
@@ -56,6 +57,22 @@ func (c *queryContext) GetState(address Address, key Key) Value {
 		return Value{}
 	}
 	return Value(res)
+}
+
+func (c *queryContext) HasEmptyStorage(address Address) tribool.Tribool {
+	if c.err != nil {
+		return tribool.Unknown()
+	}
+
+	isEmpty, err := c.state.HasEmptyStorage(common.Address(address))
+	if err != nil {
+		c.err = err
+		return tribool.Unknown()
+	}
+	if isEmpty {
+		return tribool.True()
+	}
+	return tribool.False()
 }
 
 func (c *queryContext) GetCode(address Address) []byte {

--- a/go/carmen/transaction.go
+++ b/go/carmen/transaction.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
@@ -110,6 +111,13 @@ func (t *transactionContext) SetState(address Address, key Key, value Value) {
 	if t.state != nil {
 		t.state.SetState(common.Address(address), common.Key(key), common.Value(value))
 	}
+}
+
+func (t *transactionContext) HasEmptyStorage(address Address) tribool.Tribool {
+	if t.state != nil {
+		return t.state.HasEmptyStorage(common.Address(address))
+	}
+	return tribool.Unknown()
 }
 
 func (t *transactionContext) GetTransientState(address Address, key Key) Value {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -224,6 +224,13 @@ func (a *ArchiveTrie) GetStorage(block uint64, account common.Address, slot comm
 	}
 	return view.GetValue(account, slot)
 }
+func (a *ArchiveTrie) HasEmptyStorage(block uint64, address common.Address) (bool, error) {
+	view, err := a.getView(block)
+	if err != nil {
+		return false, a.addError(err)
+	}
+	return view.HasEmptyStorage(address)
+}
 
 func (a *ArchiveTrie) GetAccountHash(block uint64, account common.Address) (common.Hash, error) {
 	return common.Hash{}, fmt.Errorf("not implemented")

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1420,6 +1420,76 @@ func TestArchiveTrie_FailingGetterOperation_InvalidatesArchive(t *testing.T) {
 	}
 }
 
+func TestArchiveTrie_HasEmptyStorage(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
+			if err != nil {
+				t.Fatalf("failed to open empty archive: %v", err)
+			}
+
+			addr := common.Address{0xA}
+			key := common.Key{0xB}
+			val := common.Value{0xC}
+
+			// create an account with a non-empty slot
+			update := common.Update{}
+			update.AppendCreateAccount(addr)
+			if err := archive.Add(0, update, nil); err != nil {
+				t.Errorf("cannot add update: %s", err)
+			}
+
+			isEmpty, err := archive.HasEmptyStorage(0, addr)
+			if err != nil {
+				t.Errorf("failed to ask whether account has empty storage; %s", err)
+			}
+			if !isEmpty {
+				t.Fatal("fresh account has empty storage but archive returned true")
+			}
+
+			update.AppendSlotUpdate(addr, key, val)
+			if err := archive.Add(1, update, nil); err != nil {
+				t.Errorf("cannot add update: %s", err)
+			}
+
+			isEmpty, err = archive.HasEmptyStorage(1, addr)
+			if err != nil {
+				t.Errorf("failed to ask whether account has empty storage; %s", err)
+			}
+			if isEmpty {
+				t.Fatal("storage is not empty but archive returned true")
+			}
+
+			// re-create an account in the next block
+			update = common.Update{}
+			update.AppendCreateAccount(addr)
+			if err := archive.Add(2, update, nil); err != nil {
+				t.Errorf("cannot add update: %s", err)
+			}
+
+			// verify that the account is re-created with an empty slot
+			exists, err := archive.Exists(2, addr)
+			if err != nil {
+				t.Errorf("cannot check account existence: %s", err)
+			}
+			if !exists {
+				t.Errorf("account does not exist")
+			}
+			isEmpty, err = archive.HasEmptyStorage(2, addr)
+			if err != nil {
+				t.Errorf("failed to ask whether account has empty storage; %s", err)
+			}
+			if !isEmpty {
+				t.Fatal("re-created account has empty storage but archive returned true")
+			}
+
+			if err := archive.Close(); err != nil {
+				t.Fatalf("failed to close empty archive: %v", err)
+			}
+		})
+	}
+}
+
 func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 	injectedErr := fmt.Errorf("injectedError")
 

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -383,6 +383,18 @@ func (s *Forest) SetValue(rootRef *NodeReference, addr common.Address, key commo
 	return newRoot, err
 }
 
+func (s *Forest) HasEmptyStorage(rootRef *NodeReference, addr common.Address) (bool, error) {
+	handle, err := s.getReadAccess(rootRef)
+	if err != nil {
+		err = fmt.Errorf("failed to obtain read access to node %v: %w", rootRef.Id(), err)
+		s.errors = append(s.errors, err)
+		return false, err
+	}
+	defer handle.Release()
+	path := AddressToNibblePath(addr, s)
+	return handle.Get().HasEmptyStorage(s, path)
+}
+
 func (s *Forest) ClearStorage(rootRef *NodeReference, addr common.Address) (NodeReference, error) {
 	root, err := s.getWriteAccess(rootRef)
 	if err != nil {

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -105,6 +105,10 @@ func getTrieView(root NodeReference, forest Database) *LiveTrie {
 	}
 }
 
+func (s *LiveTrie) HasEmptyStorage(addr common.Address) (bool, error) {
+	return s.forest.HasEmptyStorage(&s.root, addr)
+}
+
 func (s *LiveTrie) GetAccountInfo(addr common.Address) (AccountInfo, bool, error) {
 	return s.forest.GetAccountInfo(&s.root, addr)
 }

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -698,6 +698,14 @@ func TestLiveTrie_DeleteLargeAccount(t *testing.T) {
 				t.Errorf("delete took too long: %v, limit %v", duration, limit)
 			}
 
+			isEmpty, err := trie.HasEmptyStorage(addr)
+			if err != nil {
+				t.Errorf("failed to ask whether account has empty storage; %s", err)
+			}
+			if !isEmpty {
+				t.Error("storage was cleared but trie does not report so")
+			}
+
 			if _, _, err := trie.UpdateHashes(); err != nil {
 				t.Fatalf("failed to update hashes: %v", err)
 			}
@@ -888,6 +896,57 @@ func TestLiveTrie_VerificationOfLiveTrieWithCorruptedFileFails(t *testing.T) {
 
 			if err := VerifyFileLiveTrie(dir, config, NilVerificationObserver{}); err == nil {
 				t.Errorf("corrupted file should have been detected")
+			}
+		})
+	}
+}
+
+func TestLiveTrie_HasEmptyStorage(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			dir := t.TempDir()
+			trie, err := OpenFileLiveTrie(dir, config, 1024)
+			if err != nil {
+				t.Fatalf("failed to create empty trie, err %v", err)
+			}
+
+			addr := common.Address{1}
+			// Add some data.
+			err = trie.SetAccountInfo(addr, AccountInfo{Nonce: common.ToNonce(1), CodeHash: emptyCodeHash})
+			if err != nil {
+				t.Fatalf("failed to set account info: %v", err)
+			}
+
+			isEmpty, err := trie.HasEmptyStorage(addr)
+			if err != nil {
+				t.Fatalf("failed to ask whether account has empty storage: %v", err)
+			}
+			if !isEmpty {
+				t.Error("freshly created account has empty storage, but trie returned false")
+			}
+
+			err = trie.SetValue(addr, common.Key{1}, common.Value{1})
+			if err != nil {
+				t.Fatalf("failed to set value: %v", err)
+			}
+
+			isEmpty, err = trie.HasEmptyStorage(addr)
+			if err != nil {
+				t.Fatalf("failed to ask whether account has empty storage: %v", err)
+			}
+			if isEmpty {
+				t.Error("storage is not empty, but trie returned false")
+			}
+
+			// Delete some data.
+			trie.SetAccountInfo(common.Address{2}, AccountInfo{})
+
+			if err := trie.Close(); err != nil {
+				t.Fatalf("failed to close trie: %v", err)
+			}
+
+			if err := VerifyFileLiveTrie(dir, config, NilVerificationObserver{}); err != nil {
+				t.Errorf("a freshly closed LiveTrie should be fine, got: %v", err)
 			}
 		})
 	}

--- a/go/database/mpt/nodes_mocks.go
+++ b/go/database/mpt/nodes_mocks.go
@@ -172,6 +172,21 @@ func (mr *MockNodeMockRecorder) GetValue(source, key, path any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockNode)(nil).GetValue), source, key, path)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockNode) HasEmptyStorage(source NodeSource, path []Nibble) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", source, path)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockNodeMockRecorder) HasEmptyStorage(source, path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockNode)(nil).HasEmptyStorage), source, path)
+}
+
 // IsDirty mocks base method.
 func (m *MockNode) IsDirty() bool {
 	m.ctrl.T.Helper()
@@ -795,6 +810,21 @@ func (m *MockleafNode) GetValue(source NodeSource, key common.Key, path []Nibble
 func (mr *MockleafNodeMockRecorder) GetValue(source, key, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockleafNode)(nil).GetValue), source, key, path)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockleafNode) HasEmptyStorage(source NodeSource, path []Nibble) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", source, path)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockleafNodeMockRecorder) HasEmptyStorage(source, path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockleafNode)(nil).HasEmptyStorage), source, path)
 }
 
 // IsDirty mocks base method.

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -236,6 +236,19 @@ func TestEmptyNode_ChecksDoNotProduceErrors(t *testing.T) {
 	}
 }
 
+func TestEmptyNode_HasEmptyStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := NewMockNodeManager(ctrl)
+
+	addr := common.Address{1}
+
+	empty := EmptyNode{}
+	path := addressToNibbles(addr)
+	if isEmpty, err := empty.HasEmptyStorage(mgr, path[:]); !isEmpty || err != nil {
+		t.Fatalf("unexpected result, got: %v, want %v, err %v", isEmpty, false, err)
+	}
+}
+
 // ----------------------------------------------------------------------------
 //                               Branch Node
 // ----------------------------------------------------------------------------
@@ -2529,6 +2542,25 @@ func TestAccountNode_GetAccount(t *testing.T) {
 	}
 }
 
+func TestAccountNode_HasEmptyStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := NewMockNodeManager(ctrl)
+	addr := common.Address{1}
+	node := &AccountNode{address: addr}
+
+	// Case 1: the node does not have a storage reference.
+	path := addressToNibbles(addr)
+	if isEmpty, err := node.HasEmptyStorage(mgr, path[:]); !isEmpty || err != nil {
+		t.Fatalf("unexpected result, got: %v, want: %v, err: %v", isEmpty, true, err)
+	}
+
+	// Case 2: the node has a storage reference.
+	node.storage = NewNodeReference(ValueId(11))
+	if isEmpty, err := node.HasEmptyStorage(mgr, path[:]); isEmpty || err != nil {
+		t.Fatalf("unexpected result, got: %v, want: %v, err: %v", isEmpty, false, err)
+	}
+}
+
 func TestAccountNode_SetAccount_WithMatchingAccount_SameInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctxt := newNodeContext(t, ctrl)
@@ -3788,6 +3820,19 @@ func TestValueNode_SetAccount(t *testing.T) {
 
 	if _, _, err := node.SetAccount(ctxt, &ref, shared.WriteHandle[Node]{}, addr, path[:], info); err == nil {
 		t.Fatalf("SetAccount call should always return an error")
+	}
+}
+
+func TestValueNode_HasEmptyStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctxt := newNodeContext(t, ctrl)
+
+	node := &ValueNode{}
+
+	addr := common.Address{}
+	path := addressToNibbles(addr)
+	if _, err := node.HasEmptyStorage(ctxt, path[:]); err == nil {
+		t.Fatalf("HasEmptyStorage call should always return an error")
 	}
 }
 

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -65,6 +65,9 @@ type Database interface {
 	// ClearStorage removes all storage slots for the input address and the root.
 	ClearStorage(rootRef *NodeReference, addr common.Address) (NodeReference, error)
 
+	// HasEmptyStorage returns true if account has empty storage.
+	HasEmptyStorage(rootRef *NodeReference, addr common.Address) (bool, error)
+
 	// Freeze seals current trie, preventing further updates to it.
 	Freeze(ref *NodeReference) error
 
@@ -297,7 +300,9 @@ func (s *MptState) GetStorage(address common.Address, key common.Key) (value com
 func (s *MptState) SetStorage(address common.Address, key common.Key, value common.Value) error {
 	return s.trie.SetValue(address, key, value)
 }
-
+func (s *MptState) HasEmptyStorage(address common.Address) (bool, error) {
+	return s.trie.HasEmptyStorage(address)
+}
 func (s *MptState) GetCode(address common.Address) (value []byte, err error) {
 	info, exists, err := s.trie.GetAccountInfo(address)
 	if err != nil {

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -206,6 +206,21 @@ func (mr *MockDatabaseMockRecorder) GetValue(rootRef, addr, key any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockDatabase)(nil).GetValue), rootRef, addr, key)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockDatabase) HasEmptyStorage(rootRef *NodeReference, addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", rootRef, addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockDatabaseMockRecorder) HasEmptyStorage(rootRef, addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockDatabase)(nil).HasEmptyStorage), rootRef, addr)
+}
+
 // SetAccountInfo mocks base method.
 func (m *MockDatabase) SetAccountInfo(rootRef *NodeReference, addr common.Address, info AccountInfo) (NodeReference, error) {
 	m.ctrl.T.Helper()
@@ -549,6 +564,21 @@ func (m *MockLiveState) GetStorage(address common.Address, key common.Key) (comm
 func (mr *MockLiveStateMockRecorder) GetStorage(address, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockLiveState)(nil).GetStorage), address, key)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockLiveState) HasEmptyStorage(address common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", address)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockLiveStateMockRecorder) HasEmptyStorage(address any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockLiveState)(nil).HasEmptyStorage), address)
 }
 
 // Root mocks base method.

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -44,6 +44,11 @@ type CppState struct {
 	codeCache *common.LruCache[common.Address, []byte]
 }
 
+func (cs *CppState) HasEmptyStorage(address common.Address) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func newState(impl C.enum_StateImpl, params state.Parameters) (state.State, error) {
 	if err := os.MkdirAll(filepath.Join(params.Directory, "live"), 0700); err != nil {
 		return nil, err

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -77,6 +77,10 @@ func (s *ArchiveState) GetStorage(address common.Address, key common.Key) (commo
 	return storage, s.archiveError
 }
 
+func (s *ArchiveState) HasEmptyStorage(address common.Address) (bool, error) {
+	return s.archive.HasEmptyStorage(s.block, address)
+}
+
 func (s *ArchiveState) GetCode(address common.Address) ([]byte, error) {
 	if err := s.archiveError; err != nil {
 		return []byte{}, err

--- a/go/state/gostate/go_schema1.go
+++ b/go/state/gostate/go_schema1.go
@@ -187,6 +187,11 @@ func (s *GoSchema1) SetStorage(address common.Address, key common.Key, value com
 	return err
 }
 
+func (s *GoSchema1) HasEmptyStorage(address common.Address) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (s *GoSchema1) GetCode(address common.Address) (value []byte, err error) {
 	idx, err := s.addressIndex.Get(address)
 	if err != nil {

--- a/go/state/gostate/go_schema2.go
+++ b/go/state/gostate/go_schema2.go
@@ -174,6 +174,11 @@ func (s *GoSchema2) SetStorage(address common.Address, key common.Key, value com
 	return err
 }
 
+func (s *GoSchema2) HasEmptyStorage(address common.Address) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (s *GoSchema2) GetCode(address common.Address) (value []byte, err error) {
 	idx, err := s.addressIndex.Get(address)
 	if err != nil {

--- a/go/state/gostate/go_schema3.go
+++ b/go/state/gostate/go_schema3.go
@@ -180,6 +180,11 @@ func (s *GoSchema3) SetStorage(address common.Address, key common.Key, value com
 	})
 }
 
+func (s *GoSchema3) HasEmptyStorage(address common.Address) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (s *GoSchema3) GetCode(address common.Address) (value []byte, err error) {
 	idx, err := s.addressIndex.Get(address)
 	if err != nil {

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -96,6 +96,18 @@ type archiveUpdate = struct {
 	updateHints common.Releaser // an optional field for passing update hints from the LiveDB to the Archive
 }
 
+func (s *GoState) HasEmptyStorage(address common.Address) (bool, error) {
+	if err := s.stateError; err != nil {
+		return false, err
+	}
+
+	isEmpty, err := s.live.HasEmptyStorage(address)
+	if err != nil {
+		s.stateError = errors.Join(s.stateError, err)
+	}
+	return isEmpty, s.stateError
+}
+
 func (s *GoState) Exists(address common.Address) (bool, error) {
 	if err := s.stateError; err != nil {
 		return false, err

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -35,6 +35,9 @@ type State interface {
 	// GetStorage returns the memory slot for the account address (i.e. the contract) and the memory location key.
 	GetStorage(address common.Address, key common.Key) (common.Value, error)
 
+	// HasEmptyStorage returns true if given account has empty storage.
+	HasEmptyStorage(address common.Address) (bool, error)
+
 	// GetCode returns code of the contract for the input contract address.
 	GetCode(address common.Address) ([]byte, error)
 
@@ -85,6 +88,7 @@ type LiveDB interface {
 	GetBalance(address common.Address) (balance common.Balance, err error)
 	GetNonce(address common.Address) (nonce common.Nonce, err error)
 	GetStorage(address common.Address, key common.Key) (value common.Value, err error)
+	HasEmptyStorage(address common.Address) (bool, error)
 	GetCode(address common.Address) (value []byte, err error)
 	GetCodeSize(address common.Address) (size int, err error)
 	GetCodeHash(address common.Address) (hash common.Hash, err error)

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -52,6 +52,7 @@ type VmStateDB interface {
 	SetState(common.Address, common.Key, common.Value)
 	GetTransientState(common.Address, common.Key) common.Value
 	SetTransientState(common.Address, common.Key, common.Value)
+	HasEmptyStorage(common.Address) bool
 
 	// Code management.
 	GetCode(common.Address) []byte
@@ -847,6 +848,15 @@ func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value c
 	})
 
 	s.transientStorage.Put(sid, value)
+}
+
+func (s *stateDB) HasEmptyStorage(address common.Address) bool {
+	isEmpty, err := s.state.HasEmptyStorage(address)
+	if err != nil {
+		s.errors = append(s.errors, fmt.Errorf("unable to obtain info about accounts storage for: %x :%w", address, err))
+		return false
+	}
+	return isEmpty
 }
 
 func (s *stateDB) GetCode(addr common.Address) []byte {

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source state_db.go -destination state_db_mock.go -package state
 //
+
 // Package state is a generated GoMock package.
 package state
 
@@ -377,6 +378,20 @@ func (m *MockVmStateDB) GetTransientState(arg0 common.Address, arg1 common.Key) 
 func (mr *MockVmStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockVmStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockVmStateDB) HasEmptyStorage(arg0 common.Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockVmStateDBMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockVmStateDB)(nil).HasEmptyStorage), arg0)
 }
 
 // HasSuicided mocks base method.
@@ -1008,6 +1023,20 @@ func (mr *MockStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockStateDB)(nil).GetTransientState), arg0, arg1)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockStateDB) HasEmptyStorage(arg0 common.Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockStateDBMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockStateDB)(nil).HasEmptyStorage), arg0)
+}
+
 // HasSuicided mocks base method.
 func (m *MockStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -1554,6 +1583,20 @@ func (m *MockNonCommittableStateDB) GetTransientState(arg0 common.Address, arg1 
 func (mr *MockNonCommittableStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockNonCommittableStateDB) HasEmptyStorage(arg0 common.Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockNonCommittableStateDBMockRecorder) HasEmptyStorage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockNonCommittableStateDB)(nil).HasEmptyStorage), arg0)
 }
 
 // HasSuicided mocks base method.

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -24,6 +24,7 @@ import (
 	reflect "reflect"
 
 	common "github.com/Fantom-foundation/Carmen/go/common"
+	tribool "github.com/Fantom-foundation/Carmen/go/common/tribool"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -381,10 +382,10 @@ func (mr *MockVmStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.C
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockVmStateDB) HasEmptyStorage(arg0 common.Address) bool {
+func (m *MockVmStateDB) HasEmptyStorage(arg0 common.Address) tribool.Tribool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(tribool.Tribool)
 	return ret0
 }
 
@@ -1024,10 +1025,10 @@ func (mr *MockStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Cal
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockStateDB) HasEmptyStorage(arg0 common.Address) bool {
+func (m *MockStateDB) HasEmptyStorage(arg0 common.Address) tribool.Tribool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(tribool.Tribool)
 	return ret0
 }
 
@@ -1586,10 +1587,10 @@ func (mr *MockNonCommittableStateDBMockRecorder) GetTransientState(arg0, arg1 an
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockNonCommittableStateDB) HasEmptyStorage(arg0 common.Address) bool {
+func (m *MockNonCommittableStateDB) HasEmptyStorage(arg0 common.Address) tribool.Tribool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", arg0)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(tribool.Tribool)
 	return ret0
 }
 

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4389,6 +4389,24 @@ func TestNonCommittableStateDB_resetState_ClearsTransientStorage(t *testing.T) {
 	}
 }
 
+func TestStateDB_HasEmptyStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockState(ctrl)
+	db := CreateStateDBUsing(mock)
+
+	mock.EXPECT().HasEmptyStorage(address1).Return(false, nil)
+	mock.EXPECT().HasEmptyStorage(address1).Return(true, nil)
+
+	db.CreateAccount(address1)
+
+	if isEmpty := db.HasEmptyStorage(address1); isEmpty {
+		t.Errorf("unexpected return, got: %v want: %v", isEmpty, false)
+	}
+	if isEmpty := db.HasEmptyStorage(address1); !isEmpty {
+		t.Errorf("unexpected return, got: %v want: %v", isEmpty, true)
+	}
+}
+
 type sameEffectAs struct {
 	want common.Update
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4394,15 +4394,16 @@ func TestStateDB_HasEmptyStorage(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
+	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().HasEmptyStorage(address1).Return(false, nil)
 	mock.EXPECT().HasEmptyStorage(address1).Return(true, nil)
 
 	db.CreateAccount(address1)
 
-	if isEmpty := db.HasEmptyStorage(address1); isEmpty {
+	if isEmpty := db.HasEmptyStorage(address1); !isEmpty.False() {
 		t.Errorf("unexpected return, got: %v want: %v", isEmpty, false)
 	}
-	if isEmpty := db.HasEmptyStorage(address1); !isEmpty {
+	if isEmpty := db.HasEmptyStorage(address1); !isEmpty.True() {
 		t.Errorf("unexpected return, got: %v want: %v", isEmpty, true)
 	}
 }

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -316,6 +316,21 @@ func (mr *MockStateMockRecorder) GetStorage(address, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockState)(nil).GetStorage), address, key)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockState) HasEmptyStorage(address common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", address)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockStateMockRecorder) HasEmptyStorage(address any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockState)(nil).HasEmptyStorage), address)
+}
+
 // Restore mocks base method.
 func (m *MockState) Restore(data backend.SnapshotData) error {
 	m.ctrl.T.Helper()
@@ -542,6 +557,21 @@ func (m *MockLiveDB) GetStorage(address common.Address, key common.Key) (common.
 func (mr *MockLiveDBMockRecorder) GetStorage(address, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockLiveDB)(nil).GetStorage), address, key)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockLiveDB) HasEmptyStorage(address common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", address)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockLiveDBMockRecorder) HasEmptyStorage(address any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockLiveDB)(nil).HasEmptyStorage), address)
 }
 
 // RunPostRestoreTasks mocks base method.

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -964,6 +964,46 @@ func TestStateRead(t *testing.T) {
 	}
 }
 
+func TestState_HasEmptyStorage(t *testing.T) {
+	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
+		if err := s.Apply(1, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
+			t.Errorf("failed to create account: %v", err)
+		}
+
+		isEmpty, err := s.HasEmptyStorage(address1)
+		if err != nil {
+			t.Errorf("failed to ask whether account has empty storage; %s", err)
+		}
+		if !isEmpty {
+			t.Fatal("fresh account has empty storage but state returned true")
+		}
+
+		if err = s.Apply(2, common.Update{Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}}}); err != nil {
+			t.Errorf("failed to update storage slot: %v", err)
+		}
+
+		isEmpty, err = s.HasEmptyStorage(address1)
+		if err != nil {
+			t.Errorf("failed to ask whether account has empty storage; %s", err)
+		}
+		if isEmpty {
+			t.Fatal("storage is not empty but state returned true")
+		}
+
+		if err := s.Apply(3, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
+			t.Fatalf("Error: %s", err)
+		}
+
+		isEmpty, err = s.HasEmptyStorage(address1)
+		if err != nil {
+			t.Errorf("failed to ask whether account has empty storage; %s", err)
+		}
+		if !isEmpty {
+			t.Fatal("fresh account has empty storage but state returned true")
+		}
+	})
+}
+
 func execSubProcessTest(t *testing.T, dir string, stateImpl string, execTestName string) {
 	path, err := os.Executable()
 	if err != nil {

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -72,6 +72,12 @@ func (s *syncedState) GetStorage(address common.Address, key common.Key) (common
 	return s.state.GetStorage(address, key)
 }
 
+func (s *syncedState) HasEmptyStorage(address common.Address) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.HasEmptyStorage(address)
+}
+
 func (s *syncedState) GetCode(address common.Address) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
This PR adds `HasEmptyStorage(addr)` which returns true if given address has empty storage.
Fixes #887 