### PR TITLE
Use atomic flag to speed up dirty node check

### DIFF
--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sync/atomic"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
@@ -469,7 +470,7 @@ func (c *nodeCheckContext) isCompatible(other *nodeCheckContext) bool {
 type nodeBase struct {
 	hash       common.Hash // the hash of this node (may be dirty)
 	hashStatus hashStatus  // indicating whether this node's hash is valid
-	clean      bool        // by default nodes are dirty (clean == false)
+	clean      atomic.Bool // by default nodes are dirty (clean == false)
 	frozen     bool        // a flag marking the node as immutable (default: mutable)
 }
 
@@ -521,22 +522,25 @@ func (n *nodeBase) markMutable() {
 	n.frozen = false
 }
 
+// IsDirty checks whether the in-memory version is in sync with the on-disk version.
+// This function is thread safe and does not need any specific shared node access
+// permissions to be accessed safely.
 func (n *nodeBase) IsDirty() bool {
-	return !n.clean
+	return !n.clean.Load()
 }
 
 func (n *nodeBase) MarkClean() {
-	n.clean = true
+	n.clean.Store(true)
 }
 
 func (n *nodeBase) markDirty() {
-	n.clean = false
+	n.clean.Store(false)
 	n.hashStatus = hashStatusDirty
 }
 
 func (n *nodeBase) Release() {
 	// The node is disconnected from the disk version and thus clean.
-	n.clean = true
+	n.clean.Store(true)
 	n.hashStatus = hashStatusClean
 }
 

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -7730,9 +7730,8 @@ func (a *Account) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) 
 	if a.hashStatus != nil {
 		hashStatus = *a.hashStatus
 	}
-	return NewNodeReference(AccountId(ctx.nextIndex())), shared.MakeShared[Node](&AccountNode{
+	res := &AccountNode{
 		nodeBase: nodeBase{
-			clean:      !a.dirty,
 			frozen:     a.frozen,
 			hashStatus: hashStatus,
 		},
@@ -7742,7 +7741,9 @@ func (a *Account) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) 
 		storage:          storage,
 		storageHashDirty: a.storageHashDirty,
 		storageHash:      storageHash,
-	})
+	}
+	res.nodeBase.clean.Store(!a.dirty)
+	return NewNodeReference(AccountId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 
 type Children map[Nibble]NodeDesc
@@ -7763,7 +7764,7 @@ type Branch struct {
 func (b *Branch) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(BranchId(ctx.nextIndex()))
 	res := &BranchNode{}
-	res.nodeBase.clean = !b.dirty
+	res.nodeBase.clean.Store(!b.dirty)
 	res.frozen = b.frozen
 	for i, desc := range b.children {
 		ref, _ := ctx.Build(desc)
@@ -7807,7 +7808,7 @@ type Extension struct {
 func (e *Extension) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(ExtensionId(ctx.nextIndex()))
 	res := &ExtensionNode{}
-	res.nodeBase.clean = !e.dirty
+	res.nodeBase.clean.Store(!e.dirty)
 	res.frozen = e.frozen
 	res.path = CreatePathFromNibbles(e.path)
 	res.next, _ = ctx.Build(e.next)
@@ -7857,16 +7858,17 @@ func (v *Value) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	if v.hashStatus != nil {
 		hashStatus = *v.hashStatus
 	}
-	return NewNodeReference(ValueId(ctx.nextIndex())), shared.MakeShared[Node](&ValueNode{
+	res := &ValueNode{
 		nodeBase: nodeBase{
-			clean:      !v.dirty,
 			frozen:     v.frozen,
 			hashStatus: hashStatus,
 		},
 		key:        v.key,
 		value:      v.value,
 		pathLength: v.length,
-	})
+	}
+	res.nodeBase.clean.Store(!v.dirty)
+	return NewNodeReference(ValueId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 
 type entry struct {

--- a/go/database/mpt/shared/shared.go
+++ b/go/database/mpt/shared/shared.go
@@ -56,6 +56,13 @@ func MakeShared[T any](value T) *Shared[T] {
 	}
 }
 
+// GetUnprotected provides direct access to the shared value. It is not
+// synchronized with any other access and is intended for situation where T
+// itself provides synchronization. Any concurrent access is possible.
+func (p *Shared[T]) GetUnprotected() T {
+	return p.value
+}
+
 // TryGetReadHandle tries to get read access to the shared value's content. If
 // successful, indicated by the second return value, shared access to the object
 // is granted until the provided ReadHandle is released again. Other readers,

--- a/go/database/mpt/shared/shared_test.go
+++ b/go/database/mpt/shared/shared_test.go
@@ -46,6 +46,14 @@ func TestShared_LifeCycle(t *testing.T) {
 	read3.Release()
 }
 
+func TestShared_GetUnprotectedReturnsSharedValue(t *testing.T) {
+	var data = new(int)
+	shared := MakeShared(data)
+	if got, want := shared.GetUnprotected(), data; got != want {
+		t.Errorf("unexpected shared value, wanted %v, got %v", want, got)
+	}
+}
+
 func TestShared_ReadAccessDoesNotBlocksReadAccess(t *testing.T) {
 	shared := MakeShared(10)
 	read := shared.GetReadHandle()

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -772,13 +772,13 @@ func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 				handle := node.GetWriteHandle()
 				switch node := handle.Get().(type) {
 				case *BranchNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *ExtensionNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *ValueNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *AccountNode:
-					node.clean = false
+					node.clean.Store(false)
 				}
 				handle.Release()
 			})


### PR DESCRIPTION
This PR updates the `dirty` flag in nodes to be an atomic value. By doing so, determining whether a node is dirty can be conducted by a single atomic read operation. Before that, a lock hat to be required and released, involving multiple atomic read/write operations.

This change reduces the time required for flushing nodes. It also constitutes a preparation step for a follow-up PR introducing a  worker performing node-flushes in the background.

Impact of this change on the MPT performance (single sample each):
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/e79fffa4-c63b-402a-be07-a72727362efe)

The data was collected by running
```
go run ./database/mpt/tool benchmark
```

Impact on locating dirty hashes in the CPU profile:
Before (total costs of shown operation is 0.81 seconds):
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/475dc7d7-664b-488c-a24a-7cf6208c1793)

After (total costs of shown operation is 0.49 seconds):
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/2113c658-31ce-42b4-9080-02eea0bce908)

