### PR TITLE
Disable node flusher to fix nightly builds

### DIFF
--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -290,7 +290,7 @@ func makeForest(
 
 	// Start a background worker flushing dirty nodes to disk.
 	res.flusher = startNodeFlusher(res.nodeCache, sink, nodeFlusherConfig{
-		period: forestConfig.BackgroundFlushPeriod,
+		period: -1 * time.Second, // forestConfig.BackgroundFlushPeriod,  // disabled for now, see #948
 	})
 
 	// Run a background worker releasing entire tries of nodes on demand.


### PR DESCRIPTION
This mitigates the problem outlined in #948 until its cause has been identified and fixed.

By disabling this feature, the hope is to pass nightly builds and to allow pending PRs to be processed.