### PR TITLE
decodes RLP children of empty nodes into hash

### DIFF
--- a/go/database/mpt/decoder.go
+++ b/go/database/mpt/decoder.go
@@ -203,7 +203,11 @@ func decodeEmbeddedOrHashedNode(payload rlp.Item) (node common.Hash, embedded bo
 		if len(item.Str) > common.HashSize {
 			return common.Hash{}, false, fmt.Errorf("node hash is too long: got: %v, wanted: <= 32", len(item.Str))
 		}
-		copy(hash[:], item.Str)
+		if len(item.Str) == 0 {
+			hash = EmptyNodeEthereumHash
+		} else {
+			copy(hash[:], item.Str)
+		}
 	case rlp.List: // embedded node is a two item list of a value node.
 		arr := make([]byte, 0, common.HashSize)
 		if n := copy(hash[:], rlp.EncodeInto(arr, item)); n > 0 && n < common.HashSize {

--- a/go/database/mpt/decoder_test.go
+++ b/go/database/mpt/decoder_test.go
@@ -306,16 +306,34 @@ func TestDecoder_Decode_Node_Instances(t *testing.T) {
 
 	ctxt := newNodeContextWithConfig(t, ctrl, S5LiveConfig)
 
+	childHashes := ChildHashes{}
+	for i := 0; i < 16; i++ {
+		if i == 0xA {
+			continue
+		}
+		childHashes[Nibble(i)] = EmptyNodeEthereumHash
+	}
+
 	tests := map[string]struct {
 		desc NodeDesc
 	}{
 		"branchNode": {&Branch{
 			children: Children{
 				0xA: &Account{address: address, pathLength: 39, info: AccountInfo{Nonce: common.Nonce{0x00, 0x01}, Balance: common.Balance{0x00, 0x02}, CodeHash: common.Hash{0x00, 0x03}}},
-			}}},
+			},
+			childHashes: childHashes,
+		}},
 		"extensionNode": {&Extension{
 			path: AddressToNibblePath(address, ctxt)[0:30],
 			next: &Account{address: address, pathLength: 10, info: AccountInfo{Nonce: common.Nonce{0x00, 0x01}, Balance: common.Balance{0x00, 0x02}, CodeHash: common.Hash{0x00, 0x03}}},
+		}},
+		"extensionNode - next empty hash": {&Extension{
+			path:     AddressToNibblePath(address, ctxt)[0:30],
+			nextHash: &EmptyNodeEthereumHash,
+		}},
+		"extensionNode - next empty node": {&Extension{
+			path: AddressToNibblePath(address, ctxt)[0:30],
+			next: &Empty{},
 		}},
 		"accountNode": {&Account{address: address, pathLength: 40, info: AccountInfo{Nonce: common.Nonce{0x00, 0x01}, Balance: common.Balance{0x00, 0x02}, CodeHash: common.Hash{0x00, 0x03}}}},
 		"valueNode":   {&Value{key: key, length: 64, value: shortValue}},


### PR DESCRIPTION
This PR fixes decoding of RLP nodes back into nodes. 

Since RLP encoded empty children of a branch node are empty strings, the current version used to decode them as a hash with all bytes zero. 

This PR corrects it to store `EmptyNodeEthereumHash` as an empty nodes.  