### PR TITLE
integrates witness proof into public facade

### DIFF
--- a/go/backend/archive/archive.go
+++ b/go/backend/archive/archive.go
@@ -14,7 +14,11 @@ package archive
 
 import (
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 )
+
+// ErrWitnessProofNotSupported is returned when the archive does not support witness proofs.
+const ErrWitnessProofNotSupported = common.ConstError("witness proof not supported")
 
 // An Archive retains a history of state mutations in a blockchain on a
 // block-level granularity. The history is recorded by adding per-block updates.
@@ -51,6 +55,9 @@ type Archive interface {
 
 	// GetHash provides a hash of the state at the given block height.
 	GetHash(block uint64) (hash common.Hash, err error)
+
+	// CreateWitnessProof creates a witness proof for the given account and keys.
+	CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error)
 
 	// MemoryFootprintProvider provides the size of the store in memory in bytes.
 	common.MemoryFootprintProvider

--- a/go/backend/archive/archive_mock.go
+++ b/go/backend/archive/archive_mock.go
@@ -23,6 +23,7 @@ import (
 	reflect "reflect"
 
 	common "github.com/Fantom-foundation/Carmen/go/common"
+	witness "github.com/Fantom-foundation/Carmen/go/common/witness"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -75,6 +76,26 @@ func (m *MockArchive) Close() error {
 func (mr *MockArchiveMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockArchive)(nil).Close))
+}
+
+// CreateWitnessProof mocks base method.
+func (m *MockArchive) CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{block, address}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateWitnessProof", varargs...)
+	ret0, _ := ret[0].(witness.Proof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWitnessProof indicates an expected call of CreateWitnessProof.
+func (mr *MockArchiveMockRecorder) CreateWitnessProof(block, address any, keys ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{block, address}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWitnessProof", reflect.TypeOf((*MockArchive)(nil).CreateWitnessProof), varargs...)
 }
 
 // Exists mocks base method.

--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -12,6 +12,7 @@ package archive_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -256,6 +257,68 @@ func TestAccountDeleteCreate(t *testing.T) {
 				if hash, err := a.GetHash(9); err != nil || fmt.Sprintf("%x", hash) != "49a86f0a7e53b6d7411edad398e2f807ffbe79d179eebbd42117425343b38fa9" {
 					t.Errorf("unexpected hash of block 9: %x; %v", hash, err)
 				}
+			}
+		})
+	}
+}
+
+func TestArchive_CreateWitnessProof(t *testing.T) {
+	for _, factory := range getArchiveFactories(t) {
+		t.Run(factory.label, func(t *testing.T) {
+			a := factory.getArchive(t.TempDir())
+			defer func() {
+				if err := a.Close(); err != nil {
+					t.Fatalf("failed to close archive; %s", err)
+				}
+			}()
+
+			if err := a.Add(1, common.Update{
+				CreatedAccounts: []common.Address{{1}},
+				Balances: []common.BalanceUpdate{
+					{Account: common.Address{1}, Balance: common.Balance{0x12}},
+				},
+				Slots: []common.SlotUpdate{
+					{Account: common.Address{1}, Key: common.Key{2}, Value: common.Value{3}},
+				},
+			}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
+
+			proof, err := a.CreateWitnessProof(1, common.Address{1}, common.Key{2})
+			if err != nil {
+				if errors.Is(err, archive.ErrWitnessProofNotSupported) {
+					t.Skip(err)
+				}
+				t.Fatalf("failed to create witness proof; %s", err)
+			}
+
+			if !proof.IsValid() {
+				t.Errorf("invalid proof")
+			}
+
+			hash, err := a.GetHash(1)
+			if err != nil {
+				t.Fatalf("failed to get hash; %s", err)
+			}
+			balance, complete, err := proof.GetBalance(hash, common.Address{1})
+			if err != nil {
+				t.Fatalf("failed to get balance; %s", err)
+			}
+			if !complete {
+				t.Errorf("balance proof is incomplete")
+			}
+			if got, want := balance, (common.Balance{0x12}); got != want {
+				t.Errorf("unexpected balance; got: %x, want: %x", got, want)
+			}
+			value, complete, err := proof.GetState(hash, common.Address{1}, common.Key{2})
+			if err != nil {
+				t.Fatalf("failed to get state; %s", err)
+			}
+			if !complete {
+				t.Errorf("state proof is incomplete")
+			}
+			if got, want := value, (common.Value{3}); got != want {
+				t.Errorf("unexpected value; got: %x, want: %x", got, want)
 			}
 		})
 	}

--- a/go/backend/archive/ldb/archive.go
+++ b/go/backend/archive/ldb/archive.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/backend"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"sync"
 	"unsafe"
 
@@ -332,6 +333,10 @@ func (a *Archive) GetAccountHash(block uint64, account common.Address) (hash com
 		return hash, nil
 	}
 	return common.Hash{}, it.Error()
+}
+
+func (a *Archive) CreateWitnessProof(_ uint64, _ common.Address, _ ...common.Key) (witness.Proof, error) {
+	return nil, archive.ErrWitnessProofNotSupported
 }
 
 // GetMemoryFootprint provides the size of the archive in memory in bytes

--- a/go/backend/archive/sqlite/archive.go
+++ b/go/backend/archive/sqlite/archive.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"unsafe"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/archive"
@@ -507,6 +508,10 @@ func (a *Archive) getAccountHash(tx *sql.Tx, block uint64, account common.Addres
 
 func (a *Archive) GetAccountHash(block uint64, account common.Address) (hash common.Hash, err error) {
 	return a.getAccountHash(nil, block, account)
+}
+
+func (a *Archive) CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error) {
+	return nil, archive.ErrWitnessProofNotSupported
 }
 
 // GetMemoryFootprint provides the size of the archive in memory in bytes

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -12,6 +12,7 @@ package carmen
 
 import (
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
@@ -187,6 +188,11 @@ type HeadBlockContext interface {
 // to the blockchain happens.
 type HistoricBlockContext interface {
 	blockContext
+
+	// GetProof creates a witness proof for the given account and keys.
+	// Error may be produced when it occurs in the underlying database;
+	// otherwise, the proof is returned.
+	GetProof(address Address, keys ...Key) (WitnessProof, error)
 
 	// Close releases resources held by this context. All modifications made
 	// within this context are discarded. This context is invalid after this
@@ -453,6 +459,8 @@ type Value common.Value
 
 // Hash is a 32byte hash.
 type Hash common.Hash
+
+type Tribool tribool.Tribool
 
 // Log summarizes a log message recorded during the execution of a contract.
 type Log struct {

--- a/go/carmen/database.go
+++ b/go/carmen/database.go
@@ -210,7 +210,8 @@ func (db *database) GetHistoricContext(block uint64) (HistoricBlockContext, erro
 		commonContext: commonContext{
 			db: db,
 		},
-		state: state.CreateNonCommittableStateDBUsing(s)}, err
+		archiveState: s,
+		state:        state.CreateNonCommittableStateDBUsing(s)}, err
 }
 
 func (db *database) StartBulkLoad(block uint64) (BulkLoad, error) {

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -845,6 +845,374 @@ func TestDatabase_CloseDB_Unfinished_Queries(t *testing.T) {
 	}
 }
 
+func TestDatabase_GetProof(t *testing.T) {
+	db, err := openTestDatabase(t)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	codeHashes := make(map[Address]Hash)
+
+	// init data
+	const numBlocks = 100
+	const numAccounts = 11
+	const numKeys = 12
+	for i := 0; i < numBlocks; i++ {
+		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
+			for j := 0; j < numAccounts; j++ {
+				if err := context.RunTransaction(func(tc TransactionContext) error {
+					addr := Address{byte(j)}
+					tc.CreateAccount(addr)
+					tc.SetCode(addr, []byte{byte(j)})
+					codeHashes[addr] = Hash(common.Keccak256([]byte{byte(j)}))
+					tc.SetNonce(addr, uint64(i<<8+j+1))
+					tc.AddBalance(addr, NewAmount(uint64(i<<8+j+1)))
+					for k := 0; k < numKeys; k++ {
+						key := Key{byte(k)}
+						tc.SetState(addr, key, Value{byte(i), byte(j), byte(k)})
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("cannot add block: %v", err)
+		}
+	}
+
+	if err := db.Flush(); err != nil {
+		t.Fatalf("cannot flush db: %v", err)
+	}
+
+	// collect all roots
+	roots := make([]Hash, 0, numBlocks)
+	for i := 0; i < numBlocks; i++ {
+		if err := db.QueryHistoricState(uint64(i), func(context QueryContext) {
+			roots = append(roots, context.GetStateHash())
+		}); err != nil {
+			t.Fatalf("cannot query state: %v", err)
+		}
+	}
+
+	sums := make(map[Address]Amount)
+
+	// proof properties
+	for i := 0; i < numBlocks; i++ {
+		block, err := db.GetHistoricContext(uint64(i))
+		if err != nil {
+			t.Fatalf("cannot get block: %v", err)
+		}
+		// proof each account and all keys of the account
+		for j := 0; j < numAccounts; j++ {
+			addr := Address{byte(j)}
+			keys := make([]Key, 0, numKeys)
+			for k := 0; k < numKeys; k++ {
+				keys = append(keys, Key{byte(k)})
+			}
+			proof, err := block.GetProof(addr, keys...)
+			if err != nil {
+				t.Errorf("cannot get proof: %v", err)
+			}
+			if !proof.IsValid() {
+				t.Errorf("proof is not valid")
+			}
+
+			balance, complete, err := proof.GetBalance(roots[i], addr)
+			if err != nil {
+				t.Errorf("cannot get balance: %v", err)
+			}
+
+			if !complete {
+				t.Errorf("proof is not complete")
+			}
+
+			preBalance, exists := sums[addr]
+			if !exists {
+				preBalance = NewAmount()
+			}
+
+			if got, want := balance, NewAmount(preBalance.Uint64()+uint64(i<<8+j+1)); got != want {
+				t.Errorf("unexpected balance, wanted %v, got %v", want, got)
+			}
+			sums[addr] = balance
+
+			nonce, complete, err := proof.GetNonce(roots[i], addr)
+			if err != nil {
+				t.Errorf("cannot get nonce: %v", err)
+			}
+
+			if !complete {
+				t.Errorf("proof is not complete")
+			}
+
+			if got, want := nonce, uint64(i<<8+j+1); got != want {
+				t.Errorf("unexpected nonce, wanted %v, got %v", want, got)
+			}
+
+			codeHash, complete, err := proof.GetCodeHash(roots[i], addr)
+			if err != nil {
+				t.Errorf("cannot get nonce: %v", err)
+			}
+
+			if !complete {
+				t.Errorf("proof is not complete")
+			}
+
+			if got, want := codeHash, codeHashes[addr]; got != want {
+				t.Errorf("unexpected codeHash, wanted %v, got %v", want, got)
+			}
+
+			/// proof keys
+			for k := 0; k < numKeys; k++ {
+				key := Key{byte(k)}
+				value, complete, err := proof.GetState(roots[i], addr, key)
+				if err != nil {
+					t.Errorf("cannot get state: %v", err)
+				}
+				if !complete {
+					t.Errorf("proof is not complete")
+				}
+				if got, want := value, (Value{byte(i), byte(j), byte(k)}); got != want {
+					t.Errorf("unexpected value, wanted %v, got %v", want, got)
+				}
+			}
+		}
+		if err := block.Close(); err != nil {
+			t.Fatalf("cannot close block: %v", err)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db cannot be closed: %v", err)
+	}
+}
+
+func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
+	db, err := openTestDatabase(t)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	// init data
+	const numBlocks = 100
+	const numAccounts = 11
+	const numKeys = 12
+	for i := 0; i < numBlocks; i++ {
+		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
+			for j := 0; j < numAccounts; j++ {
+				if err := context.RunTransaction(func(tc TransactionContext) error {
+					addr := Address{byte(j)}
+					tc.CreateAccount(addr)
+					tc.SetNonce(addr, uint64(i<<8+j+1))
+					for k := 0; k < numKeys; k++ {
+						key := Key{byte(k)}
+						tc.SetState(addr, key, Value{byte(i), byte(j), byte(k)})
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("cannot add block: %v", err)
+		}
+	}
+
+	if err := db.Flush(); err != nil {
+		t.Fatalf("cannot flush db: %v", err)
+	}
+
+	// collect all roots
+	roots := make([]Hash, 0, numBlocks)
+	for i := 0; i < numBlocks; i++ {
+		if err := db.QueryHistoricState(uint64(i), func(context QueryContext) {
+			roots = append(roots, context.GetStateHash())
+		}); err != nil {
+			t.Fatalf("cannot query state: %v", err)
+		}
+	}
+
+	// proof properties
+	serialized := make([]string, 0, 1024)
+	for i := 0; i < numBlocks; i++ {
+		block, err := db.GetHistoricContext(uint64(i))
+		if err != nil {
+			t.Fatalf("cannot get block: %v", err)
+		}
+		// proof each account and all keys of the account
+		for j := 0; j < numAccounts; j++ {
+			addr := Address{byte(j)}
+			keys := make([]Key, 0, numKeys)
+			for k := 0; k < numKeys; k++ {
+				keys = append(keys, Key{byte(k)})
+			}
+			proof, err := block.GetProof(addr, keys...)
+			if err != nil {
+				t.Errorf("cannot get proof: %v", err)
+			}
+			serialized = append(serialized, proof.GetElements()...)
+		}
+		if err := block.Close(); err != nil {
+			t.Fatalf("cannot close block: %v", err)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db cannot be closed: %v", err)
+	}
+
+	recovered := CreateWitnessProofFromNodes(serialized...)
+	for i := 0; i < numBlocks; i++ {
+		for j := 0; j < numAccounts; j++ {
+			addr := Address{byte(j)}
+
+			nonce, complete, err := recovered.GetNonce(roots[i], addr)
+			if err != nil {
+				t.Errorf("cannot get nonce: %v", err)
+			}
+
+			if !complete {
+				t.Errorf("proof is not complete")
+			}
+
+			if got, want := nonce, uint64(i<<8+j+1); got != want {
+				t.Errorf("unexpected nonce, wanted %v, got %v", want, got)
+			}
+
+			/// proof keys
+			for k := 0; k < numKeys; k++ {
+				key := Key{byte(k)}
+				value, complete, err := recovered.GetState(roots[i], addr, key)
+				if err != nil {
+					t.Errorf("cannot get state: %v", err)
+				}
+				if !complete {
+					t.Errorf("proof is not complete")
+				}
+				if got, want := value, (Value{byte(i), byte(j), byte(k)}); got != want {
+					t.Errorf("unexpected value, wanted %v, got %v", want, got)
+				}
+			}
+		}
+	}
+}
+
+func TestDatabase_CloseDB_Unfinished_Proof_CannotCloseDb(t *testing.T) {
+	db, err := openTestDatabase(t)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	if err := db.AddBlock(1, func(context HeadBlockContext) error {
+		if err := context.RunTransaction(func(tc TransactionContext) error {
+			addr := Address{1}
+			tc.CreateAccount(addr)
+			tc.SetNonce(addr, uint64(1))
+			return nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("cannot add block: %v", err)
+	}
+
+	if err := db.Flush(); err != nil {
+		t.Fatalf("cannot flush db: %v", err)
+	}
+
+	block, err := db.GetHistoricContext(1)
+	if err != nil {
+		t.Fatalf("cannot get block: %v", err)
+	}
+
+	// attempts to close db must fail
+	if err := db.Close(); !errors.Is(err, errBlockContextRunning) {
+		t.Errorf("closing db should fail: %v", err)
+	}
+
+	_, err = block.GetProof(Address{1})
+	if err != nil {
+		t.Fatalf("cannot get proof: %v", err)
+	}
+
+	// attempts to close db must fail
+	if err := db.Close(); !errors.Is(err, errBlockContextRunning) {
+		t.Errorf("closing db should fail: %v", err)
+	}
+
+	if err := block.Close(); err != nil {
+		t.Fatalf("cannot close block: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("cannot close db: %v", err)
+	}
+}
+
+func TestDatabase_ClosedBlock_CannotGetProof(t *testing.T) {
+	db, err := openTestDatabase(t)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	if err := db.AddBlock(1, func(context HeadBlockContext) error {
+		if err := context.RunTransaction(func(tc TransactionContext) error {
+			addr := Address{1}
+			tc.CreateAccount(addr)
+			tc.SetNonce(addr, uint64(1))
+			return nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("cannot add block: %v", err)
+	}
+
+	if err := db.Flush(); err != nil {
+		t.Fatalf("cannot flush db: %v", err)
+	}
+
+	block, err := db.GetHistoricContext(1)
+	if err != nil {
+		t.Fatalf("cannot get block: %v", err)
+	}
+
+	if err := block.Close(); err != nil {
+		t.Fatalf("cannot close block: %v", err)
+	}
+
+	if _, err := block.GetProof(Address{}); err == nil {
+		t.Errorf("getting proof from closed block should fail")
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("cannot close db: %v", err)
+	}
+}
+
+func TestDatabase_GetProof_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockState(ctrl)
+
+	injectedError := fmt.Errorf("injectedError")
+	state.EXPECT().CreateWitnessProof(gomock.Any(), gomock.Any()).Return(nil, injectedError)
+	block := archiveBlockContext{
+		commonContext: commonContext{
+			db: &database{},
+		},
+		archiveState: state,
+	}
+
+	if _, err := block.GetProof(Address{}); !errors.Is(err, injectedError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestDatabase_BeginBlock_Parallel(t *testing.T) {
 	const loops = 100
 

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -12,6 +12,7 @@ package carmen_test
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
 	"log"
 	"os"
 
@@ -281,4 +282,130 @@ func ExampleDatabase_GetHistoricContext() {
 	}
 
 	// Output: Balance of [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] is 100
+}
+
+func ExampleHistoricBlockContext_GetProof() {
+	dir, err := os.MkdirTemp("", "carmen_db_*")
+	if err != nil {
+		log.Fatalf("cannot create temporary directory: %v", err)
+	}
+	db, err := carmen.OpenDatabase(dir, carmen.GetCarmenGoS5WithArchiveConfiguration(), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// ------- Prepare the database -------
+
+	const N = 10
+	// Add N blocks with one address and storage slot each
+	for i := 0; i < N; i++ {
+		if err := db.AddBlock(uint64(i), func(context carmen.HeadBlockContext) error {
+			if err := context.RunTransaction(func(context carmen.TransactionContext) error {
+				context.CreateAccount(carmen.Address{byte(i)})
+				context.AddBalance(carmen.Address{byte(i)}, carmen.NewAmount(uint64(i)))
+				context.SetState(carmen.Address{byte(i)}, carmen.Key{byte(i)}, carmen.Value{byte(i)})
+				return nil
+			}); err != nil {
+				log.Fatalf("cannot create transaction: %v", err)
+			}
+			return nil
+		}); err != nil {
+			log.Fatalf("cannot add block: %v", err)
+		}
+	}
+
+	// block wait until the archive is in sync
+	if err := db.Flush(); err != nil {
+		log.Fatalf("cannot flush: %v", err)
+	}
+
+	// ------- Query witness proofs for each block -------
+
+	completeProof := make(map[string]struct{}, 1024)
+	// proof each address and key from each block, and merge all in one proof
+	for i := 0; i < N; i++ {
+		if err := db.QueryBlock(uint64(i), func(ctxt carmen.HistoricBlockContext) error {
+			proof, err := ctxt.GetProof(carmen.Address{byte(i)}, carmen.Key{byte(i)})
+			if err != nil {
+				log.Fatalf("cannot create witness proof: %v", err)
+			}
+
+			// proof can be extracted and merged with other proofs
+			for _, e := range proof.GetElements() {
+				completeProof[e] = struct{}{}
+			}
+
+			return nil
+		}); err != nil {
+			log.Fatalf("cannot query block: %v", err)
+		}
+	}
+
+	rootHashes := make([]carmen.Hash, N)
+	for i := 0; i < N; i++ {
+		if err := db.QueryHistoricState(uint64(i), func(ctxt carmen.QueryContext) {
+			rootHashes[i] = ctxt.GetStateHash()
+		}); err != nil {
+			log.Fatalf("cannot query block: %v", err)
+		}
+	}
+
+	// ------- Close the database - no more needed -------
+	if err := db.Close(); err != nil {
+		log.Fatalf("cannot close db: %v", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		log.Fatalf("cannot remove dir: %v", err)
+	}
+
+	// ------- WitnessProof can be deserialized  -------
+
+	recoveredProof := carmen.CreateWitnessProofFromNodes(maps.Keys(completeProof)...)
+
+	// ------- Properties can be proven offline  -------
+	for i := 0; i < N; i++ {
+		{
+			// query account balance
+			balance, complete, err := recoveredProof.GetBalance(rootHashes[i], carmen.Address{byte(i)})
+			if err != nil {
+				log.Fatalf("cannot get balance: %v", err)
+			}
+			if !complete {
+				log.Fatalf("proof is incomplete")
+			}
+			fmt.Printf("Balance of address 0x%x at block: %d is 0x%x\n", carmen.Address{byte(i)}, i, balance)
+		}
+		{
+			// query storage slot
+			value, complete, err := recoveredProof.GetState(rootHashes[i], carmen.Address{byte(i)}, carmen.Key{byte(i)})
+			if err != nil {
+				log.Fatalf("cannot get state: %v", err)
+			}
+			if !complete {
+				log.Fatalf("proof is incomplete")
+			}
+			fmt.Printf("Storage slot value of key 0x%x at block: %d and address: 0x%x is 0x%x\n", carmen.Key{byte(i)}, i, carmen.Address{byte(i)}, value)
+		}
+	}
+
+	// Output: Balance of address 0x0000000000000000000000000000000000000000 at block: 0 is 0x30
+	//Storage slot value of key 0x0000000000000000000000000000000000000000000000000000000000000000 at block: 0 and address: 0x0000000000000000000000000000000000000000 is 0x0000000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0100000000000000000000000000000000000000 at block: 1 is 0x31
+	//Storage slot value of key 0x0100000000000000000000000000000000000000000000000000000000000000 at block: 1 and address: 0x0100000000000000000000000000000000000000 is 0x0100000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0200000000000000000000000000000000000000 at block: 2 is 0x32
+	//Storage slot value of key 0x0200000000000000000000000000000000000000000000000000000000000000 at block: 2 and address: 0x0200000000000000000000000000000000000000 is 0x0200000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0300000000000000000000000000000000000000 at block: 3 is 0x33
+	//Storage slot value of key 0x0300000000000000000000000000000000000000000000000000000000000000 at block: 3 and address: 0x0300000000000000000000000000000000000000 is 0x0300000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0400000000000000000000000000000000000000 at block: 4 is 0x34
+	//Storage slot value of key 0x0400000000000000000000000000000000000000000000000000000000000000 at block: 4 and address: 0x0400000000000000000000000000000000000000 is 0x0400000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0500000000000000000000000000000000000000 at block: 5 is 0x35
+	//Storage slot value of key 0x0500000000000000000000000000000000000000000000000000000000000000 at block: 5 and address: 0x0500000000000000000000000000000000000000 is 0x0500000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0600000000000000000000000000000000000000 at block: 6 is 0x36
+	//Storage slot value of key 0x0600000000000000000000000000000000000000000000000000000000000000 at block: 6 and address: 0x0600000000000000000000000000000000000000 is 0x0600000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0700000000000000000000000000000000000000 at block: 7 is 0x37
+	//Storage slot value of key 0x0700000000000000000000000000000000000000000000000000000000000000 at block: 7 and address: 0x0700000000000000000000000000000000000000 is 0x0700000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0800000000000000000000000000000000000000 at block: 8 is 0x38
+	//Storage slot value of key 0x0800000000000000000000000000000000000000000000000000000000000000 at block: 8 and address: 0x0800000000000000000000000000000000000000 is 0x0800000000000000000000000000000000000000000000000000000000000000
+	//Balance of address 0x0900000000000000000000000000000000000000 at block: 9 is 0x39
+	//Storage slot value of key 0x0900000000000000000000000000000000000000000000000000000000000000 at block: 9 and address: 0x0900000000000000000000000000000000000000 is 0x0900000000000000000000000000000000000000000000000000000000000000
 }

--- a/go/carmen/proof.go
+++ b/go/carmen/proof.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package carmen
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
+)
+
+// CreateWitnessProofFromNodes creates a witness proof from a list of strings.
+// Each string is an RLP node of the witness proof.
+func CreateWitnessProofFromNodes(elements ...string) WitnessProof {
+	proof := mpt.CreateWitnessProofFromNodes(elements)
+	return witnessProof{proof}
+}
+
+// WitnessProof is an interface for witness proofs. A witness proof is a data structure that
+// contains a witness for a subset of the state. The witness proof can be used to
+// extract information, such as account balances, nonces, code hashes,
+// and storage slots. The witness proof is self-contained and does not require access to
+// the full state to extract information.
+type WitnessProof interface {
+
+	// IsValid checks that this proof is self-consistent. If the result is true, the proof can be used
+	// for extracting verified information. If false, the proof is corrupted and should be discarded.
+	IsValid() bool
+
+	// GetElements returns serialised elements of the witness proof.
+	GetElements() []string
+
+	// GetBalance extracts a balance from the witness proof for the input root hash and the address.
+	// If the witness proof contains the requested account for the input address for the given root hash, it returns its balance.
+	// If the proof does not cover the requested account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetBalance(root Hash, address Address) (Amount, bool, error)
+
+	// GetNonce extracts a nonce from the witness proof for the input root hash and the address.
+	// If the witness proof contains the account for the input address, it returns its nonce.
+	// If the proof does not contain the account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetNonce(root Hash, address Address) (uint64, bool, error)
+
+	// GetCodeHash extracts a code hash from the witness proof for the input root hash and the address.
+	// If the witness proof contains the account for the input address, it returns its code hash.
+	// If the proof does not contain the account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetCodeHash(root Hash, address Address) (Hash, bool, error)
+
+	// GetState extracts a storage slot from the witness proof for the input root hash, account address and the storage key.
+	// If the witness proof contains the input storage slot for the input key, it returns its value.
+	// If the proof does not contain the slot, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetState(root Hash, address Address, key Key) (Value, bool, error)
+
+	// AllStatesZero checks that all storage slots are empty for the input root hash,
+	// account address and the storage key range. If the witness proof contains all empty slots
+	// for the input key range, it returns true. If there is at least one non-empty slot,
+	// it returns false. If the proof is not complete, it returns unknown. An incomplete proof
+	// is a proof where the input address or key terminates in a node that is not a correct
+	// value node, or an empty node.
+	AllStatesZero(root Hash, address Address, from, to Key) (Tribool, error)
+
+	// AllAddressesEmpty checks that all accounts are empty for the input root hash and the address range.
+	// If the witness proof contains all empty accounts for the input address range, it returns true.
+	// An empty account is an account that contains a zero balance, nonce, and code hash.
+	// If there is at least one non-empty account, it returns false. If the proof is not complete,
+	// it returns unknown. An incomplete proof is a proof where the input address terminates in a node
+	// that is not a correct account node.
+	AllAddressesEmpty(root Hash, from, to Address) (Tribool, error)
+}
+
+type witnessProof struct {
+	proof witness.Proof
+}
+
+func (w witnessProof) GetElements() []string {
+	return w.proof.GetElements()
+}
+
+func (w witnessProof) IsValid() bool {
+	return w.proof.IsValid()
+}
+
+func (w witnessProof) GetBalance(root Hash, address Address) (Amount, bool, error) {
+	balance, complete, err := w.proof.GetBalance(common.Hash(root), common.Address(address))
+	return NewAmountFromBytes(balance[:]...), complete, err
+}
+
+func (w witnessProof) GetNonce(root Hash, address Address) (uint64, bool, error) {
+	nonce, complete, err := w.proof.GetNonce(common.Hash(root), common.Address(address))
+	return nonce.ToUint64(), complete, err
+}
+
+func (w witnessProof) GetCodeHash(root Hash, address Address) (Hash, bool, error) {
+	hash, complete, err := w.proof.GetCodeHash(common.Hash(root), common.Address(address))
+	return Hash(hash), complete, err
+}
+
+func (w witnessProof) GetState(root Hash, address Address, key Key) (Value, bool, error) {
+	value, complete, err := w.proof.GetState(common.Hash(root), common.Address(address), common.Key(key))
+	return Value(value), complete, err
+}
+
+func (w witnessProof) AllStatesZero(root Hash, address Address, from, to Key) (Tribool, error) {
+	tri, err := w.proof.AllStatesZero(common.Hash(root), common.Address(address), common.Key(from), common.Key(to))
+	return Tribool(tri), err
+}
+
+func (w witnessProof) AllAddressesEmpty(root Hash, from, to Address) (Tribool, error) {
+	tri, err := w.proof.AllAddressesEmpty(common.Hash(root), common.Address(from), common.Address(to))
+	return Tribool(tri), err
+}

--- a/go/carmen/proof_test.go
+++ b/go/carmen/proof_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package carmen
+
+import (
+	"slices"
+	"sort"
+	"testing"
+)
+
+func TestProof_CreateWitnessProofFromNodes(t *testing.T) {
+	const N = 10
+
+	nodes := make([]string, 0, N)
+	var str string
+	for i := 0; i < N; i++ {
+		str += string(byte(i))
+		nodes = append(nodes, str)
+	}
+
+	// proof will not be valid, but it can be still serialised back and forth
+	proof := CreateWitnessProofFromNodes(nodes...)
+	if proof.IsValid() {
+		t.Errorf("proof should be invalid")
+	}
+	recovered := proof.GetElements()
+
+	sort.Strings(nodes)
+	sort.Strings(recovered)
+
+	if got, want := recovered, nodes; !slices.Equal(got, want) {
+		t.Errorf("unexpected proof elements: got %v, want %v", got, want)
+	}
+}

--- a/go/common/witness/proof.go
+++ b/go/common/witness/proof.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package witness
+
+import (
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
+)
+
+// Proof is an interface for witness proofs. A witness proof is a data structure that
+// contains a witness for a subset of the state. The witness proof can be used to
+// extract information, such as account balances, nonces, code hashes,
+// and storage slots. The witness proof is self-contained and does not require access to
+// the full state to extract information.
+type Proof interface {
+
+	// IsValid checks that this proof is self-consistent. If the result is true, the proof can be used
+	// for extracting verified information. If false, the proof is corrupted and should be discarded.
+	IsValid() bool
+
+	// GetElements returns serialised elements of the witness proof.
+	GetElements() []string
+
+	// GetBalance extracts a balance from the witness proof for the input root hash and the address.
+	// If the witness proof contains the requested account for the input address for the given root hash, it returns its balance.
+	// If the proof does not cover the requested account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetBalance(root common.Hash, address common.Address) (common.Balance, bool, error)
+
+	// GetNonce extracts a nonce from the witness proof for the input root hash and the address.
+	// If the witness proof contains the account for the input address, it returns its nonce.
+	// If the proof does not contain the account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetNonce(root common.Hash, address common.Address) (common.Nonce, bool, error)
+
+	// GetCodeHash extracts a code hash from the witness proof for the input root hash and the address.
+	// If the witness proof contains the account for the input address, it returns its code hash.
+	// If the proof does not contain the account, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetCodeHash(root common.Hash, address common.Address) (common.Hash, bool, error)
+
+	// GetState extracts a storage slot from the witness proof for the input root hash, account address and the storage key.
+	// If the witness proof contains the input storage slot for the input key, it returns its value.
+	// If the proof does not contain the slot, it returns false.
+	// The method may return an error if the proof is invalid.
+	GetState(root common.Hash, address common.Address, key common.Key) (common.Value, bool, error)
+
+	// AllStatesZero checks that all storage slots are empty for the input root hash,
+	// account address and the storage key range. If the witness proof contains all empty slots
+	// for the input key range, it returns true. If there is at least one non-empty slot,
+	// it returns false. If the proof is not complete, it returns unknown. An incomplete proof
+	// is a proof where the input address or key terminates in a node that is not a correct
+	// value node, or an empty node.
+	AllStatesZero(root common.Hash, address common.Address, from, to common.Key) (tribool.Tribool, error)
+
+	// AllAddressesEmpty checks that all accounts are empty for the input root hash and the address range.
+	// If the witness proof contains all empty accounts for the input address range, it returns true.
+	// An empty account is an account that contains a zero balance, nonce, and code hash.
+	// If there is at least one non-empty account, it returns false. If the proof is not complete,
+	// it returns unknown. An incomplete proof is a proof where the input address terminates in a node
+	// that is not a correct account node.
+	AllAddressesEmpty(root common.Hash, from, to common.Address) (tribool.Tribool, error)
+}

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -14,6 +14,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/backend/archive"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"io"
 	"os"
 	"sync"
@@ -239,6 +241,16 @@ func (a *ArchiveTrie) GetHash(block uint64) (hash common.Hash, err error) {
 	res := a.roots.get(block).Hash
 	a.rootsMutex.Unlock()
 	return res, nil
+}
+
+func (a *ArchiveTrie) CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error) {
+	if a.nodeSource.getConfig().Name != "S5-Archive" {
+		return nil, archive.ErrWitnessProofNotSupported
+	}
+	a.rootsMutex.Lock()
+	ref := a.roots.roots[block].NodeRef
+	a.rootsMutex.Unlock()
+	return CreateWitnessProof(a.nodeSource, &ref, address, keys...)
 }
 
 // GetDiff computes the difference between the given source and target blocks.

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -781,6 +781,67 @@ func TestArchiveTrie_CannotGet_AccountHash(t *testing.T) {
 	}
 }
 
+func TestArchiveTrie_CreateWitnessProof(t *testing.T) {
+	for _, config := range []MptConfig{S5LiveConfig, S5ArchiveConfig} {
+		t.Run(config.Name, func(t *testing.T) {
+			arch, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			defer func() {
+				if err := arch.Close(); err != nil {
+					t.Fatalf("failed to close archive; %s", err)
+				}
+			}()
+
+			if err := arch.Add(1, common.Update{
+				CreatedAccounts: []common.Address{{1}},
+				Balances: []common.BalanceUpdate{
+					{Account: common.Address{1}, Balance: common.Balance{0x12}},
+				},
+				Slots: []common.SlotUpdate{
+					{Account: common.Address{1}, Key: common.Key{2}, Value: common.Value{3}},
+				},
+			}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
+
+			proof, err := arch.CreateWitnessProof(1, common.Address{1}, common.Key{2})
+			if err != nil {
+				if errors.Is(err, archive.ErrWitnessProofNotSupported) {
+					t.Skip(err)
+				}
+				t.Fatalf("failed to create witness proof; %s", err)
+			}
+			if !proof.IsValid() {
+				t.Errorf("invalid proof")
+			}
+
+			hash, err := arch.GetHash(1)
+			if err != nil {
+				t.Fatalf("failed to get hash; %s", err)
+			}
+			balance, complete, err := proof.GetBalance(hash, common.Address{1})
+			if err != nil {
+				t.Fatalf("failed to get balance; %s", err)
+			}
+			if !complete {
+				t.Errorf("balance proof is incomplete")
+			}
+			if got, want := balance, (common.Balance{0x12}); got != want {
+				t.Errorf("unexpected balance; got: %x, want: %x", got, want)
+			}
+			value, complete, err := proof.GetState(hash, common.Address{1}, common.Key{2})
+			if err != nil {
+				t.Fatalf("failed to get state; %s", err)
+			}
+			if !complete {
+				t.Errorf("state proof is incomplete")
+			}
+			if got, want := value, (common.Value{3}); got != want {
+				t.Errorf("unexpected value; got: %x, want: %x", got, want)
+			}
+		})
+	}
+}
+
 func TestArchiveTrie_GetDiffProducesValidResults(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {

--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -41,6 +41,18 @@ type WitnessProof struct {
 	proofDb
 }
 
+// CreateWitnessProofFromNodes creates a witness proof from a list of strings.
+// Each string is an RLP node of the witness proof.
+func CreateWitnessProofFromNodes(nodes []string) WitnessProof {
+	db := make(proofDb, len(nodes))
+	for _, n := range nodes {
+		h := common.Keccak256([]byte(n))
+		db[h] = []byte(n)
+	}
+
+	return WitnessProof{db}
+}
+
 // CreateWitnessProof creates a witness proof for the input account address
 // and possibly storage slots of the same account under the input storage keys.
 // This method may return an error when it occurs in the underlying database.
@@ -309,6 +321,15 @@ func (p WitnessProof) String() string {
 		b.WriteString(fmt.Sprintf("0x%x->0x%x\n", k, p.proofDb[k]))
 	}
 	return b.String()
+}
+
+// GetElements returns serialised elements of the witness proof.
+func (p WitnessProof) GetElements() []string {
+	res := make([]string, 0, len(p.proofDb))
+	for _, v := range p.proofDb {
+		res = append(res, string(v))
+	}
+	return res
 }
 
 // MergeProofs merges the input witness proofs and returns the resulting witness proof.

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -23,6 +23,7 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -277,6 +278,10 @@ func (cs *CppState) GetArchiveBlockHeight() (uint64, bool, error) {
 func (cs *CppState) Check() error {
 	// TODO: implement, see https://github.com/Fantom-foundation/Carmen/issues/313
 	return nil
+}
+
+func (cs *CppState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	panic("not implemented")
 }
 
 type objectId struct {

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -13,6 +13,7 @@ package gostate
 import (
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"unsafe"
 
 	"github.com/Fantom-foundation/Carmen/go/backend"
@@ -198,4 +199,16 @@ func (s *ArchiveState) GetArchiveBlockHeight() (uint64, bool, error) {
 
 func (s *ArchiveState) Check() error {
 	return s.archiveError
+}
+
+func (s *ArchiveState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	if err := s.archiveError; err != nil {
+		return nil, err
+	}
+
+	proof, err := s.archive.CreateWitnessProof(s.block, address, keys...)
+	if err != nil {
+		s.archiveError = errors.Join(s.archiveError, err)
+	}
+	return proof, s.archiveError
 }

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -95,6 +95,15 @@ func TestState_ArchiveState_FailingOperation_InvalidatesArchive(t *testing.T) {
 				return err
 			},
 		},
+		"witnessProof": {
+			func(archive *archive.MockArchive, injectedErr error) {
+				archive.EXPECT().CreateWitnessProof(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, injectedErr)
+			},
+			func(stateArchive state.State) error {
+				_, err := stateArchive.CreateWitnessProof(common.Address{}, common.Key{})
+				return err
+			},
+		},
 	}
 
 	testNames := make([]string, 0, len(tests))

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -13,6 +13,7 @@ package gostate
 import (
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"runtime"
 
 	"github.com/Fantom-foundation/Carmen/go/backend"
@@ -423,4 +424,8 @@ func (s *GoState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier
 		verifiers = append(verifiers, verifier)
 	}
 	return backend.NewComposedSnapshotVerifier(verifiers, partCounts), nil
+}
+
+func (s *GoState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	panic("not implemented")
 }

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -15,6 +15,7 @@ package state
 import (
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 )
 
 // NoArchiveError is an error returned by implementation of the State interface
@@ -75,6 +76,11 @@ type State interface {
 	// If an error is reported, all operations since the
 	// last successful check need to be considered invalid.
 	Check() error
+
+	// CreateWitnessProof creates a witness proof for the given account and keys.
+	// Error may be produced when it occurs in the underlying database;
+	// otherwise, the proof is returned.
+	CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error)
 
 	// States can be snapshotted.
 	backend.Snapshotable

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -15,7 +15,6 @@
 //
 //	mockgen -source state.go -destination state_mock.go -package state
 //
-
 // Package state is a generated GoMock package.
 package state
 
@@ -24,6 +23,7 @@ import (
 
 	backend "github.com/Fantom-foundation/Carmen/go/backend"
 	common "github.com/Fantom-foundation/Carmen/go/common"
+	witness "github.com/Fantom-foundation/Carmen/go/common/witness"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -105,6 +105,26 @@ func (m *MockState) CreateSnapshot() (backend.Snapshot, error) {
 func (mr *MockStateMockRecorder) CreateSnapshot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSnapshot", reflect.TypeOf((*MockState)(nil).CreateSnapshot))
+}
+
+// CreateWitnessProof mocks base method.
+func (m *MockState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{address}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateWitnessProof", varargs...)
+	ret0, _ := ret[0].(witness.Proof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWitnessProof indicates an expected call of CreateWitnessProof.
+func (mr *MockStateMockRecorder) CreateWitnessProof(address any, keys ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{address}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWitnessProof", reflect.TypeOf((*MockState)(nil).CreateWitnessProof), varargs...)
 }
 
 // Exists mocks base method.

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -11,6 +11,7 @@
 package state
 
 import (
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"sync"
 
 	"github.com/Fantom-foundation/Carmen/go/backend"
@@ -160,4 +161,10 @@ func (s *syncedState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVeri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.state.GetSnapshotVerifier(metadata)
+}
+
+func (s *syncedState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.CreateWitnessProof(address, keys...)
 }


### PR DESCRIPTION
This PR extends the public API of the  `WitnessProof` support. 

* This defines a new package `witness` with a simple `Proof` interface. 
* This interface is implemented by `mpt.WitnessProof`, i.e. the MPT support of the witness proof. 
* The `carmen.HistoricBlockContext` is extended of a new  features to extract the proof, i.e. a new method `GetProof`
* `State` exposes a method  `CreateWitnessProof` called from `carmen.HistoricBlockContext` and it provides `witness.Proof`, all schemes except S5 do `panic` when calling this method, only the `ArchiveTrie` supports it.  

An example is provided showing how to use.