### PR TITLE
allows for tracking embedded node in the node vistior

### DIFF
--- a/go/common/tribool/tribool.go
+++ b/go/common/tribool/tribool.go
@@ -18,6 +18,14 @@ type Tribool struct {
 	value byte
 }
 
+// New creates a new Tribool with the given value.
+func New(value bool) Tribool {
+	if value {
+		return True()
+	}
+	return False()
+}
+
 // Unknown returns true if the value is unknown.
 func (t Tribool) Unknown() bool {
 	return t.value == 0 || t.value > 2

--- a/go/common/tribool/tribool_test.go
+++ b/go/common/tribool/tribool_test.go
@@ -117,6 +117,30 @@ func TestTribool_Default_Is_Unknown(t *testing.T) {
 	}
 }
 
+func TestTribool_Create_From_Bool(t *testing.T) {
+	tests := map[string]struct {
+		val  bool
+		want Tribool
+	}{
+		"true": {
+			val:  true,
+			want: True(),
+		},
+		"false": {
+			val:  false,
+			want: False(),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got, want := New(tt.val), tt.want; got != want {
+				t.Errorf("unexpected tribool: got: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestTriboolString(t *testing.T) {
 	tests := []struct {
 		name string

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -16,11 +16,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
 	"io"
 	"slices"
-
-	"github.com/Fantom-foundation/Carmen/go/common"
-	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
 )
 
 // This file defines the interface and implementation of all node types in a
@@ -285,6 +285,7 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 	var last shared.ViewHandle[Node]
 	var found, done bool
 	var lastNodeId *NodeReference
+	var nextEmbedded, currentEmbedded bool
 	for !done {
 		handle, err := source.getViewAccess(nodeId)
 		if last.Valid() {
@@ -302,6 +303,7 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 			if n.path.IsPrefixOf(path) {
 				nodeId = &n.next
 				path = path[n.path.Length():]
+				nextEmbedded = n.nextIsEmbedded
 				done = len(path) == 0
 			} else {
 				done = true
@@ -311,6 +313,7 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 				done = true
 			} else {
 				nodeId = &n.children[path[0]]
+				nextEmbedded = n.isEmbedded(byte(path[0]))
 				path = path[1:]
 			}
 		case *AccountNode:
@@ -328,9 +331,10 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 			return false, nil
 		}
 
-		if res := visitor.Visit(last.Get(), NodeInfo{Id: lastNodeId.Id()}); res != VisitResponseContinue {
+		if res := visitor.Visit(last.Get(), NodeInfo{Id: lastNodeId.Id(), Embedded: tribool.New(currentEmbedded)}); res != VisitResponseContinue {
 			done = true
 		}
+		currentEmbedded = nextEmbedded
 	}
 
 	last.Release()

--- a/go/database/mpt/nodes_mocks.go
+++ b/go/database/mpt/nodes_mocks.go
@@ -15,7 +15,6 @@
 //
 //	mockgen -source nodes.go -destination nodes_mocks.go -package mpt
 //
-
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -170,21 +169,6 @@ func (m *MockNode) GetValue(source NodeSource, key common.Key, path []Nibble) (c
 func (mr *MockNodeMockRecorder) GetValue(source, key, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockNode)(nil).GetValue), source, key, path)
-}
-
-// HasEmptyStorage mocks base method.
-func (m *MockNode) HasEmptyStorage(source NodeSource, address common.Address, path []Nibble) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasEmptyStorage", source, address, path)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HasEmptyStorage indicates an expected call of HasEmptyStorage.
-func (mr *MockNodeMockRecorder) HasEmptyStorage(source, address, path any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockNode)(nil).HasEmptyStorage), source, address, path)
 }
 
 // IsDirty mocks base method.
@@ -810,21 +794,6 @@ func (m *MockleafNode) GetValue(source NodeSource, key common.Key, path []Nibble
 func (mr *MockleafNodeMockRecorder) GetValue(source, key, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockleafNode)(nil).GetValue), source, key, path)
-}
-
-// HasEmptyStorage mocks base method.
-func (m *MockleafNode) HasEmptyStorage(source NodeSource, address common.Address, path []Nibble) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasEmptyStorage", source, address, path)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HasEmptyStorage indicates an expected call of HasEmptyStorage.
-func (mr *MockleafNodeMockRecorder) HasEmptyStorage(source, address, path any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockleafNode)(nil).HasEmptyStorage), source, address, path)
 }
 
 // IsDirty mocks base method.

--- a/go/database/mpt/visitor.go
+++ b/go/database/mpt/visitor.go
@@ -14,6 +14,7 @@ package mpt
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"strings"
 )
 
@@ -37,8 +38,9 @@ type NodeVisitor interface {
 }
 
 type NodeInfo struct {
-	Id    NodeId // the ID of the visited node
-	Depth *int   // the nesting level of the visited node, only set for tree visits
+	Id       NodeId          // the ID of the visited node
+	Depth    *int            // the nesting level of the visited node, only set for tree visits
+	Embedded tribool.Tribool // true if this node is embedded in another node, tracked in visitPathTo
 }
 
 type VisitResponse int


### PR DESCRIPTION
This PR enables tracking of embedded node in the node visitor. The flag is filled in the `visitPathTo` method.

This feature will be used in witness proof not to include embedded nodes as entries in the proof database. 