### PR TITLE
fixes propagation of embedded flag when iterating witness proof

### DIFF
--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -198,7 +198,7 @@ func MergeProofs(others ...WitnessProof) WitnessProof {
 func visitWitnessPathTo(source proofDb, root common.Hash, path []Nibble, visitor witnessProofVisitor) (bool, error) {
 	nodeHash := root
 
-	var nextEmbedded bool
+	var nextEmbedded, currentEmbedded bool
 	var found, done bool
 	for !done {
 		var rlpNode rlpEncodedNode
@@ -251,8 +251,9 @@ func visitWitnessPathTo(source proofDb, root common.Hash, path []Nibble, visitor
 			return false, nil // EmptyNode -> do not visit, and terminate
 		}
 
-		visitor.Visit(nodeHash, rlpNode, node, found && nextEmbedded)
+		visitor.Visit(nodeHash, rlpNode, node, currentEmbedded)
 		nodeHash = nextHash
+		currentEmbedded = nextEmbedded
 	}
 
 	return found, nil


### PR DESCRIPTION
This PR fixes propagation of embedded flag.

It was originally assumed that the embedded node is always on the right path.  
Perhaps there may be situations where this is not true - at least a test can be synthesised for this. 

this PR fixes this + extend tests 