### PR TITLE
fix embedded nodes rlp decoder

### DIFF
--- a/go/database/mpt/decoder.go
+++ b/go/database/mpt/decoder.go
@@ -58,52 +58,15 @@ func DecodeFromRlp(data []byte) (Node, error) {
 	return nil, fmt.Errorf("invalid number of list elements: got: %v, wanted: either 2 or 17", len(list.Items))
 }
 
-// DecodeEmbeddedFromRlp decodes an embedded node from RLP-encoded data.
-// It checks for malformed data and returns an error if the data is not valid.
-// Otherwise, it returns the decoded embedded node.
-func DecodeEmbeddedFromRlp(data []byte) (Node, error) {
-	if len(data) > common.HashSize {
-		return nil, fmt.Errorf("embedded node is too long: got: %v, wanted: < 32", len(data))
-	}
-
-	var n int
-	var found bool
-	for n = len(data) - 1; n >= 0; n-- {
-		if data[n] == 0xF {
-			found = true
-			break
-		}
-		if data[n] != 0 {
-			return nil, fmt.Errorf("embedded node is not padded with zeros: got: %v, wanted: 0", data[n])
-		}
-	}
-
-	if !found {
-		return nil, fmt.Errorf("embedded node does not have terminal marker")
-	}
-
-	return DecodeFromRlp(data[:n])
-}
-
 // decodeExtensionNodeFromRlp decodes an extension node from RLP-encoded data.
 // It checks for malformed data and returns an error if the data is not valid.
 // Otherwise, it returns the decoded extension node.
 func decodeExtensionNodeFromRlp(path Path, payload rlp.Item) (Node, error) {
-	next, ok := payload.(rlp.String)
-	if !ok {
-		return nil, fmt.Errorf("invalid next type: got: %T, wanted: String", payload)
+	hashed, embedded, err := decodeEmbeddedOrHashedNode(payload)
+	if err != nil {
+		return nil, err
 	}
-	if len(next.Str) > common.HashSize {
-		return nil, fmt.Errorf("next node hash is too long: got: %v, wanted: <= 32", len(next.Str))
-	}
-	var nextNode common.Hash
-	var embedded bool
-	if n := copy(nextNode[:], next.Str); n > 0 && n < common.HashSize {
-		embedded = true
-		nextNode[n] = 0xF // terminal marker
-	}
-
-	return &ExtensionNode{path: path, nextHash: nextNode, nextIsEmbedded: embedded}, nil
+	return &ExtensionNode{path: path, nextHash: hashed, nextIsEmbedded: embedded}, nil
 }
 
 // decodeLeafNodeFromRlp decodes a leaf node from RLP-encoded data.
@@ -141,13 +104,10 @@ func decodeLeafNodeFromRlp(path Path, payload rlp.Item) (Node, error) {
 // It checks for malformed data and returns an error if the data is not valid.
 // Otherwise, it returns the decoded value node.
 func decodeValueNodeFromRlp(path Path, payload rlp.String) (Node, error) {
-	if got, want := path.Length(), 2*common.KeySize; got > want {
-		return nil, fmt.Errorf("invalid value path length: got: %v, wanted: <= %v", got, want)
-	}
 	var key common.Key
 	copy(key[:], path.GetPackedNibbles()) // it does not cover full key as it is not available in RLP.
 	var value common.Value
-	copy(value[:], payload.Str)
+	copy(value[32-len(payload.Str):], payload.Str) // align the value to the right
 	return &ValueNode{key: key, value: value, pathLength: byte(path.Length())}, nil
 }
 
@@ -158,10 +118,6 @@ func decodeValueNodeFromRlp(path Path, payload rlp.String) (Node, error) {
 // It checks for malformed data and returns an error if the data is not valid.
 // Otherwise, it returns the decoded account node.
 func decodeAccountFromRlp(path Path, items rlp.List) (Node, error) {
-	if got, want := path.Length(), 2*common.AddressSize; got > want {
-		return nil, fmt.Errorf("invalid account path length: got: %v, wanted: <= %v", got, want)
-	}
-
 	if len(items.Items) != 4 {
 		return nil, fmt.Errorf("invalid number of account items: got: %v, wanted: 4", len(items.Items))
 	}
@@ -226,25 +182,38 @@ func decodeAccountFromRlp(path Path, items rlp.List) (Node, error) {
 func decodeBranchNodeFromRlp(list rlp.List) (Node, error) {
 	node := BranchNode{}
 	for i, item := range list.Items[0:16] {
-		child, ok := item.(rlp.String)
-		if !ok {
-			return nil, fmt.Errorf("invalid child type: got: %T, wanted: String", item)
+		hashed, embedded, err := decodeEmbeddedOrHashedNode(item)
+		if err != nil {
+			return nil, err
 		}
-		if len(child.Str) > common.HashSize {
-			return nil, fmt.Errorf("child node hash is too long: got: %v, wanted: <= 32", len(child.Str))
-		}
-		var hash common.Hash
-		var embedded bool
-		if n := copy(hash[:], child.Str); n > 0 && n < common.HashSize {
-			embedded = true
-			hash[n] = 0xF // terminal marker
-		}
-
-		node.hashes[i] = hash
+		node.hashes[i] = hashed
 		node.setEmbedded(byte(i), embedded)
 	}
 
 	return &node, nil
+}
+
+// decodeEmbeddedOrHashedNode decodes an embedded or hashed node from RLP-encoded data.
+// It checks for malformed data and returns an error if the data is not valid.
+// Otherwise, it returns the decoded node hash and a flag indicating if the node is embedded.
+func decodeEmbeddedOrHashedNode(payload rlp.Item) (node common.Hash, embedded bool, err error) {
+	var hash common.Hash
+	switch item := payload.(type) {
+	case rlp.String:
+		if len(item.Str) > common.HashSize {
+			return common.Hash{}, false, fmt.Errorf("node hash is too long: got: %v, wanted: <= 32", len(item.Str))
+		}
+		copy(hash[:], item.Str)
+	case rlp.List: // embedded node is a two item list of a value node.
+		arr := make([]byte, 0, common.HashSize)
+		if n := copy(hash[:], rlp.EncodeInto(arr, item)); n > 0 && n < common.HashSize {
+			embedded = true
+		} else {
+			return common.Hash{}, false, fmt.Errorf("embedded node is too long: got: %v, wanted: < 32", n)
+		}
+	}
+
+	return hash, embedded, nil
 }
 
 // isEncodedLeafNode checks if the path is a leaf node in the compact encoding.

--- a/go/database/mpt/hasher.go
+++ b/go/database/mpt/hasher.go
@@ -458,9 +458,11 @@ func (h ethHasher) getHash(ref *NodeReference, source NodeSource) (common.Hash, 
 		return common.Hash{}, err
 	}
 
-	// The hash for embedded nodes is 0.
+	// The hash for embedded nodes is the node representation.
 	if len(data) < 32 {
-		return common.Hash{}, nil
+		var hash common.Hash
+		copy(hash[:], data)
+		return hash, nil
 	}
 
 	return common.Keccak256(data), nil

--- a/go/database/mpt/hasher_test.go
+++ b/go/database/mpt/hasher_test.go
@@ -585,3 +585,44 @@ func TestEthereumLikeHasher_GetLowerBoundForValueNode(t *testing.T) {
 		}
 	}
 }
+func TestEthereumLikeHasher_EmbeddedNode_Hashes_As_Itself(t *testing.T) {
+	address := common.Address{0xAB, 0xCD, 0xEF}
+	key := common.Key{0x12, 0x34, 0x56, 0x78}
+	var value common.Value
+	value[20] = 0x02
+	value[21] = 0x04
+
+	ctrl := gomock.NewController(t)
+	ctxt := newNodeContextWithConfig(t, ctrl, S5LiveConfig)
+
+	desc := &Extension{
+		path: AddressToNibblePath(address, ctxt)[0:30],
+		next: &Account{address: address, pathLength: 34, info: AccountInfo{Nonce: common.Nonce{0x01}, Balance: common.Balance{0x02}, CodeHash: common.Hash{0x03}},
+			storage: &Extension{
+				path:         KeyToNibblePath(key, ctxt)[0:40],
+				nextEmbedded: true,
+				next:         &Tag{label: "V", nested: &Value{key: key, length: 24, value: value}},
+			}},
+	}
+
+	ctxt.Build(desc)
+	ref, sharedNode := ctxt.Get("V")
+	got, err := ctxt.getHashFor(&ref)
+	if err != nil {
+		t.Fatalf("failed to get hash for embedded node: %v", err)
+	}
+	handle := sharedNode.GetReadHandle()
+	defer handle.Release()
+	node := handle.Get()
+	rlp, err := encodeToRlp(node, ctxt, []byte{})
+	if err != nil {
+		t.Fatalf("failed to encode node: %v", err)
+	}
+	var want common.Hash
+	copy(want[:], rlp)
+
+	// hash of an embedded node is its RLP encoding
+	if got != want {
+		t.Errorf("unexpected hash: got: %v, wanted: %v", want, got)
+	}
+}

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -7696,6 +7696,7 @@ type Branch struct {
 	dirty            bool
 	children         Children
 	childHashes      ChildHashes
+	embeddedChildren []bool
 	dirtyChildHashes []int
 	frozen           bool
 	frozenChildren   []int
@@ -7722,6 +7723,9 @@ func (b *Branch) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	for _, i := range b.frozenChildren {
 		res.setChildFrozen(byte(i), true)
 	}
+	for i, embedded := range b.embeddedChildren {
+		res.setEmbedded(byte(i), embedded)
+	}
 	res.hashStatus = hashStatusClean
 	if b.dirtyHash {
 		res.hashStatus = hashStatusDirty
@@ -7741,6 +7745,7 @@ type Extension struct {
 	nextHash      *common.Hash
 	nextHashDirty bool
 	hashStatus    *hashStatus // overrides dirtyHash flag if set
+	nextEmbedded  bool
 }
 
 func (e *Extension) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
@@ -7751,6 +7756,7 @@ func (e *Extension) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]
 	res.path = CreatePathFromNibbles(e.path)
 	res.next, _ = ctx.Build(e.next)
 	res.hashStatus = hashStatusClean
+	res.nextIsEmbedded = e.nextEmbedded
 	if e.hashDirty {
 		res.hashStatus = hashStatusDirty
 	}


### PR DESCRIPTION
This PR fixes RLP decoder of embedded nodes. 

* It extends the testing framework to track embedded nodes
* It fixes decoding of embedded nodes, in particular they are encoded as an` rlp.List` which contains a value node, not an `rlp.String`, which was previously wrongly assumed. 
* furthermore decoding of common.Value was fixed in cases when prefix bytes contain zeros, the decoded value used to be wrongly aligned 
* tests were fixed to follow new changes
* new end-to-end tests were added, which tests the embedded nodes and values that are < 32bytes
* previous method that decodes embedded nodes was removed as embedded nodes are stored in standard rlp code and can be decoded by calling the common decoding method
