### PR TITLE
Improve efficiency of the scan for dirty nodes

### DIFF
--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -523,10 +523,7 @@ func (s *Forest) Flush() error {
 	// Get snapshot of set of dirty Node IDs.
 	ids := make([]NodeId, 0, 1<<16)
 	s.nodeCache.ForEach(func(id NodeId, node *shared.Shared[Node]) {
-		handle := node.GetViewHandle()
-		dirty := handle.Get().IsDirty()
-		handle.Release()
-		if dirty {
+		if node.GetUnprotected().IsDirty() {
 			ids = append(ids, id)
 		}
 	})
@@ -553,6 +550,10 @@ func (s *Forest) flushDirtyIds(ids []NodeId) error {
 		if present {
 			handle := node.GetWriteHandle()
 			node := handle.Get()
+			if !node.IsDirty() {
+				handle.Release()
+				continue
+			}
 			err := s.flushNode(id, node)
 			if err == nil {
 				node.MarkClean()

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -911,7 +911,7 @@ func (s *Forest) createAccount() (NodeReference, shared.WriteHandle[Node], error
 	instance, present := s.addToCache(&ref, shared.MakeShared[Node](node))
 	if present {
 		write := instance.GetWriteHandle()
-		*write.Get().(*AccountNode) = *node
+		write.Get().Reset()
 		write.Release()
 	}
 	return ref, instance.GetWriteHandle(), err
@@ -927,7 +927,7 @@ func (s *Forest) createBranch() (NodeReference, shared.WriteHandle[Node], error)
 	instance, present := s.addToCache(&ref, shared.MakeShared[Node](node))
 	if present {
 		write := instance.GetWriteHandle()
-		*write.Get().(*BranchNode) = *node
+		write.Get().Reset()
 		write.Release()
 	}
 	return ref, instance.GetWriteHandle(), err
@@ -943,7 +943,7 @@ func (s *Forest) createExtension() (NodeReference, shared.WriteHandle[Node], err
 	instance, present := s.addToCache(&ref, shared.MakeShared[Node](node))
 	if present {
 		write := instance.GetWriteHandle()
-		*write.Get().(*ExtensionNode) = *node
+		write.Get().Reset()
 		write.Release()
 	}
 	return ref, instance.GetWriteHandle(), err
@@ -959,7 +959,7 @@ func (s *Forest) createValue() (NodeReference, shared.WriteHandle[Node], error) 
 	instance, present := s.addToCache(&ref, shared.MakeShared[Node](node))
 	if present {
 		write := instance.GetWriteHandle()
-		*write.Get().(*ValueNode) = *node
+		write.Get().Reset()
 		write.Release()
 	}
 	return ref, instance.GetWriteHandle(), err

--- a/go/database/mpt/node_flusher.go
+++ b/go/database/mpt/node_flusher.go
@@ -87,16 +87,9 @@ func tryFlushDirtyNodes(cache NodeCache, sink NodeSink) error {
 	dirtyIds := *(dirtyIdsPtr)
 	dirtyIds = dirtyIds[:0]
 	cache.ForEach(func(id NodeId, node *shared.Shared[Node]) {
-		handle, success := node.TryGetViewHandle()
-		if !success {
-			return
+		if node.GetUnprotected().IsDirty() {
+			dirtyIds = append(dirtyIds, id)
 		}
-		dirty := handle.Get().IsDirty()
-		handle.Release()
-		if !dirty {
-			return
-		}
-		dirtyIds = append(dirtyIds, id)
 	})
 
 	// The IDs are sorted to increase the chance of sequential

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -781,9 +781,7 @@ func (n *BranchNode) setNextNode(
 		}
 		defer handle.Release()
 		newNode := handle.Get().(*BranchNode)
-		*newNode = *n
-		newNode.markDirty()
-		newNode.markMutable()
+		newNode.assign(n)
 		n = newNode
 		thisRef = &newRef
 		isClone = true
@@ -948,6 +946,16 @@ func (n *BranchNode) Reset() {
 	n.dirtyHashes = 0
 	n.embeddedChildren = 0
 	n.frozenChildren = 0
+}
+
+func (n *BranchNode) assign(other *BranchNode) {
+	n.nodeBase.markDirty()
+	n.nodeBase.markMutable()
+	n.children = other.children
+	n.hashes = other.hashes
+	n.dirtyHashes = other.dirtyHashes
+	n.embeddedChildren = other.embeddedChildren
+	n.frozenChildren = other.frozenChildren
 }
 
 func (n *BranchNode) MarkFrozen() {
@@ -1209,9 +1217,7 @@ func (n *ExtensionNode) setNextNode(
 				}
 				defer handle.Release()
 				newNode := handle.Get().(*ExtensionNode)
-				*newNode = *n
-				newNode.markDirty()
-				newNode.markMutable()
+				newNode.assign(n)
 				thisRef, n = &newRef, newNode
 				isClone = true
 			}
@@ -1292,9 +1298,7 @@ func (n *ExtensionNode) setNextNode(
 		}
 		defer handle.Release()
 		newNode := handle.Get().(*ExtensionNode)
-		*newNode = *n
-		newNode.markDirty()
-		newNode.markMutable()
+		newNode.assign(n)
 		thisRef, n = &newRef, newNode
 		isClone = true
 	}
@@ -1431,6 +1435,16 @@ func (n *ExtensionNode) Reset() {
 	n.next = NodeReference{}
 	n.nextHashDirty = true
 	n.nextIsEmbedded = false
+}
+
+func (n *ExtensionNode) assign(other *ExtensionNode) {
+	n.nodeBase.markDirty()
+	n.nodeBase.markMutable()
+	n.path = other.path
+	n.next = other.next
+	n.nextHash = other.nextHash
+	n.nextHashDirty = other.nextHashDirty
+	n.nextIsEmbedded = other.nextIsEmbedded
 }
 
 func (n *ExtensionNode) Freeze(manager NodeManager, this shared.WriteHandle[Node]) error {
@@ -1608,9 +1622,7 @@ func (n *AccountNode) SetAccount(manager NodeManager, thisRef *NodeReference, th
 			}
 			defer handle.Release()
 			newNode := handle.Get().(*AccountNode)
-			*newNode = *n
-			newNode.markDirty()
-			newNode.markMutable()
+			newNode.assign(n)
 			newNode.info = info
 			return newRef, false, nil
 		}
@@ -1762,9 +1774,7 @@ func (n *AccountNode) SetSlot(manager NodeManager, thisRef *NodeReference, this 
 			}
 			defer newHandle.Release()
 			newNode := newHandle.Get().(*AccountNode)
-			*newNode = *n
-			newNode.markDirty()
-			newNode.markMutable()
+			newNode.assign(n)
 			newNode.storage = root
 			newNode.storageHashDirty = true
 			return newRef, false, nil
@@ -1794,9 +1804,7 @@ func (n *AccountNode) ClearStorage(manager NodeManager, thisRef *NodeReference, 
 		}
 		defer newHandle.Release()
 		newNode := newHandle.Get().(*AccountNode)
-		*newNode = *n
-		newNode.markDirty()
-		newNode.markMutable()
+		newNode.assign(n)
 		newNode.storage = NewNodeReference(EmptyId())
 		newNode.storageHashDirty = true
 		return newRef, false, nil
@@ -1840,6 +1848,17 @@ func (n *AccountNode) Reset() {
 	n.pathLength = 0
 }
 
+func (n *AccountNode) assign(other *AccountNode) {
+	n.nodeBase.markDirty()
+	n.nodeBase.markMutable()
+	n.address = other.address
+	n.info = other.info
+	n.storage = other.storage
+	n.storageHash = other.storageHash
+	n.storageHashDirty = other.storageHashDirty
+	n.pathLength = other.pathLength
+}
+
 func (n *AccountNode) setPathLength(manager NodeManager, thisRef *NodeReference, this shared.WriteHandle[Node], length byte) (NodeReference, bool, error) {
 	if n.pathLength == length {
 		return *thisRef, false, nil
@@ -1851,9 +1870,7 @@ func (n *AccountNode) setPathLength(manager NodeManager, thisRef *NodeReference,
 		}
 		defer newHandle.Release()
 		newNode := newHandle.Get().(*AccountNode)
-		*newNode = *n
-		newNode.markDirty()
-		newNode.markMutable()
+		newNode.assign(n)
 		newNode.pathLength = length
 		return newRef, false, nil
 	}
@@ -2084,6 +2101,14 @@ func (n *ValueNode) Reset() {
 	n.key = common.Key{}
 	n.value = common.Value{}
 	n.pathLength = 0
+}
+
+func (n *ValueNode) assign(other *ValueNode) {
+	n.nodeBase.markDirty()
+	n.nodeBase.markMutable()
+	n.key = other.key
+	n.value = other.value
+	n.pathLength = other.pathLength
 }
 
 func (n *ValueNode) setPathLength(manager NodeManager, thisRef *NodeReference, this shared.WriteHandle[Node], length byte) (NodeReference, bool, error) {

--- a/go/database/mpt/nodes_mocks.go
+++ b/go/database/mpt/nodes_mocks.go
@@ -237,6 +237,18 @@ func (mr *MockNodeMockRecorder) Release(manager, thisRef, this any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockNode)(nil).Release), manager, thisRef, this)
 }
 
+// Reset mocks base method.
+func (m *MockNode) Reset() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset")
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockNodeMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockNode)(nil).Reset))
+}
+
 // SetAccount mocks base method.
 func (m *MockNode) SetAccount(manager NodeManager, thisRef *NodeReference, this shared.WriteHandle[Node], address common.Address, path []Nibble, info AccountInfo) (NodeReference, bool, error) {
 	m.ctrl.T.Helper()
@@ -860,6 +872,18 @@ func (m *MockleafNode) Release(manager NodeManager, thisRef *NodeReference, this
 func (mr *MockleafNodeMockRecorder) Release(manager, thisRef, this any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockleafNode)(nil).Release), manager, thisRef, this)
+}
+
+// Reset mocks base method.
+func (m *MockleafNode) Reset() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset")
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockleafNodeMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockleafNode)(nil).Reset))
 }
 
 // SetAccount mocks base method.

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -7806,9 +7806,8 @@ func (a *Account) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) 
 	if a.hashStatus != nil {
 		hashStatus = *a.hashStatus
 	}
-	return NewNodeReference(AccountId(ctx.nextIndex())), shared.MakeShared[Node](&AccountNode{
+	res := &AccountNode{
 		nodeBase: nodeBase{
-			clean:      !a.dirty,
 			frozen:     a.frozen,
 			hashStatus: hashStatus,
 		},
@@ -7818,7 +7817,9 @@ func (a *Account) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) 
 		storage:          storage,
 		storageHashDirty: a.storageHashDirty,
 		storageHash:      storageHash,
-	})
+	}
+	res.nodeBase.clean.Store(!a.dirty)
+	return NewNodeReference(AccountId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 
 type Children map[Nibble]NodeDesc
@@ -7839,7 +7840,7 @@ type Branch struct {
 func (b *Branch) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(BranchId(ctx.nextIndex()))
 	res := &BranchNode{}
-	res.nodeBase.clean = !b.dirty
+	res.nodeBase.clean.Store(!b.dirty)
 	res.frozen = b.frozen
 	for i, desc := range b.children {
 		ref, _ := ctx.Build(desc)
@@ -7883,7 +7884,7 @@ type Extension struct {
 func (e *Extension) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(ExtensionId(ctx.nextIndex()))
 	res := &ExtensionNode{}
-	res.nodeBase.clean = !e.dirty
+	res.nodeBase.clean.Store(!e.dirty)
 	res.frozen = e.frozen
 	res.path = CreatePathFromNibbles(e.path)
 	res.next, _ = ctx.Build(e.next)
@@ -7933,16 +7934,17 @@ func (v *Value) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	if v.hashStatus != nil {
 		hashStatus = *v.hashStatus
 	}
-	return NewNodeReference(ValueId(ctx.nextIndex())), shared.MakeShared[Node](&ValueNode{
+	res := &ValueNode{
 		nodeBase: nodeBase{
-			clean:      !v.dirty,
 			frozen:     v.frozen,
 			hashStatus: hashStatus,
 		},
 		key:        v.key,
 		value:      v.value,
 		pathLength: v.length,
-	})
+	}
+	res.nodeBase.clean.Store(!v.dirty)
+	return NewNodeReference(ValueId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 
 type entry struct {

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -14,11 +14,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
@@ -7818,7 +7819,9 @@ func (a *Account) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) 
 		storageHashDirty: a.storageHashDirty,
 		storageHash:      storageHash,
 	}
-	res.nodeBase.clean.Store(!a.dirty)
+	if !a.dirty {
+		res.MarkClean()
+	}
 	return NewNodeReference(AccountId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 
@@ -7840,7 +7843,9 @@ type Branch struct {
 func (b *Branch) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(BranchId(ctx.nextIndex()))
 	res := &BranchNode{}
-	res.nodeBase.clean.Store(!b.dirty)
+	if !b.dirty {
+		res.MarkClean()
+	}
 	res.frozen = b.frozen
 	for i, desc := range b.children {
 		ref, _ := ctx.Build(desc)
@@ -7884,7 +7889,9 @@ type Extension struct {
 func (e *Extension) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 	ref := NewNodeReference(ExtensionId(ctx.nextIndex()))
 	res := &ExtensionNode{}
-	res.nodeBase.clean.Store(!e.dirty)
+	if !e.dirty {
+		res.MarkClean()
+	}
 	res.frozen = e.frozen
 	res.path = CreatePathFromNibbles(e.path)
 	res.next, _ = ctx.Build(e.next)
@@ -7943,7 +7950,9 @@ func (v *Value) Build(ctx *nodeContext) (NodeReference, *shared.Shared[Node]) {
 		value:      v.value,
 		pathLength: v.length,
 	}
-	res.nodeBase.clean.Store(!v.dirty)
+	if !v.dirty {
+		res.MarkClean()
+	}
 	return NewNodeReference(ValueId(ctx.nextIndex())), shared.MakeShared[Node](res)
 }
 

--- a/go/database/mpt/shared/shared.go
+++ b/go/database/mpt/shared/shared.go
@@ -56,6 +56,13 @@ func MakeShared[T any](value T) *Shared[T] {
 	}
 }
 
+// GetUnprotected provides direct access to the shared value. It is not
+// synchronized with any other access and is intended for situation where T
+// itself provides synchronization. Any concurrent access is possible.
+func (p *Shared[T]) GetUnprotected() T {
+	return p.value
+}
+
 // TryGetReadHandle tries to get read access to the shared value's content. If
 // successful, indicated by the second return value, shared access to the object
 // is granted until the provided ReadHandle is released again. Other readers,

--- a/go/database/mpt/shared/shared_test.go
+++ b/go/database/mpt/shared/shared_test.go
@@ -46,6 +46,14 @@ func TestShared_LifeCycle(t *testing.T) {
 	read3.Release()
 }
 
+func TestShared_GetUnprotectedReturnsSharedValue(t *testing.T) {
+	var data = new(int)
+	shared := MakeShared(data)
+	if got, want := shared.GetUnprotected(), data; got != want {
+		t.Errorf("unexpected shared value, wanted %v, got %v", want, got)
+	}
+}
+
 func TestShared_ReadAccessDoesNotBlocksReadAccess(t *testing.T) {
 	shared := MakeShared(10)
 	read := shared.GetReadHandle()

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -772,13 +772,13 @@ func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 				handle := node.GetWriteHandle()
 				switch node := handle.Get().(type) {
 				case *BranchNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *ExtensionNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *ValueNode:
-					node.clean = false
+					node.clean.Store(false)
 				case *AccountNode:
-					node.clean = false
+					node.clean.Store(false)
 				}
 				handle.Release()
 			})

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -772,13 +772,13 @@ func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 				handle := node.GetWriteHandle()
 				switch node := handle.Get().(type) {
 				case *BranchNode:
-					node.clean.Store(false)
+					node.markDirty()
 				case *ExtensionNode:
-					node.clean.Store(false)
+					node.markDirty()
 				case *ValueNode:
-					node.clean.Store(false)
+					node.markDirty()
 				case *AccountNode:
-					node.clean.Store(false)
+					node.markDirty()
 				}
 				handle.Release()
 			})


### PR DESCRIPTION
This PR applies some performance improvement on the scan for dirty nodes during flush operations. The main change is to track the dirty-state of nodes using atomic operations to facilitate checking for dirty nodes without the need of acquiring node-access permissions.

This reduces the time it takes to search for dirty nodes by more than 60%:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Carmen/go/database/mpt
cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
                                              │  before.log  │              after.log               │
                                              │    sec/op    │    sec/op     vs base                │
NodeFlusher_CollectDirtyNodes/size=1000-4       33.796µ ± 4%   5.372µ ±  3%  -84.10% (p=0.000 n=10)
NodeFlusher_CollectDirtyNodes/size=10000-4      335.45µ ± 3%   54.32µ ±  7%  -83.81% (p=0.000 n=10)
NodeFlusher_CollectDirtyNodes/size=100000-4      3.891m ± 1%   1.462m ±  3%  -62.41% (p=0.000 n=10)
NodeFlusher_CollectDirtyNodes/size=1000000-4     39.50m ± 3%   14.70m ±  2%  -62.78% (p=0.000 n=10)
NodeFlusher_CollectDirtyNodes/size=10000000-4    399.0m ± 4%   142.6m ± 30%  -64.25% (p=0.000 n=10)
geomean                                          3.702m        978.0µ        -73.58%
```

### Notes for Reviewers
By introducing atomic operations on the `clean` flag in the `nodeBase` assignment operations on the node level like the one done in the `Forest` implementation (e.g. `*write.Get().(*AccountNode) = *node`) introduce a race condition since the reset of the `clean` flag is not atomic in this case. Thus, a new `Reset` function needed to be introduced, performing the `clean` flag reset using an atomic operation.