### PR TITLE
propagates all terminal node except empty one via path iterators

### DIFF
--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -306,9 +306,11 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 				done = true
 			}
 		case *BranchNode:
+			if len(path) == 0 {
+				done = true
+			}
 			nodeId = &n.children[path[0]]
 			path = path[1:]
-			done = len(path) == 0
 		case *AccountNode:
 			if address != nil && n.address == *address {
 				found = true

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -308,9 +308,10 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 		case *BranchNode:
 			if len(path) == 0 {
 				done = true
+			} else {
+				nodeId = &n.children[path[0]]
+				path = path[1:]
 			}
-			nodeId = &n.children[path[0]]
-			path = path[1:]
 		case *AccountNode:
 			if address != nil && n.address == *address {
 				found = true

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -301,16 +301,14 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 			if n.path.IsPrefixOf(path) {
 				nodeId = &n.next
 				path = path[n.path.Length():]
+				done = len(path) == 0
 			} else {
 				done = true
 			}
 		case *BranchNode:
-			if len(path) == 0 {
-				done = true
-			} else {
-				nodeId = &n.children[path[0]]
-				path = path[1:]
-			}
+			nodeId = &n.children[path[0]]
+			path = path[1:]
+			done = len(path) == 0
 		case *AccountNode:
 			if address != nil && n.address == *address {
 				found = true
@@ -322,14 +320,12 @@ func visitPathTo(source NodeSource, root *NodeReference, path []Nibble, address 
 			}
 			done = true
 		default:
-			done = true
+			last.Release()
+			return false, nil
 		}
 
-		// visit when we are in the middle of the path or when we found the result
-		if !done || found {
-			if res := visitor.Visit(last.Get(), NodeInfo{Id: lastNodeId.Id()}); res != VisitResponseContinue {
-				done = true
-			}
+		if res := visitor.Visit(last.Get(), NodeInfo{Id: lastNodeId.Id()}); res != VisitResponseContinue {
+			done = true
 		}
 	}
 

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -6617,6 +6617,16 @@ func TestVisitPathToAccount_CanReachTerminalNodes(t *testing.T) {
 			},
 			path: []string{"A"},
 		},
+		"nested branch node too deep": {
+			trie: &Tag{"A", &Extension{
+				path: addressToNibbles(address)[0:39], // branch node will exhaust the path
+				next: &Tag{"B", &Branch{children: Children{
+					0: &Tag{"C", &Branch{children: Children{
+						0: &Tag{"D", &Account{}},
+					}}}}},
+				}}},
+			path: []string{"A", "B", "C"},
+		},
 		"account node too deep": {
 			trie: &Tag{"A", &Extension{
 				path: addressToNibbles(address)[0:39], // branch node will exhaust the path
@@ -6736,6 +6746,16 @@ func TestVisitPathToStorage_CanReachTerminalNodes(t *testing.T) {
 				next: &Tag{"B", &Branch{}},
 			}},
 			path: []string{"A"},
+		},
+		"nested branch node too deep": {
+			trie: &Tag{"A", &Extension{
+				path: keyToNibbles(key)[0:63], // branch node will exhaust the path
+				next: &Tag{"B", &Branch{children: Children{
+					0: &Tag{"C", &Branch{children: Children{
+						0: &Tag{"D", &Value{}},
+					}}}}},
+				}}},
+			path: []string{"A", "B", "C"},
 		},
 		"value node too deep": {
 			trie: &Tag{"A", &Extension{

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -6565,7 +6565,7 @@ func TestVisitPathToAccount_CanReachTerminalNodes(t *testing.T) {
 		},
 		"wrong account": {
 			trie: &Tag{"A", &Account{}},
-			path: []string{},
+			path: []string{"A"},
 		},
 		"correct account": {
 			trie: &Tag{"A", &Account{address: address}},
@@ -6585,7 +6585,7 @@ func TestVisitPathToAccount_CanReachTerminalNodes(t *testing.T) {
 				1: &Tag{"C", &Account{}},
 				2: &Tag{"D", &Empty{}},
 			}}},
-			path: []string{"A"},
+			path: []string{"A", "C"},
 		},
 		"branch with correct account": {
 			trie: &Tag{"A", &Branch{children: Children{
@@ -6607,7 +6607,7 @@ func TestVisitPathToAccount_CanReachTerminalNodes(t *testing.T) {
 		},
 		"extension without common prefix": {
 			trie: &Tag{"A", &Extension{path: []Nibble{2, 3}}},
-			path: []string{},
+			path: []string{"A"},
 		},
 		"branch node too deep": {
 			trie: &Tag{"A", &Extension{
@@ -6713,13 +6713,31 @@ func TestVisitPathToStorage_CanReachTerminalNodes(t *testing.T) {
 			}}},
 			path: []string{"A", "C"},
 		},
+		"branch with incorrect storage": {
+			trie: &Tag{"A", &Branch{children: Children{
+				0: &Tag{"B", &Empty{}},
+				1: &Tag{"C", &Value{}},
+				2: &Tag{"D", &Empty{}},
+			}}},
+			path: []string{"A", "C"},
+		},
 		"branch node too deep": {
 			trie: &Tag{"A", &Extension{
 				path: keyToNibbles(key), // extension node will exhaust the path
 				next: &Tag{"B", &Branch{}},
-			},
-			},
+			}},
 			path: []string{"A"},
+		},
+		"wrong extension": {
+			trie: &Tag{"A", &Extension{
+				path: keyToNibbles(common.Key{}),
+				next: &Tag{"B", &Branch{}},
+			}},
+			path: []string{"A"},
+		},
+		"empty node ": {
+			trie: &Tag{"A", Empty{}},
+			path: []string{},
 		},
 	}
 

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -6617,6 +6617,15 @@ func TestVisitPathToAccount_CanReachTerminalNodes(t *testing.T) {
 			},
 			path: []string{"A"},
 		},
+		"account node too deep": {
+			trie: &Tag{"A", &Extension{
+				path: addressToNibbles(address)[0:39], // branch node will exhaust the path
+				next: &Tag{"B", &Branch{children: Children{
+					0: &Tag{"C", &Account{address: address}}},
+				}}},
+			},
+			path: []string{"A", "B", "C"},
+		},
 	}
 
 	for name, test := range tests {
@@ -6727,6 +6736,15 @@ func TestVisitPathToStorage_CanReachTerminalNodes(t *testing.T) {
 				next: &Tag{"B", &Branch{}},
 			}},
 			path: []string{"A"},
+		},
+		"value node too deep": {
+			trie: &Tag{"A", &Extension{
+				path: keyToNibbles(key)[0:63], // branch node will exhaust the path
+				next: &Tag{"B", &Branch{children: Children{
+					0: &Tag{"C", &Value{key: key}},
+				}}},
+			}},
+			path: []string{"A", "B", "C"},
 		},
 		"wrong extension": {
 			trie: &Tag{"A", &Extension{


### PR DESCRIPTION
This PR updates methods to visit path in the MPT in the way that terminal nodes are visited even when their path in the MPT was not matched. In this case such nodes are terminal and are last returned. 

Exception are Empty node and a Branch node when the path was exhausted - these nodes are not returned.  