### PR TITLE
Fill missing hashes for archive nodes when visiting path

### DIFF
--- a/go/database/mpt/hasher.go
+++ b/go/database/mpt/hasher.go
@@ -348,56 +348,9 @@ func (h ethHasher) updateHashesInternal(
 			// At this point the hashes of all children are up-to-date.
 			// They can now be transferred to the parents.
 			node := cur.handle.Get()
-			switch cur := node.(type) {
-			case *BranchNode:
-				for i := 0; i < len(cur.children); i++ {
-					if !cur.children[i].Id().IsEmpty() && cur.isChildHashDirty(byte(i)) {
-						handle, e := manager.getViewAccess(&cur.children[i])
-						if e != nil {
-							err = e
-							break
-						}
-						hash, dirty := handle.Get().GetHash()
-						if dirty {
-							panic("FATAL: detected dirty child of branch node\n")
-						}
-						cur.hashes[i] = hash
-						cur.setEmbedded(byte(i), embedded[cur.children[i].Id()])
-						handle.Release()
-					}
-				}
-				cur.clearChildHashDirtyFlags()
-			case *ExtensionNode:
-				if cur.nextHashDirty {
-					handle, e := manager.getViewAccess(&cur.next)
-					if e != nil {
-						err = e
-						break
-					}
-					hash, dirty := handle.Get().GetHash()
-					if dirty {
-						panic("FATAL: detected dirty child of extension node\n")
-					}
-					cur.nextIsEmbedded = embedded[cur.next.Id()]
-					cur.nextHash = hash
-					handle.Release()
-					cur.nextHashDirty = false
-				}
-			case *AccountNode:
-				if cur.storageHashDirty && !cur.storage.Id().IsEmpty() {
-					handle, e := manager.getViewAccess(&cur.storage)
-					if e != nil {
-						err = e
-						break
-					}
-					hash, dirty := handle.Get().GetHash()
-					if dirty {
-						panic("FATAL: detected dirty child of account node\n")
-					}
-					cur.storageHash = hash
-					handle.Release()
-					cur.storageHashDirty = false
-				}
+			if e := updateChildrenHashes(manager, node, embedded); e != nil {
+				err = e
+				break
 			}
 
 			// Test whether this node is to be embedded.
@@ -466,6 +419,60 @@ func (h ethHasher) getHash(ref *NodeReference, source NodeSource) (common.Hash, 
 	}
 
 	return common.Keccak256(data), nil
+}
+
+// updateChildrenHashes refreshes the hashes of all children of the given node.
+func updateChildrenHashes(manager NodeSource, node Node, embedded map[NodeId]bool) error {
+	switch cur := node.(type) {
+	case *BranchNode:
+		for i := 0; i < len(cur.children); i++ {
+			if !cur.children[i].Id().IsEmpty() && cur.isChildHashDirty(byte(i)) {
+				handle, e := manager.getViewAccess(&cur.children[i])
+				if e != nil {
+					return e
+				}
+				hash, dirty := handle.Get().GetHash()
+				if dirty {
+					panic("FATAL: detected dirty child of branch node\n")
+				}
+				cur.hashes[i] = hash
+				cur.setEmbedded(byte(i), embedded[cur.children[i].Id()])
+				handle.Release()
+			}
+		}
+		cur.clearChildHashDirtyFlags()
+	case *ExtensionNode:
+		if cur.nextHashDirty {
+			handle, e := manager.getViewAccess(&cur.next)
+			if e != nil {
+				return e
+			}
+			hash, dirty := handle.Get().GetHash()
+			if dirty {
+				panic("FATAL: detected dirty child of extension node\n")
+			}
+			cur.nextIsEmbedded = embedded[cur.next.Id()]
+			cur.nextHash = hash
+			handle.Release()
+			cur.nextHashDirty = false
+		}
+	case *AccountNode:
+		if cur.storageHashDirty && !cur.storage.Id().IsEmpty() {
+			handle, e := manager.getViewAccess(&cur.storage)
+			if e != nil {
+				return e
+			}
+			hash, dirty := handle.Get().GetHash()
+			if dirty {
+				panic("FATAL: detected dirty child of account node\n")
+			}
+			cur.storageHash = hash
+			handle.Release()
+			cur.storageHashDirty = false
+		}
+	}
+
+	return nil
 }
 
 // encodeToRlp computes the RLP encoding of the given node. If needed, additional nodes are
@@ -747,6 +754,17 @@ func getEncodedPartialPathSize(numNibbles int) int {
 // marked dirty, this information is updated. Thus, calls to this function may
 // cause updates to the state of some nodes.
 func (h ethHasher) isEmbedded(
+	node Node,
+	source NodeSource,
+) (bool, error) {
+	return isNodeEmbedded(node, source)
+}
+
+// isNodeEmbedded determines whether the given node is an embedded node or not.
+// If information required for determining the embedded-state of the node is
+// marked dirty, this information is updated. Thus, calls to this function may
+// cause updates to the state of some nodes.
+func isNodeEmbedded(
 	node Node,
 	source NodeSource,
 ) (bool, error) {


### PR DESCRIPTION
This PR extends the method `CreateWitnessProof`, which iterates nodes from a root to a leaf node for a path.

This change fills children hashes (extension node, children of branch node, storage of account) back to the parents for archive node.

These hashes are missing when nodes are loaded from the archive, It caused wrong hashes computed from RLP of those nodes. It then produced a wrong witness proof.   