### PR TITLE
introduces decoded account node to store potentially long paths

### DIFF
--- a/go/database/mpt/decoder_test.go
+++ b/go/database/mpt/decoder_test.go
@@ -82,8 +82,8 @@ func TestDecoder_CanDecodeNodes(t *testing.T) {
 	key1 := common.Key{0x12, 0x34}
 	key2 := common.Key{0x01, 0x23, 0x45}
 
-	address1 := common.Address{0x12, 0x34}
-	address2 := common.Address{0x01, 0x23, 0x45}
+	address1Path := CreatePathFromNibbles([]Nibble{0x1, 0x2, 0x3, 0x4})
+	address2Path := CreatePathFromNibbles([]Nibble{0x1, 0x2, 0x3, 0x4, 0x5})
 
 	tests := map[string]struct {
 		item     rlp.Item
@@ -121,21 +121,21 @@ func TestDecoder_CanDecodeNodes(t *testing.T) {
 			rlp.List{Items: childrenRlp},
 			&BranchNode{hashes: childrenHashes, embeddedChildren: (1 << 14) | (1 << 13)},
 		},
-		"even account empty storage ": {
+		"even account empty storage": {
 			rlp.List{Items: []rlp.Item{rlp.String{Str: []byte{0x20, 0x12, 0x34}}, rlp.String{Str: rlp.Encode(accountDetailEmptyStorage)}}},
-			&AccountNode{address: address1, info: AccountInfo{nonce, balance, hash}, storageHash: EmptyNodeEthereumHash, pathLength: 4},
+			&decodedAccountNode{AccountNode{info: AccountInfo{nonce, balance, hash}, storageHash: EmptyNodeEthereumHash, pathLength: 4}, address1Path},
 		},
-		"even account with storage ": {
+		"even account with storage": {
 			rlp.List{Items: []rlp.Item{rlp.String{Str: []byte{0x20, 0x12, 0x34}}, rlp.String{Str: rlp.Encode(accountDetailStorage)}}},
-			&AccountNode{address: address1, info: AccountInfo{nonce, balance, hash}, storageHash: hash, pathLength: 4},
+			&decodedAccountNode{AccountNode{info: AccountInfo{nonce, balance, hash}, storageHash: hash, pathLength: 4}, address1Path},
 		},
-		"odd account empty storage ": {
+		"odd account empty storage": {
 			rlp.List{Items: []rlp.Item{rlp.String{Str: []byte{0x31, 0x23, 0x45}}, rlp.String{Str: rlp.Encode(accountDetailEmptyStorage)}}},
-			&AccountNode{address: address2, info: AccountInfo{nonce, balance, hash}, storageHash: EmptyNodeEthereumHash, pathLength: 5},
+			&decodedAccountNode{AccountNode{info: AccountInfo{nonce, balance, hash}, storageHash: EmptyNodeEthereumHash, pathLength: 5}, address2Path},
 		},
-		"odd account with storage ": {
+		"odd account with storage": {
 			rlp.List{Items: []rlp.Item{rlp.String{Str: []byte{0x31, 0x23, 0x45}}, rlp.String{Str: rlp.Encode(accountDetailStorage)}}},
-			&AccountNode{address: address2, info: AccountInfo{nonce, balance, hash}, storageHash: hash, pathLength: 5},
+			&decodedAccountNode{AccountNode{info: AccountInfo{nonce, balance, hash}, storageHash: hash, pathLength: 5}, address2Path},
 		},
 	}
 
@@ -412,6 +412,60 @@ func TestDecoder_Decode_ExtensionNodeHasEmbeddedValue(t *testing.T) {
 	}
 }
 
+func TestDecoder_Decode_AccountNode_Instances_Above20bytesPaths(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	address := common.Address{1}
+
+	ctxt := newNodeContextWithConfig(t, ctrl, S5LiveConfig)
+	nibbles := AddressToNibblePath(address, ctxt)
+
+	childHashes := ChildHashes{}
+	for i := 0; i < 16; i++ {
+		if Nibble(i) == nibbles[0] {
+			continue
+		}
+		childHashes[Nibble(i)] = EmptyNodeEthereumHash
+	}
+
+	tests := map[string]struct {
+		desc NodeDesc
+	}{
+		"branchNode": {&Branch{
+			children: Children{
+				nibbles[0]: &Account{address: address, pathLength: 63, info: AccountInfo{Nonce: common.Nonce{0x01}}},
+			},
+			childHashes: childHashes,
+		}},
+		"extensionNode": {&Extension{
+			path: nibbles[0:10],
+			next: &Account{address: address, pathLength: 54, info: AccountInfo{Nonce: common.Nonce{0x01}}},
+		}},
+		"accountNode": {&Account{address: address, pathLength: 64, info: AccountInfo{Nonce: common.Nonce{0x01}}}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, node := ctxt.Build(test.desc)
+			handle := node.GetReadHandle()
+			defer handle.Release()
+
+			want := handle.Get()
+			rlp, err := encodeToRlp(want, ctxt, []byte{})
+			if err != nil {
+				t.Fatalf("failed to encode node: %v", err)
+			}
+
+			got, err := DecodeFromRlp(rlp)
+			if err != nil {
+				t.Fatalf("failed to decode node: %v", err)
+			}
+
+			matchNodesRlpDecoded(t, customiseNodePaths(ctxt, want, 0), got)
+		})
+	}
+}
+
 func TestDecoder_Decode_BranchNodeHasEmbeddedValue(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -471,13 +525,12 @@ func TestDecoder_Decode_BranchNodeHasEmbeddedValue(t *testing.T) {
 // customiseNodePaths modifies input nodes as keys and addresses are different after RLP decoding.
 // RLP decoded contains hashes of keys and addresses, not the original values.
 func customiseNodePaths(ctxt NodeSource, node Node, prevPathLength int) Node {
+	res := node
 	switch node := node.(type) {
 	case *AccountNode:
 		nibbles := AddressToNibblePath(node.address, ctxt)[64-node.pathLength:]
 		path := CreatePathFromNibbles(nibbles)
-		var address common.Address
-		copy(address[:], path.ShiftLeft(prevPathLength).GetPackedNibbles())
-		node.address = address
+		res = &decodedAccountNode{*node, path}
 	case *ValueNode:
 		nibbles := KeyToNibblePath(node.key, ctxt)
 		path := CreatePathFromNibbles(nibbles)
@@ -485,7 +538,7 @@ func customiseNodePaths(ctxt NodeSource, node Node, prevPathLength int) Node {
 		copy(key[:], path.ShiftLeft(prevPathLength).GetPackedNibbles())
 		node.key = key
 	}
-	return node
+	return res
 }
 
 func matchNodesRlpDecoded(t *testing.T, a, b Node) {
@@ -535,13 +588,13 @@ func matchNodesRlpDecoded(t *testing.T, a, b Node) {
 		if aa.hashes != bb.hashes {
 			t.Errorf("expected hashes %v, got %v", aa.hashes, bb.hashes)
 		}
-	case *AccountNode:
-		bb, ok := b.(*AccountNode)
+	case *decodedAccountNode:
+		bb, ok := b.(*decodedAccountNode)
 		if !ok {
 			t.Errorf("expected *AccountNode, got %T", b)
 		}
-		if aa.address != bb.address {
-			t.Errorf("expected address %v, got %v", aa.address, bb.address)
+		if aa.suffix != bb.suffix {
+			t.Errorf("expected address path %v, got %v", aa.suffix, bb.suffix)
 		}
 		if aa.info != bb.info {
 			t.Errorf("expected info %v, got %v", aa.info, bb.info)
@@ -552,5 +605,8 @@ func matchNodesRlpDecoded(t *testing.T, a, b Node) {
 		if aa.pathLength != bb.pathLength {
 			t.Errorf("expected pathLength %v, got %v", aa.pathLength, bb.pathLength)
 		}
+	default:
+		t.Fatalf("unexpected node type %T", b)
 	}
+
 }

--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -235,9 +235,8 @@ func visitWitnessPathTo(source proofDb, root common.Hash, path []Nibble, visitor
 				nextEmbedded = n.isEmbedded(byte(path[0]))
 				path = path[1:]
 			}
-		case *AccountNode:
-			addressPath := createPathFromAddressPrefix(n.address, n.pathLength)
-			if addressPath.IsEqualTo(path) {
+		case *decodedAccountNode:
+			if n.suffix.IsEqualTo(path) {
 				found = true
 			}
 			done = true
@@ -270,25 +269,17 @@ type witnessProofVisitor interface {
 }
 
 type proofCollectingVisitor struct {
-	visited        proofDb     // all visited nodes
-	visitedAccount AccountNode // the last visited account node
+	visited        proofDb            // all visited nodes
+	visitedAccount decodedAccountNode // the last visited account node
 }
 
 func (v *proofCollectingVisitor) Visit(hash common.Hash, rlpNode rlpEncodedNode, node Node, isEmbedded bool) {
 	if !isEmbedded {
 		v.visited[hash] = rlpNode
 	}
-	if account, ok := node.(*AccountNode); ok {
+	if account, ok := node.(*decodedAccountNode); ok {
 		v.visitedAccount = *account
 	}
-}
-
-// createPathFromAddressPrefix creates a path from an address with the given number
-// of nibbles to use from the beginning of the address.
-func createPathFromAddressPrefix(address common.Address, nibbles uint8) Path {
-	res := Path{length: nibbles}
-	copy(res.path[:], address[:])
-	return res
 }
 
 // createPathFromKeyPrefix creates a path from a key with the given number of nibbles

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -72,12 +72,7 @@ func TestWitnessProof_Extract_and_Merge_Proofs(t *testing.T) {
 		}},
 	})
 
-	rootHandle := node.GetViewHandle()
-	rootHash, dirty := rootHandle.Get().GetHash()
-	if dirty {
-		t.Fatalf("expected node to be clean")
-	}
-	rootHandle.Release()
+	rootHash, _ := ctxt.getHashFor(&root)
 
 	// create following reference proofs
 	// 1. proof that contains only nodes for address1 and key1
@@ -180,10 +175,7 @@ func TestWitnessProof_Extract_Various_NodeTypes_NotFoundProofs(t *testing.T) {
 			handle := node.GetViewHandle()
 			defer handle.Release()
 
-			rootHash, dirty := handle.Get().GetHash()
-			if dirty {
-				t.Fatalf("expected node to be clean")
-			}
+			rootHash, _ := ctxt.getHashFor(&root)
 
 			extractedProof, exists := proofWithEmpty.Extract(rootHash, address, key)
 			if exists {
@@ -278,10 +270,8 @@ func TestWitnessProof_Extract_Can_Extract_Terminal_Nodes_In_Proof(t *testing.T) 
 
 			expectedProof := createReferenceProofForLabels(t, ctxt, test.path...)
 
-			handle := node.GetViewHandle()
-			defer handle.Release()
+			rootHash, _ := ctxt.getHashFor(&root)
 
-			rootHash, _ := handle.Get().GetHash()
 			extractedProof, exists := totalProof.Extract(rootHash, address)
 			if exists {
 				t.Fatalf("proof should not exist")
@@ -309,12 +299,9 @@ func TestWitnessProof_Extract_MissingNode_In_Proof(t *testing.T) {
 
 	root, node := ctxt.Build(desc)
 	totalProof := createReferenceProof(t, ctxt, &root, node)
-	handle := node.GetViewHandle()
-	defer handle.Release()
-	rootHash, dirty := handle.Get().GetHash()
-	if dirty {
-		t.Fatalf("expected node to be clean")
-	}
+
+	rootHash, _ := ctxt.getHashFor(&root)
+
 	// remove a non-root node from the proof
 	for k := range totalProof.proofDb {
 		if k != rootHash {
@@ -342,12 +329,9 @@ func TestWitnessProof_Extract_CorruptedRlp_In_Proof(t *testing.T) {
 
 	root, node := ctxt.Build(desc)
 	totalProof := createReferenceProof(t, ctxt, &root, node)
-	handle := node.GetViewHandle()
-	defer handle.Release()
-	rootHash, dirty := handle.Get().GetHash()
-	if dirty {
-		t.Fatalf("expected node to be clean")
-	}
+
+	rootHash, _ := ctxt.getHashFor(&root)
+
 	// corrupt non-root node in the proof
 	for k := range totalProof.proofDb {
 		if k != rootHash {


### PR DESCRIPTION
This PR introduces a new variant of node `DecodedAccountNode`. This is used for an `AccountNode` when decoding from RLP.  The hashed address - the path - may be up to 32bytes and for this reason it does not fit into 20bytes addresses. 

This new type wraps the AccountNode and adds a path to store the RLP decoded Path.  This is furthermore used in `WitnessProof` utilities. 

It fixes #900 