### PR TITLE
Update storing of archive roots to be incremental

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -33,7 +33,7 @@ type ArchiveTrie struct {
 	head         LiveState // the current head-state
 	forest       Database  // global forest with all versions of LiveState
 	nodeSource   NodeSource
-	roots        []Root     // the roots of individual blocks indexed by block height
+	roots        rootList   // the roots of individual blocks indexed by block height
 	rootsMutex   sync.Mutex // protecting access to the roots list
 	rootFile     string     // the file storing the list of roots
 	addMutex     sync.Mutex // a mutex to make sure that at any time only one thread is adding new blocks
@@ -83,10 +83,10 @@ func VerifyArchiveTrie(directory string, config MptConfig, observer Verification
 	if err != nil {
 		return err
 	}
-	if len(roots) == 0 {
+	if len(roots.roots) == 0 {
 		return nil
 	}
-	return VerifyMptState(directory, config, roots, observer)
+	return VerifyMptState(directory, config, roots.roots, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
@@ -100,20 +100,20 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 	defer a.addMutex.Unlock()
 
 	a.rootsMutex.Lock()
-	if uint64(len(a.roots)) > block {
+	if uint64(a.roots.Length()) > block {
 		a.rootsMutex.Unlock()
 		return fmt.Errorf("block %d already present", block)
 	}
 
 	// Mark skipped blocks as having no changes.
-	if uint64(len(a.roots)) < block {
+	if uint64(a.roots.Length()) < block {
 		lastHash, err := a.head.GetHash()
 		if err != nil {
 			a.rootsMutex.Unlock()
 			return a.addError(err)
 		}
-		for uint64(len(a.roots)) < block {
-			a.roots = append(a.roots, Root{a.head.Root(), lastHash})
+		for uint64(a.roots.Length()) < block {
+			a.roots.Append(Root{a.head.Root(), lastHash})
 		}
 	}
 	a.rootsMutex.Unlock()
@@ -150,14 +150,14 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 
 	// Save new root node.
 	a.rootsMutex.Lock()
-	a.roots = append(a.roots, Root{a.head.Root(), hash})
+	a.roots.Append(Root{a.head.Root(), hash})
 	a.rootsMutex.Unlock()
 	return nil
 }
 
 func (a *ArchiveTrie) GetBlockHeight() (block uint64, empty bool, err error) {
 	a.rootsMutex.Lock()
-	length := uint64(len(a.roots))
+	length := uint64(a.roots.Length())
 	a.rootsMutex.Unlock()
 	if length == 0 {
 		return 0, true, nil
@@ -231,12 +231,12 @@ func (a *ArchiveTrie) GetAccountHash(block uint64, account common.Address) (comm
 
 func (a *ArchiveTrie) GetHash(block uint64) (hash common.Hash, err error) {
 	a.rootsMutex.Lock()
-	length := uint64(len(a.roots))
+	length := uint64(a.roots.Length())
 	if block >= length {
 		a.rootsMutex.Unlock()
 		return common.Hash{}, fmt.Errorf("invalid block: %d >= %d", block, length)
 	}
-	res := a.roots[block].Hash
+	res := a.roots.Get(block).Hash
 	a.rootsMutex.Unlock()
 	return res, nil
 }
@@ -244,16 +244,16 @@ func (a *ArchiveTrie) GetHash(block uint64) (hash common.Hash, err error) {
 // GetDiff computes the difference between the given source and target blocks.
 func (a *ArchiveTrie) GetDiff(srcBlock, trgBlock uint64) (Diff, error) {
 	a.rootsMutex.Lock()
-	if srcBlock >= uint64(len(a.roots)) {
+	if srcBlock >= uint64(a.roots.Length()) {
 		a.rootsMutex.Unlock()
-		return Diff{}, fmt.Errorf("source block %d not present in archive, highest block is %d", srcBlock, len(a.roots)-1)
+		return Diff{}, fmt.Errorf("source block %d not present in archive, highest block is %d", srcBlock, a.roots.Length()-1)
 	}
-	if trgBlock >= uint64(len(a.roots)) {
+	if trgBlock >= uint64(a.roots.Length()) {
 		a.rootsMutex.Unlock()
-		return Diff{}, fmt.Errorf("target block %d not present in archive, highest block is %d", trgBlock, len(a.roots)-1)
+		return Diff{}, fmt.Errorf("target block %d not present in archive, highest block is %d", trgBlock, a.roots.Length()-1)
 	}
-	before := a.roots[srcBlock].NodeRef
-	after := a.roots[trgBlock].NodeRef
+	before := a.roots.Get(srcBlock).NodeRef
+	after := a.roots.Get(trgBlock).NodeRef
 	a.rootsMutex.Unlock()
 	return GetDiff(a.nodeSource, &before, &after)
 }
@@ -263,11 +263,11 @@ func (a *ArchiveTrie) GetDiff(srcBlock, trgBlock uint64) (Diff, error) {
 func (a *ArchiveTrie) GetDiffForBlock(block uint64) (Diff, error) {
 	if block == 0 {
 		a.rootsMutex.Lock()
-		if len(a.roots) == 0 {
+		if a.roots.Length() == 0 {
 			a.rootsMutex.Unlock()
 			return Diff{}, fmt.Errorf("archive is empty, no diff present for block 0")
 		}
-		after := a.roots[0].NodeRef
+		after := a.roots.Get(0).NodeRef
 		a.rootsMutex.Unlock()
 		return GetDiff(a.nodeSource, &emptyNodeReference, &after)
 	}
@@ -278,15 +278,15 @@ func (a *ArchiveTrie) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*a))
 	mf.AddChild("head", a.head.GetMemoryFootprint())
 	a.rootsMutex.Lock()
-	mf.AddChild("roots", common.NewMemoryFootprint(uintptr(len(a.roots))*unsafe.Sizeof(NodeId(0))))
+	mf.AddChild("roots", common.NewMemoryFootprint(uintptr(a.roots.Length())*unsafe.Sizeof(NodeId(0))))
 	a.rootsMutex.Unlock()
 	return mf
 }
 
 func (a *ArchiveTrie) Check() error {
-	roots := make([]*NodeReference, len(a.roots))
-	for i := 0; i < len(a.roots); i++ {
-		roots[i] = &a.roots[i].NodeRef
+	roots := make([]*NodeReference, a.roots.Length())
+	for i := 0; i < a.roots.Length(); i++ {
+		roots[i] = &a.roots.roots[i].NodeRef
 	}
 	return errors.Join(
 		a.CheckErrors(),
@@ -296,7 +296,7 @@ func (a *ArchiveTrie) Check() error {
 func (a *ArchiveTrie) Dump() {
 	a.rootsMutex.Lock()
 	defer a.rootsMutex.Unlock()
-	for i, root := range a.roots {
+	for i, root := range a.roots.roots {
 		fmt.Printf("\nBlock %d: %x\n", i, root.Hash)
 		view := getTrieView(root.NodeRef, a.forest)
 		view.Dump()
@@ -310,7 +310,7 @@ func (a *ArchiveTrie) Flush() error {
 	return errors.Join(
 		a.CheckErrors(),
 		a.head.Flush(),
-		StoreRoots(a.rootFile, a.roots),
+		a.roots.storeRoots(),
 	)
 }
 
@@ -326,12 +326,12 @@ func (a *ArchiveTrie) getView(block uint64) (*LiveTrie, error) {
 	}
 
 	a.rootsMutex.Lock()
-	length := uint64(len(a.roots))
+	length := uint64(a.roots.Length())
 	if block >= length {
 		a.rootsMutex.Unlock()
 		return nil, fmt.Errorf("invalid block: %d >= %d", block, length)
 	}
-	rootRef := a.roots[block].NodeRef
+	rootRef := a.roots.roots[block].NodeRef
 	a.rootsMutex.Unlock()
 	return getTrieView(rootRef, a.forest), nil
 }
@@ -358,19 +358,47 @@ func (a *ArchiveTrie) addError(err error) error {
 
 // ---- Reading and Writing Root Node ID Lists ----
 
-func loadRoots(filename string) ([]Root, error) {
+// rootList is a utility type managing an in-memory copy of the list of roots
+// of an archive and its synchronization with a on-disk file copy.
+type rootList struct {
+	roots          []Root
+	filename       string
+	numRootsInFile int
+}
+
+func (l *rootList) Length() int {
+	return len(l.roots)
+}
+
+func (l *rootList) Get(block uint64) Root {
+	return l.roots[block]
+}
+
+func (l *rootList) Append(r Root) {
+	l.roots = append(l.roots, r)
+}
+
+func loadRoots(filename string) (rootList, error) {
 	// If there is no file, initialize and return an empty list.
 	if _, err := os.Stat(filename); err != nil {
-		return nil, nil
+		return rootList{filename: filename}, nil
 	}
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return rootList{}, err
 	}
 	defer f.Close()
 	reader := bufio.NewReader(f)
-	return loadRootsFrom(reader)
+	roots, err := loadRootsFrom(reader)
+	if err != nil {
+		return rootList{}, err
+	}
+	return rootList{
+		roots:          roots,
+		filename:       filename,
+		numRootsInFile: len(roots),
+	}, nil
 }
 
 func loadRootsFrom(reader io.Reader) ([]Root, error) {
@@ -397,15 +425,30 @@ func loadRootsFrom(reader io.Reader) ([]Root, error) {
 }
 
 func StoreRoots(filename string, roots []Root) error {
-	f, err := os.Create(filename)
+	list := rootList{roots: roots, filename: filename}
+	return list.storeRoots()
+}
+
+func (l *rootList) storeRoots() error {
+	toBeWritten := l.roots[l.numRootsInFile:]
+	if l.numRootsInFile > 0 && len(toBeWritten) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(l.filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}
 	writer := bufio.NewWriter(f)
-	return errors.Join(
-		storeRootsTo(writer, roots),
+	res := errors.Join(
+		storeRootsTo(writer, toBeWritten),
 		writer.Flush(),
-		f.Close())
+		f.Close(),
+	)
+	if res == nil {
+		l.numRootsInFile = len(l.roots)
+	}
+	return res
 }
 
 func storeRootsTo(writer io.Writer, roots []Root) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -359,7 +359,7 @@ func (a *ArchiveTrie) addError(err error) error {
 // ---- Reading and Writing Root Node ID Lists ----
 
 // rootList is a utility type managing an in-memory copy of the list of roots
-// of an archive and its synchronization with a on-disk file copy.
+// of an archive and its synchronization with an on-disk file copy.
 type rootList struct {
 	roots          []Root
 	filename       string

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -118,7 +119,7 @@ func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 
 	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
 	}
 }
 
@@ -134,12 +135,12 @@ func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 
 	// remove read access
 	if err := os.Chmod(filepath.Join(dir, "roots.dat"), 0); err != nil {
-		t.Fatalf("cannot chmod rotos file: %v", err)
+		t.Fatalf("cannot chmod roots file: %v", err)
 	}
 
 	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
 	}
 }
 
@@ -547,12 +548,12 @@ func TestArchive_RootsGrowSubLinearly(t *testing.T) {
 				}
 
 				if i > threshold {
-					if got, want := cap(archive.roots), int(factor*float64(prevCap)); got >= want {
+					if got, want := cap(archive.roots.roots), int(factor*float64(prevCap)); got >= want {
 						t.Fatalf("array grows too fast: %d >= %d", got, want)
 					}
 				}
 
-				prevCap = cap(archive.roots)
+				prevCap = cap(archive.roots.roots)
 			}
 		})
 	}
@@ -1160,17 +1161,22 @@ func TestArchiveTrie_CanLoadRootsFromJunkySource(t *testing.T) {
 }
 
 func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
-	roots := []Root{}
+	file := filepath.Join(t.TempDir(), "roots.dat")
+	original, err := loadRoots(file)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	if original.Length() != 0 {
+		t.Errorf("unexpected number of roots, wanted 0, got %d", original.Length())
+	}
 	for i := 0; i < 48; i++ {
 		id := NodeId(uint64(1) << i)
-		roots = append(roots, Root{NodeRef: NewNodeReference(id)})
+		original.Append(Root{NodeRef: NewNodeReference(id)})
 		id = NodeId((uint64(1) << (i + 1)) - 1)
-		roots = append(roots, Root{NodeRef: NewNodeReference(id)})
+		original.Append(Root{NodeRef: NewNodeReference(id)})
 	}
 
-	dir := t.TempDir()
-	file := dir + string(filepath.Separator) + "roots.dat"
-	if err := StoreRoots(file, roots); err != nil {
+	if err := original.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
@@ -1178,16 +1184,121 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if len(roots) != len(restored) {
-		t.Fatalf("invalid number of restored roots, wanted %d, got %d", len(roots), len(restored))
+	if want, got := original.Length(), restored.Length(); want != got {
+		t.Fatalf("invalid number of restored roots, wanted %d, got %d", want, got)
 	}
 
-	for i := 0; i < len(roots); i++ {
-		want := roots[i].NodeRef.Id()
-		got := restored[i].NodeRef.Id()
+	for i := 0; i < original.Length(); i++ {
+		want := original.roots[i].NodeRef.Id()
+		got := restored.roots[i].NodeRef.Id()
 		if want != got {
 			t.Errorf("invalid restored root at position %d, wanted %v, got %v", i, want, got)
 		}
+	}
+}
+
+func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "roots.dat")
+	list, err := loadRoots(file)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	// The first write establishes a list of roots in the output file.
+	list.Append(Root{})
+	list.Append(Root{})
+	list.Append(Root{})
+	if err := list.storeRoots(); err != nil {
+		t.Fatalf("failed to store roots: %v", err)
+	}
+
+	// We redirect the incremental update into another file to see what is written.
+	list.filename = filepath.Join(t.TempDir(), "roots2.dat")
+	list.Append(Root{})
+	list.Append(Root{})
+	if err := list.storeRoots(); err != nil {
+		t.Fatalf("failed to store roots: %v", err)
+	}
+
+	// Loading the second file should only produce 2 roots.
+	restored, err := loadRoots(list.filename)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	if want, got := 2, restored.Length(); want != got {
+		t.Fatalf("invalid number of restored roots, wanted %d, got %d", want, got)
+	}
+}
+
+func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "roots.dat")
+	list, err := loadRoots(file)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	if list.Length() != 0 {
+		t.Errorf("unexpected number of roots, wanted 0, got %d", list.Length())
+	}
+
+	counter := 0
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 10; j++ {
+			id := NodeId(counter)
+			list.Append(Root{NodeRef: NewNodeReference(id)})
+			counter++
+		}
+		if err := list.storeRoots(); err != nil {
+			t.Fatalf("failed to store roots: %v", err)
+		}
+
+		restored, err := loadRoots(file)
+		if err != nil {
+			t.Fatalf("failed to reload roots: %v", err)
+		}
+
+		if !reflect.DeepEqual(list, restored) {
+			t.Fatalf("failed to restore roots, wanted %v, got %v", list, restored)
+		}
+	}
+}
+
+func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "roots.dat")
+	roots := []Root{
+		{NewNodeReference(ValueId(12)), common.Hash{12}},
+		{NewNodeReference(ValueId(14)), common.Hash{14}},
+	}
+
+	if err := StoreRoots(file, roots); err != nil {
+		t.Fatalf("failed to store roots: %v", err)
+	}
+	restored, err := loadRoots(file)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	if !slices.Equal(roots, restored.roots) {
+		t.Errorf("failed to restore roots, wanted %v, got %v", roots, restored.roots)
+	}
+}
+
+func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "roots.dat")
+	list, err := loadRoots(file)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	if err := list.storeRoots(); err != nil {
+		t.Fatalf("failed to store empty roots file: %v", err)
+	}
+
+	// remove write access
+	if err := os.Chmod(file, 0x400); err != nil {
+		t.Fatalf("cannot chmod roots file: %v", err)
+	}
+
+	list.Append(Root{})
+	if err := list.storeRoots(); err == nil {
+		t.Errorf("expected an error when storing roots into non-accessible file")
 	}
 }
 

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1166,14 +1166,14 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if original.Length() != 0 {
-		t.Errorf("unexpected number of roots, wanted 0, got %d", original.Length())
+	if original.length() != 0 {
+		t.Errorf("unexpected number of roots, wanted 0, got %d", original.length())
 	}
 	for i := 0; i < 48; i++ {
 		id := NodeId(uint64(1) << i)
-		original.Append(Root{NodeRef: NewNodeReference(id)})
+		original.append(Root{NodeRef: NewNodeReference(id)})
 		id = NodeId((uint64(1) << (i + 1)) - 1)
-		original.Append(Root{NodeRef: NewNodeReference(id)})
+		original.append(Root{NodeRef: NewNodeReference(id)})
 	}
 
 	if err := original.storeRoots(); err != nil {
@@ -1184,11 +1184,11 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if want, got := original.Length(), restored.Length(); want != got {
+	if want, got := original.length(), restored.length(); want != got {
 		t.Fatalf("invalid number of restored roots, wanted %d, got %d", want, got)
 	}
 
-	for i := 0; i < original.Length(); i++ {
+	for i := 0; i < original.length(); i++ {
 		want := original.roots[i].NodeRef.Id()
 		got := restored.roots[i].NodeRef.Id()
 		if want != got {
@@ -1205,17 +1205,17 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	}
 
 	// The first write establishes a list of roots in the output file.
-	list.Append(Root{})
-	list.Append(Root{})
-	list.Append(Root{})
+	list.append(Root{})
+	list.append(Root{})
+	list.append(Root{})
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
 	// We redirect the incremental update into another file to see what is written.
 	list.filename = filepath.Join(t.TempDir(), "roots2.dat")
-	list.Append(Root{})
-	list.Append(Root{})
+	list.append(Root{})
+	list.append(Root{})
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
@@ -1225,7 +1225,7 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if want, got := 2, restored.Length(); want != got {
+	if want, got := 2, restored.length(); want != got {
 		t.Fatalf("invalid number of restored roots, wanted %d, got %d", want, got)
 	}
 }
@@ -1236,15 +1236,15 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if list.Length() != 0 {
-		t.Errorf("unexpected number of roots, wanted 0, got %d", list.Length())
+	if list.length() != 0 {
+		t.Errorf("unexpected number of roots, wanted 0, got %d", list.length())
 	}
 
 	counter := 0
 	for i := 0; i < 5; i++ {
 		for j := 0; j < 10; j++ {
 			id := NodeId(counter)
-			list.Append(Root{NodeRef: NewNodeReference(id)})
+			list.append(Root{NodeRef: NewNodeReference(id)})
 			counter++
 		}
 		if err := list.storeRoots(); err != nil {
@@ -1296,7 +1296,7 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 		t.Fatalf("cannot chmod roots file: %v", err)
 	}
 
-	list.Append(Root{})
+	list.append(Root{})
 	if err := list.storeRoots(); err == nil {
 		t.Errorf("expected an error when storing roots into non-accessible file")
 	}

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1539,3 +1539,17 @@ var archiveGetters = map[string]func(archive archive.Archive) error{
 		return err
 	},
 }
+
+func BenchmarkArchiveFlush_Roots(b *testing.B) {
+	archive, err := OpenArchiveTrie(b.TempDir(), S5ArchiveConfig, 1000)
+	if err != nil {
+		b.Fatalf("cannot open archive: %v", err)
+	}
+	defer archive.Close()
+	archive.Add(1_000_000, common.Update{}, nil)
+	for i := 0; i < b.N; i++ {
+		if err := archive.Flush(); err != nil {
+			b.Fatalf("failed to flush archive: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the export of roots to be incremental.

Before this change, every time an Archive was flushed or closed, the full list of roots has been dumped to the root file on the disk. In particular for large archives, covering 85 million blocks, this corresponds to writing more than 3 GiB of data to the disk.

With this change, the Archie is tracking how much roots are already stored on the disk and only writes incremental updates to the disk. As a side-effect, in consecutive `Flush` and `Close` calls, new roots are only written once.

For a benchmark stress-testing the storing of 1M root nodes in an archive, this results in a more than 90% reduction in the time required to flush an archive:
```
pkg: github.com/Fantom-foundation/Carmen/go/database/mpt
cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
                     │  before.log   │              after.log               │
                     │    sec/op     │    sec/op     vs base                │
ArchiveFlush_Roots-4   498.65m ± 17%   30.96m ± 14%  -93.79% (p=0.000 n=10)
```

This can also be seen in the CPU profiles. Before the change:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/626f371e-4eb4-4ddb-b25d-e40f3f933f1d)

and after, the root hashes are no longer written during the `Close` operation since they have already been synced by the `Flush`:
![image](https://github.com/Fantom-foundation/Carmen/assets/4097849/dfa3e5c8-da03-41b3-840a-b3537d3ff873)
