### PR TITLE
Make flush interval configurable

### DIFF
--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -60,7 +60,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S4",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig, mpt.DefaultMptStateCapacity)
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig, mpt.NodeCacheConfig{})
 				if err != nil {
 					tb.Fatalf("failed to open S4 archive: %v", err)
 				}
@@ -71,7 +71,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S5",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig, mpt.DefaultMptStateCapacity)
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
 				if err != nil {
 					tb.Fatalf("failed to open S5 archive: %v", err)
 				}

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -41,7 +41,7 @@ type ArchiveTrie struct {
 	archiveError error // a non-nil error will be stored here should it occur during any archive operation
 }
 
-func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*ArchiveTrie, error) {
+func OpenArchiveTrie(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*ArchiveTrie, error) {
 	lock, err := openStateDirectory(directory)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheCapacity int) (*Ar
 	if err != nil {
 		return nil, err
 	}
-	forestConfig := ForestConfig{Mode: Immutable, CacheCapacity: cacheCapacity}
+	forestConfig := ForestConfig{Mode: Immutable, NodeCacheConfig: cacheConfig}
 	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err

--- a/go/database/mpt/archive_trie_fuzzing_test.go
+++ b/go/database/mpt/archive_trie_fuzzing_test.go
@@ -963,7 +963,7 @@ func (c *archiveTrieAccountFuzzingCampaign[T, C]) Init() []fuzzing.OperationSequ
 // the created context.
 func (c *archiveTrieAccountFuzzingCampaign[T, C]) CreateContext(t fuzzing.TestingT) *C {
 	path := t.TempDir()
-	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, 10_000)
+	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, NodeCacheConfig{Capacity: 10_000})
 	if err != nil {
 		t.Fatalf("failed to open archive trie: %v", err)
 	}

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -43,7 +43,7 @@ import (
 func TestArchiveTrie_OpenAndClose(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -56,11 +56,11 @@ func TestArchiveTrie_OpenAndClose(t *testing.T) {
 
 func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open test archive: %v", err)
 	}
-	if _, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if _, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		t.Fatalf("archive should not be accessible by more than one instance")
 	}
 	if err := archive.Close(); err != nil {
@@ -71,7 +71,7 @@ func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
 func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < 5; i++ {
-		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 		if err != nil {
 			t.Fatalf("failed to open test archive: %v", err)
 		}
@@ -83,7 +83,7 @@ func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestArchiveTrie_Open_Fails_Wrong_Roots(t *testing.T) {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("openning archive should not succeed")
 	}
@@ -104,7 +104,7 @@ func TestArchiveTrie_Open_Fails_Wrong_Roots(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("opening archive should not succeed")
 	}
@@ -125,7 +125,7 @@ func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 		t.Fatalf("cannot chmod roots file: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("opening archive should not succeed")
 	}
@@ -146,7 +146,7 @@ func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_ForestMeta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestArchiveTrie_Open_Fails_Wrong_ForestMeta(t *testing.T) {
 		t.Fatalf("cannot update meta: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("openning archive should not succeed")
 	}
@@ -167,7 +167,7 @@ func TestArchiveTrie_Open_Fails_Wrong_ForestMeta(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_TrieMeta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestArchiveTrie_Open_Fails_Wrong_TrieMeta(t *testing.T) {
 		t.Fatalf("cannot update meta: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("openning archive should not succeed")
 	}
@@ -188,7 +188,7 @@ func TestArchiveTrie_Open_Fails_Wrong_TrieMeta(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_Codes(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestArchiveTrie_Open_Fails_Wrong_Codes(t *testing.T) {
 		t.Fatalf("cannot update codes: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
 		_ = archive.Close()
 		t.Errorf("openning archive should not succeed")
 	}
@@ -210,7 +210,7 @@ func TestArchiveTrie_Open_Fails_Wrong_Codes(t *testing.T) {
 func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -248,7 +248,7 @@ func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -292,7 +292,7 @@ func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 
 func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -316,13 +316,13 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 			continue
 		}
 		t.Run(config.Name, func(t *testing.T) {
-			live, err := OpenGoMemoryState(t.TempDir(), config, 1024)
+			live, err := OpenGoMemoryState(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open live trie: %v", err)
 			}
 
 			archiveDir := t.TempDir()
-			archive, err := OpenArchiveTrie(archiveDir, config, 1024)
+			archive, err := OpenArchiveTrie(archiveDir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -412,7 +412,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -463,7 +463,7 @@ func TestArchiveTrie_Add_DuplicatedBlock(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -488,7 +488,7 @@ func TestArchiveTrie_Add_UpdateFailsHashing(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 0)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -516,7 +516,7 @@ func TestArchiveTrie_Add_UpdateFailsHashing(t *testing.T) {
 func TestArchive_RootsGrowSubLinearly(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, 0)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -564,7 +564,7 @@ func TestArchiveTrie_Add_LiveStateFailsHashing(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 0)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -591,7 +591,7 @@ func TestArchiveTrie_Add_LiveStateFailsCreateAccount(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 0)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -618,9 +618,9 @@ func TestArchiveTrie_Add_FreezingFails(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 0)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
-				t.Fatalf("failed to openarchive, err %v", err)
+				t.Fatalf("failed to open archive, err %v", err)
 			}
 
 			// inject failing stock to trigger an error applying the update
@@ -646,7 +646,7 @@ func TestArchiveTrie_GettingView_Block_OutOfRange(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -675,7 +675,7 @@ func TestArchiveTrie_GetCodes(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -729,7 +729,7 @@ func TestArchiveTrie_GetHash(t *testing.T) {
 			dir := t.TempDir()
 
 			{
-				archive, err := OpenArchiveTrie(dir, config, 1024)
+				archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 				if err != nil {
 					t.Fatalf("failed to create empty archive, err %v", err)
 				}
@@ -745,7 +745,7 @@ func TestArchiveTrie_GetHash(t *testing.T) {
 				}
 			}
 
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -770,7 +770,7 @@ func TestArchiveTrie_CannotGet_AccountHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -785,7 +785,7 @@ func TestArchiveTrie_GetDiffProducesValidResults(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -884,7 +884,7 @@ func TestArchiveTrie_GetDiffDetectsInvalidInput(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -935,7 +935,7 @@ func TestArchiveTrie_GetDiffForBlockProducesValidResults(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -995,7 +995,7 @@ func TestArchiveTrie_GetDiffForBlockDetectsEmptyArchive(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1013,7 +1013,7 @@ func TestArchiveTrie_GetMemoryFootprint(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1033,7 +1033,7 @@ func TestArchiveTrie_Dump(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1053,7 +1053,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1093,7 +1093,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, 1024)
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1305,7 +1305,7 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 func TestArchiveTrie_RecreateAccount_ClearStorage(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, 1024)
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -1356,7 +1356,7 @@ func TestArchiveTrie_RecreateAccount_ClearStorage(t *testing.T) {
 
 func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 	// Goal: stress-test an archive with a limited node cache.
-	archive, err := OpenArchiveTrie(t.TempDir(), S5ArchiveConfig, 30_000)
+	archive, err := OpenArchiveTrie(t.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 30_000})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -1490,7 +1490,7 @@ func TestArchiveTrie_FailingGetterOperation_InvalidatesArchive(t *testing.T) {
 			db.EXPECT().GetAccountInfo(gomock.Any(), gomock.Any()).Return(AccountInfo{}, false, injectedErr).MaxTimes(1)
 			db.EXPECT().GetValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Value{}, injectedErr).MaxTimes(1)
 
-			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, 1000)
+			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000})
 			if err != nil {
 				t.Fatalf("cannot open archive: %v", err)
 			}
@@ -1575,7 +1575,7 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			db.EXPECT().Freeze(gomock.Any()).AnyTimes()
 			db.EXPECT().CheckAll(gomock.Any()).AnyTimes()
 
-			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, 1000)
+			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000})
 			if err != nil {
 				t.Fatalf("cannot open archive: %v", err)
 			}
@@ -1652,7 +1652,7 @@ var archiveGetters = map[string]func(archive archive.Archive) error{
 }
 
 func BenchmarkArchiveFlush_Roots(b *testing.B) {
-	archive, err := OpenArchiveTrie(b.TempDir(), S5ArchiveConfig, 1000)
+	archive, err := OpenArchiveTrie(b.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 1000})
 	if err != nil {
 		b.Fatalf("cannot open archive: %v", err)
 	}

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -45,10 +45,10 @@ var fileAndMemVariants = []variant{
 }
 
 var forestConfigs = map[string]ForestConfig{
-	"mutable_1k":     {Mode: Mutable, CacheCapacity: 1024},
-	"mutable_128k":   {Mode: Mutable, CacheCapacity: 128 * 1024},
-	"immutable_1k":   {Mode: Immutable, CacheCapacity: 1024},
-	"immutable_128k": {Mode: Immutable, CacheCapacity: 128 * 1024},
+	"mutable_1k":     {Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}},
+	"mutable_128k":   {Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 128 * 1024}},
+	"immutable_1k":   {Mode: Immutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}},
+	"immutable_128k": {Mode: Immutable, NodeCacheConfig: NodeCacheConfig{Capacity: 128 * 1024}},
 }
 
 func TestForest_Cannot_Open_Corrupted_Stock_Meta(t *testing.T) {
@@ -66,7 +66,7 @@ func TestForest_Cannot_Open_Corrupted_Stock_Meta(t *testing.T) {
 						t.Fatalf("cannot prepare for test: %s", err)
 					}
 
-					if _, err := variant.factory(rootDir, config, ForestConfig{Mode: Mutable, CacheCapacity: 1024}); err == nil {
+					if _, err := variant.factory(rootDir, config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}}); err == nil {
 						t.Errorf("opening forest should fail")
 					}
 				})
@@ -84,7 +84,7 @@ func TestForest_Cannot_Open_Corrupted_Forest_Meta(t *testing.T) {
 					t.Fatalf("cannot prepare for test: %s", err)
 				}
 
-				if _, err := variant.factory(dir, config, ForestConfig{Mode: Mutable, CacheCapacity: 1024}); err == nil {
+				if _, err := variant.factory(dir, config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}}); err == nil {
 					t.Errorf("opening forest should fail")
 				}
 			})
@@ -102,7 +102,7 @@ func TestForest_Cannot_Open_Cannot_Parse_Meta(t *testing.T) {
 					t.Fatalf("cannot prepare for test: %s", err)
 				}
 
-				if _, err := variant.factory(dir, config, ForestConfig{Mode: Mutable, CacheCapacity: 1024}); err == nil {
+				if _, err := variant.factory(dir, config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}}); err == nil {
 					t.Errorf("opening forest should fail")
 				}
 			})
@@ -119,10 +119,10 @@ func TestForest_Cannot_Open_Meta_DoesNot_Match(t *testing.T) {
 				t.Fatalf("cannot prepare for test: %s", err)
 			}
 
-			if _, err := variant.factory(dir, S5LiveConfig, ForestConfig{Mode: Mutable, CacheCapacity: 0}); err == nil {
+			if _, err := variant.factory(dir, S5LiveConfig, ForestConfig{Mode: Mutable}); err == nil {
 				t.Errorf("opening forest should fail")
 			}
-			if _, err := variant.factory(dir, S4LiveConfig, ForestConfig{Mode: Immutable, CacheCapacity: 0}); err == nil {
+			if _, err := variant.factory(dir, S4LiveConfig, ForestConfig{Mode: Immutable}); err == nil {
 				t.Errorf("opening forest should fail")
 			}
 		})
@@ -314,7 +314,7 @@ func TestForest_Freeze_Fails(t *testing.T) {
 			t.Run(fmt.Sprintf("%s-%s", variant.name, config.Name), func(t *testing.T) {
 				directory := t.TempDir()
 
-				forest, err := variant.factory(directory, config, ForestConfig{Mode: Immutable, CacheCapacity: 1024})
+				forest, err := variant.factory(directory, config, ForestConfig{Mode: Immutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}})
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}
@@ -450,7 +450,7 @@ func TestForest_Release_Queue_Error_Release_Node(t *testing.T) {
 			t.Run(fmt.Sprintf("%s-%s", variant.name, config.Name), func(t *testing.T) {
 				directory := t.TempDir()
 
-				forest, err := variant.factory(directory, config, ForestConfig{Mode: Mutable, CacheCapacity: 1024})
+				forest, err := variant.factory(directory, config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}})
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}
@@ -970,7 +970,7 @@ func TestForest_InLiveModeHistoryIsOverridden(t *testing.T) {
 	for _, variant := range variants {
 		for _, config := range allMptConfigs {
 			t.Run(fmt.Sprintf("%s-%s", variant.name, config.Name), func(t *testing.T) {
-				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Mutable, CacheCapacity: 1024})
+				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}})
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}
@@ -1014,7 +1014,7 @@ func TestForest_InArchiveModeHistoryIsPreserved(t *testing.T) {
 	for _, variant := range variants {
 		for _, config := range allMptConfigs {
 			t.Run(fmt.Sprintf("%s-%s", variant.name, config.Name), func(t *testing.T) {
-				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Immutable, CacheCapacity: 1024})
+				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Immutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}})
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}
@@ -1238,7 +1238,6 @@ func TestForest_ReleaserReleasesNodesOnlyOnce(t *testing.T) {
 
 	forest, err := makeForest(
 		MptConfig{Hashing: DirectHashing},
-		t.TempDir(),
 		branches,
 		extensions,
 		accounts,
@@ -1332,12 +1331,11 @@ func testForest_WriteBufferRecoveryIsThreadSafe(t *testing.T, withConcurrentNode
 
 	forest, err := makeForest(
 		MptConfig{Hashing: DirectHashing},
-		t.TempDir(),
 		branches,
 		extensions,
 		accounts,
 		values,
-		ForestConfig{CacheCapacity: 1},
+		ForestConfig{NodeCacheConfig: NodeCacheConfig{Capacity: 1}},
 	)
 	if err != nil {
 		t.Fatalf("failed to create test forest: %v", err)
@@ -1455,7 +1453,7 @@ func openFileShadowForest(directory string, mptConfig MptConfig, forestConfig Fo
 	extensions := shadow.MakeShadowStock(extensionsA, extensionsB)
 	accounts := shadow.MakeShadowStock(accountsA, accountsB)
 	values := shadow.MakeShadowStock(valuesA, valuesB)
-	return makeForest(mptConfig, directory, branches, extensions, accounts, values, forestConfig)
+	return makeForest(mptConfig, branches, extensions, accounts, values, forestConfig)
 }
 
 func TestForest_NodeHandlingDoesNotDeadlock(t *testing.T) {
@@ -1489,14 +1487,15 @@ func TestForest_NodeHandlingDoesNotDeadlock(t *testing.T) {
 
 	forest, err := makeForest(
 		MptConfig{Hashing: DirectHashing},
-		t.TempDir(),
 		branches,
 		extensions,
 		accounts,
 		values,
 		ForestConfig{
-			CacheCapacity:          1,
-			writeBufferChannelSize: 1,
+			NodeCacheConfig: NodeCacheConfig{
+				Capacity:               1,
+				writeBufferChannelSize: 1,
+			},
 		},
 	)
 	if err != nil {
@@ -1562,8 +1561,8 @@ func TestForest_CheckPassesAfterReopeningDirectory(t *testing.T) {
 					// it, and check that the consistency test still passes.
 					dir := t.TempDir()
 					forestConfig := ForestConfig{
-						Mode:          mode,
-						CacheCapacity: 1024,
+						Mode:            mode,
+						NodeCacheConfig: NodeCacheConfig{Capacity: 1024},
 					}
 					forest, err := OpenFileForest(dir, config, forestConfig)
 					if err != nil {
@@ -1799,7 +1798,6 @@ func TestForest_ErrorsAreForwardedAndCollected(t *testing.T) {
 
 			forest, err := makeForest(
 				MptConfig{Hashing: DirectHashing},
-				t.TempDir(),
 				branches,
 				extensions,
 				accounts,
@@ -1838,7 +1836,6 @@ func TestForest_MultipleErrorsCanBeCollected(t *testing.T) {
 
 	forest, err := makeForest(
 		MptConfig{Hashing: DirectHashing},
-		t.TempDir(),
 		branches,
 		extensions,
 		accounts,
@@ -1892,7 +1889,6 @@ func TestForest_CollectedErrorsAreReportedInFlushAndClose(t *testing.T) {
 
 	forest, err := makeForest(
 		MptConfig{Hashing: DirectHashing},
-		t.TempDir(),
 		branches,
 		extensions,
 		accounts,
@@ -1970,7 +1966,7 @@ func TestForest_AsyncDelete_CacheIsNotExhausted(t *testing.T) {
 				// The tree is shallow - 1 account + 4byte storage addresses.
 				// The size of the cache here is estimated considering the numbers above, but it is not set
 				// exactly as some nodes are created and then deleted while building the tree.
-				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Mutable, CacheCapacity: 10})
+				forest, err := variant.factory(t.TempDir(), config, ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 10}})
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}

--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -66,7 +66,7 @@ func ExportArchive(ctx context.Context, directory string, out io.Writer) error {
 		return fmt.Errorf("can only support export of S5 Archive instances, found %v in directory", info.Config.Name)
 	}
 
-	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.DefaultMptStateCapacity)
+	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func importArchive(liveDbDir, archiveDbDir string, in io.Reader) (err error) {
 	}
 
 	// Create a live-DB updated in parallel for faster hash computation.
-	live, err := mpt.OpenGoFileState(liveDbDir, mpt.S5LiveConfig, mpt.DefaultMptStateCapacity)
+	live, err := mpt.OpenGoFileState(liveDbDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to create auxiliary live DB: %w", err)
 	}
@@ -251,7 +251,7 @@ func importArchive(liveDbDir, archiveDbDir string, in io.Reader) (err error) {
 	}()
 
 	// Create an empty archive.
-	archive, err := mpt.OpenArchiveTrie(archiveDbDir, mpt.S5ArchiveConfig, mpt.DefaultMptStateCapacity)
+	archive, err := mpt.OpenArchiveTrie(archiveDbDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to create empty state: %w", err)
 	}

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -24,7 +24,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 
 	// Create a small Archive to be exported.
 	sourceDir := t.TempDir()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, 1024)
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
-	target, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, 1024)
+	target, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 
 	// Create a small Archive to be exported.
 	sourceDir := t.TempDir()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, 1024)
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 		t.Fatalf("verification of imported LiveDB failed: %v", err)
 	}
 
-	live, err := mpt.OpenFileLiveTrie(path.Join(targetDir, "live"), mpt.S5LiveConfig, 1024)
+	live, err := mpt.OpenFileLiveTrie(path.Join(targetDir, "live"), mpt.S5LiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("cannot open live trie: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
-	archive, err := mpt.OpenArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, 1024)
+	archive, err := mpt.OpenArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}

--- a/go/database/mpt/io/interrupt_test.go
+++ b/go/database/mpt/io/interrupt_test.go
@@ -89,7 +89,7 @@ func createTestLive(t *testing.T, sourceDir string) {
 
 func createTestArchive(t *testing.T, sourceDir string) {
 	t.Helper()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, 1024)
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -101,7 +101,7 @@ func createTestArchive(t *testing.T, sourceDir string) {
 
 // checkCanOpenLiveDB makes sure LiveDB is not corrupted and can be opened (and closed)
 func checkCanOpenLiveDB(t *testing.T, sourceDir string) {
-	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig, mpt.DefaultMptStateCapacity)
+	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -113,7 +113,7 @@ func checkCanOpenLiveDB(t *testing.T, sourceDir string) {
 
 // checkCanOpenLiveDB makes sure Archive is not corrupted and can be opened (and closed)
 func checkCanOpenArchive(t *testing.T, sourceDir string) {
-	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.DefaultMptStateCapacity)
+	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		t.Fatalf("failed to open archive: %v", err)
 	}

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -67,7 +67,7 @@ func Export(ctx context.Context, directory string, out io.Writer) error {
 		return fmt.Errorf("can only support export of LiveDB instances, found %v in directory", info.Mode)
 	}
 
-	db, err := mpt.OpenGoFileState(directory, info.Config, mpt.DefaultMptStateCapacity)
+	db, err := mpt.OpenGoFileState(directory, info.Config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to open LiveDB: %v", err)
 	}
@@ -181,7 +181,7 @@ func runImport(directory string, in io.Reader, config mpt.MptConfig) (root mpt.N
 	}
 
 	// Create a state.
-	db, err := mpt.OpenGoFileState(directory, config, mpt.DefaultMptStateCapacity)
+	db, err := mpt.OpenGoFileState(directory, config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return root, hash, fmt.Errorf("failed to create empty state: %v", err)
 	}

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -35,7 +35,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 
-	db, err := mpt.OpenGoFileState(targetDir, mpt.S5LiveConfig, 1024)
+	db, err := mpt.OpenGoFileState(targetDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 
-	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, 1024)
+	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
@@ -152,7 +152,7 @@ func exportExampleState(t *testing.T) ([]byte, common.Hash) {
 
 func createExampleLiveDB(t *testing.T, sourceDir string) *mpt.MptState {
 	// Create a small LiveDB.
-	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig, 1024)
+	db, err := mpt.OpenGoFileState(sourceDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create test DB: %v", err)
 	}

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -38,8 +38,8 @@ type LiveTrie struct {
 // OpenInMemoryLiveTrie loads trie information from the given directory and
 // creates a LiveTrie instance retaining all information in memory. If the
 // directory is empty, an empty trie is created.
-func OpenInMemoryLiveTrie(directory string, config MptConfig, cacheCapacity int) (*LiveTrie, error) {
-	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: cacheCapacity}
+func OpenInMemoryLiveTrie(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*LiveTrie, error) {
+	forestConfig := ForestConfig{Mode: Mutable, NodeCacheConfig: cacheConfig}
 	forest, err := OpenInMemoryForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func OpenInMemoryLiveTrie(directory string, config MptConfig, cacheCapacity int)
 // creates a LiveTrie instance using a fixed-size cache for retaining nodes in
 // memory, backed by a file-based storage automatically kept in sync. If the
 // directory is empty, an empty trie is created.
-func OpenFileLiveTrie(directory string, config MptConfig, cacheCapacity int) (*LiveTrie, error) {
-	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: cacheCapacity}
+func OpenFileLiveTrie(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*LiveTrie, error) {
+	forestConfig := ForestConfig{Mode: Mutable, NodeCacheConfig: cacheConfig}
 	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err

--- a/go/database/mpt/live_trie_fuzzing_test.go
+++ b/go/database/mpt/live_trie_fuzzing_test.go
@@ -223,7 +223,7 @@ func (c *liveTrieAccountFuzzingCampaign[T, C]) Init() []fuzzing.OperationSequenc
 // It creates a temporary directory and opens a LiveTrie using that directory.
 func (c *liveTrieAccountFuzzingCampaign[T, C]) CreateContext(t fuzzing.TestingT) *C {
 	path := t.TempDir()
-	liveTrie, err := OpenFileLiveTrie(path, S5LiveConfig, 10_000)
+	liveTrie, err := OpenFileLiveTrie(path, S5LiveConfig, NodeCacheConfig{Capacity: 10_000})
 	if err != nil {
 		t.Fatalf("failed to open live trie: %v", err)
 	}

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -28,7 +28,7 @@ import (
 func TestLiveTrie_EmptyTrieIsConsistent(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -50,7 +50,7 @@ func TestLiveTrie_Cannot_Open_Memory(t *testing.T) {
 				t.Fatalf("cannot update meta: %v", err)
 			}
 
-			if _, err := OpenInMemoryLiveTrie(dir, config, 1024); err == nil {
+			if _, err := OpenInMemoryLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}); err == nil {
 				t.Errorf("opening trie should fail")
 			}
 
@@ -67,7 +67,7 @@ func TestLiveTrie_Cannot_Open_File(t *testing.T) {
 				t.Fatalf("cannot update meta: %v", err)
 			}
 
-			if _, err := OpenFileLiveTrie(dir, config, 1024); err == nil {
+			if _, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}); err == nil {
 				t.Errorf("opening trie should fail")
 			}
 
@@ -84,7 +84,7 @@ func TestLiveTrie_Cannot_MakeTrie_CorruptMeta(t *testing.T) {
 				t.Fatalf("cannot update meta: %v", err)
 			}
 
-			if _, err := OpenFileLiveTrie(dir, config, 1024); err == nil {
+			if _, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}); err == nil {
 				t.Errorf("opening trie should fail")
 			}
 
@@ -101,7 +101,7 @@ func TestLiveTrie_Cannot_MakeTrie_CannotReadMeta(t *testing.T) {
 				t.Fatalf("cannot update meta: %v", err)
 			}
 
-			if _, err := OpenFileLiveTrie(dir, config, 1024); err == nil {
+			if _, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}); err == nil {
 				t.Errorf("opening trie should fail")
 			}
 
@@ -148,7 +148,7 @@ func TestLiveTrie_Fail_Read_Data(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			mpt, err := OpenFileLiveTrie(dir, config, 1024)
+			mpt, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("cannot open trie: %s", err)
 			}
@@ -193,7 +193,7 @@ func TestLiveTrie_Cannot_Flush_Metadata(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			mpt, err := OpenFileLiveTrie(dir, config, 1024)
+			mpt, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("opening trie should not fail: %s", err)
 			}
@@ -215,7 +215,7 @@ func TestLiveTrie_Cannot_Flush_Hashes(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			mpt, err := OpenFileLiveTrie(dir, config, 1024)
+			mpt, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("opening trie should not fail: %s", err)
 			}
@@ -237,7 +237,7 @@ func TestLiveTrie_Cannot_Flush_Hashes(t *testing.T) {
 func TestLiveTrie_NonExistingAccountsHaveEmptyInfo(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -258,7 +258,7 @@ func TestLiveTrie_NonExistingAccountsHaveEmptyInfo(t *testing.T) {
 func TestLiveTrie_SetAndGetSingleAccountInformationWorks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -299,7 +299,7 @@ func TestLiveTrie_SetAndGetSingleAccountInformationWorks(t *testing.T) {
 func TestLiveTrie_SetAndGetMultipleAccountInformationWorks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -343,7 +343,7 @@ func TestLiveTrie_SetAndGetMultipleAccountInformationWorks(t *testing.T) {
 func TestLiveTrie_NonExistingValueHasZeroValue(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -371,7 +371,7 @@ func TestLiveTrie_NonExistingValueHasZeroValue(t *testing.T) {
 func TestLiveTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -406,11 +406,11 @@ func TestLiveTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
 func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie1, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie1, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
-			trie2, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie2, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -466,7 +466,7 @@ func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -503,7 +503,7 @@ func TestLiveTrie_InsertLotsOfData(t *testing.T) {
 			t.Parallel()
 			const N = 30
 
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024*1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024 * 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -566,7 +566,7 @@ func TestLiveTrie_InsertLotsOfValues(t *testing.T) {
 			t.Parallel()
 			const N = 500
 
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -654,7 +654,7 @@ func TestLiveTrie_DeleteLargeAccount(t *testing.T) {
 			t.Parallel()
 			const N = 200000
 
-			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, 1024*1024)
+			trie, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024 * 1024})
 			if err != nil {
 				t.Fatalf("failed to open trie: %v", err)
 			}
@@ -771,7 +771,7 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config, 1024)
+			trie, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -808,7 +808,7 @@ func TestLiveTrie_VerificationOfLiveTrieWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config, 1024)
+			trie, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -849,7 +849,7 @@ func TestLiveTrie_VerificationOfLiveTrieWithCorruptedFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			trie, err := OpenFileLiveTrie(dir, config, 1024)
+			trie, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to create empty trie, err %v", err)
 			}
@@ -903,7 +903,7 @@ func TestLiveTrie_HasEmptyStorage(t *testing.T) {
 			db := NewMockDatabase(ctrl)
 			db.EXPECT().HasEmptyStorage(gomock.Any(), addr)
 
-			mpt, err := OpenFileLiveTrie(dir, config, 1024)
+			mpt, err := OpenFileLiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				t.Fatalf("failed to open live trie: %v", err)
 			}
@@ -953,7 +953,7 @@ func BenchmarkValueInsertionInMemoryTrie(b *testing.B) {
 	for _, config := range allMptConfigs {
 		b.Run(config.Name, func(b *testing.B) {
 			b.StopTimer()
-			trie, err := OpenInMemoryLiveTrie(b.TempDir(), config, 1024)
+			trie, err := OpenInMemoryLiveTrie(b.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				b.Fatalf("failed to open trie: %v", err)
 			}
@@ -969,7 +969,7 @@ func BenchmarkValueInsertionInFileTrie(b *testing.B) {
 	for _, config := range allMptConfigs {
 		b.Run(config.Name, func(b *testing.B) {
 			b.StopTimer()
-			trie, err := OpenFileLiveTrie(b.TempDir(), config, 1024)
+			trie, err := OpenFileLiveTrie(b.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 			if err != nil {
 				b.Fatalf("failed to open trie: %v", err)
 			}

--- a/go/database/mpt/root_hash_test.go
+++ b/go/database/mpt/root_hash_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestS5RootHash_EmptyTrie(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestS5RootHash_EmptyTrie(t *testing.T) {
 
 func TestS5RootHash_SingleAccount(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestS5RootHash_SingleAccount(t *testing.T) {
 
 func TestS5RootHash_SingleAccountWithSingleValue(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestS5RootHash_SingleAccountWithSingleValue(t *testing.T) {
 
 func TestS5RootHash_TwoAccounts(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestS5RootHash_TwoAccounts(t *testing.T) {
 
 func TestS5RootHash_TwoAccountsWithValues(t *testing.T) {
 	t.Parallel()
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithEvenLength(t *testing.T) {
 		t.Fatalf("invalid setup, addresses do not have common prefix")
 	}
 
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithOddLength(t *testing.T) {
 		t.Fatalf("invalid setup, addresses do not have single prefix bit prefix")
 	}
 
-	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	state, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open empty state: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestS5RootHash_AddressAndKeys(t *testing.T) {
 
 	const N = 100
 
-	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open trie: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestS5RootHash_Values(t *testing.T) {
 		return res
 	}
 
-	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, 1024)
+	trie, err := OpenGoMemoryState(t.TempDir(), S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open trie: %v", err)
 	}
@@ -345,7 +345,7 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 		// To prepare the stage for the issue, a branch node with two embedded
 		// values is created.
 		directory := t.TempDir()
-		state, err := OpenGoMemoryState(directory, config, 1024)
+		state, err := OpenGoMemoryState(directory, config, NodeCacheConfig{Capacity: 1024})
 		if err != nil {
 			t.Fatalf("failed to open trie: %v", err)
 		}
@@ -376,7 +376,7 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 		// The error causing issue #769 is caused by loading nodes from disk not
 		// including embedded information and not correctly recomputing those when
 		// computing hashes.
-		state, err = OpenGoMemoryState(directory, config, 1024)
+		state, err = OpenGoMemoryState(directory, config, NodeCacheConfig{Capacity: 1024})
 		if err != nil {
 			t.Fatalf("failed to open trie: %v", err)
 		}

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -146,14 +146,6 @@ type MptState struct {
 	hasher    hash.Hash
 }
 
-// The capacity of an MPT's node cache must be at least as large as the maximum
-// number of nodes modified in a block. Evaluations show that most blocks
-// modify less than 2000 nodes. However, one block, presumably the one handling
-// the opera fork at ~4.5M, modifies 434.589 nodes. Thus, the cache size of a
-// MPT processing Fantom's history should be at least ~500.000 nodes.
-const DefaultMptStateCapacity = 10_000_000
-const MinMptStateCapacity = 2_000
-
 var emptyCodeHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})
 
 func newMptState(directory string, lock common.LockFile, trie *LiveTrie) (*MptState, error) {
@@ -196,24 +188,24 @@ func tryMarkDirty(directory string) error {
 
 // OpenGoMemoryState loads state information from the given directory and
 // creates a Trie entirely retained in memory.
-func OpenGoMemoryState(directory string, config MptConfig, cacheCapacity int) (*MptState, error) {
+func OpenGoMemoryState(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*MptState, error) {
 	lock, err := openStateDirectory(directory)
 	if err != nil {
 		return nil, err
 	}
-	trie, err := OpenInMemoryLiveTrie(directory, config, cacheCapacity)
+	trie, err := OpenInMemoryLiveTrie(directory, config, cacheConfig)
 	if err != nil {
 		return nil, err
 	}
 	return newMptState(directory, lock, trie)
 }
 
-func OpenGoFileState(directory string, config MptConfig, cacheCapacity int) (*MptState, error) {
+func OpenGoFileState(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*MptState, error) {
 	lock, err := openStateDirectory(directory)
 	if err != nil {
 		return nil, err
 	}
-	trie, err := OpenFileLiveTrie(directory, config, cacheCapacity)
+	trie, err := OpenFileLiveTrie(directory, config, cacheConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -33,15 +33,25 @@ import (
 )
 
 var stateFactories = map[string]func(string) (io.Closer, error){
-	"memory":  func(dir string) (io.Closer, error) { return OpenGoMemoryState(dir, S5LiveConfig, 1024) },
-	"file":    func(dir string) (io.Closer, error) { return OpenGoFileState(dir, S5LiveConfig, 1024) },
-	"archive": func(dir string) (io.Closer, error) { return OpenArchiveTrie(dir, S5ArchiveConfig, 1024) },
-	"verify":  func(dir string) (io.Closer, error) { return openVerificationNodeSource(dir, S5LiveConfig) },
+	"memory": func(dir string) (io.Closer, error) {
+		return OpenGoMemoryState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
+	},
+	"file": func(dir string) (io.Closer, error) {
+		return OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
+	},
+	"archive": func(dir string) (io.Closer, error) {
+		return OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	},
+	"verify": func(dir string) (io.Closer, error) { return openVerificationNodeSource(dir, S5LiveConfig) },
 }
 
 var mptStateFactories = map[string]func(string) (*MptState, error){
-	"memory": func(dir string) (*MptState, error) { return OpenGoMemoryState(dir, S5LiveConfig, 1024) },
-	"file":   func(dir string) (*MptState, error) { return OpenGoFileState(dir, S5LiveConfig, 1024) },
+	"memory": func(dir string) (*MptState, error) {
+		return OpenGoMemoryState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
+	},
+	"file": func(dir string) (*MptState, error) {
+		return OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
+	},
 }
 
 func TestState_CanOnlyBeOpenedOnce(t *testing.T) {
@@ -109,7 +119,7 @@ func TestState_RegularCloseResultsInCleanState(t *testing.T) {
 	if dirty, err := isDirty(dir); dirty || err != nil {
 		t.Fatalf("directory initially in invalid state: %t, %v", dirty, err)
 	}
-	state, err := OpenGoFileState(dir, S5LiveConfig, 1024)
+	state, err := OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open test state: %v", err)
 	}
@@ -132,7 +142,7 @@ func TestState_ErrorsLeadToDirtyState(t *testing.T) {
 	if dirty, err := isDirty(dir); dirty || err != nil {
 		t.Fatalf("directory initially in invalid state: %t, %v", dirty, err)
 	}
-	state, err := OpenGoFileState(dir, S5LiveConfig, 1024)
+	state, err := OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open test state: %v", err)
 	}
@@ -159,7 +169,7 @@ func BenchmarkStorageChanges(b *testing.B) {
 				mode = "with_hashing"
 			}
 			b.Run(fmt.Sprintf("%s/%s", config.Name, mode), func(b *testing.B) {
-				state, err := OpenGoMemoryState(b.TempDir(), config, 1024)
+				state, err := OpenGoMemoryState(b.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 				if err != nil {
 					b.Fail()
 				}
@@ -530,7 +540,7 @@ func TestState_GetCodes(t *testing.T) {
 func TestState_ForestErrorIsReportedInFlushAndClose(t *testing.T) {
 
 	dir := t.TempDir()
-	state, err := OpenGoFileState(dir, S4LiveConfig, 1024)
+	state, err := OpenGoFileState(dir, S4LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open test state: %v", err)
 	}
@@ -554,7 +564,7 @@ func TestState_ForestErrorIsReportedInFlushAndClose(t *testing.T) {
 
 func TestState_Flush_WriteDirtyCodesOnly(t *testing.T) {
 	dir := t.TempDir()
-	state, err := OpenGoFileState(dir, S5LiveConfig, 1024)
+	state, err := OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open test state: %v", err)
 	}
@@ -733,7 +743,7 @@ func TestEstimatePerNodeMemoryUsage(t *testing.T) {
 
 func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 	numAccounts := 100_000
-	state, err := OpenGoFileState(b.TempDir(), config, numAccounts)
+	state, err := OpenGoFileState(b.TempDir(), config, NodeCacheConfig{Capacity: numAccounts})
 	if err != nil {
 		b.Fatalf("failed to open state, err %v", err)
 	}

--- a/go/database/mpt/tool/block.go
+++ b/go/database/mpt/tool/block.go
@@ -59,7 +59,7 @@ func block(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	archive, err := mpt.OpenArchiveTrie(dir, info.Config, 1024)
+	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		return fmt.Errorf("failed to open archive in %s: %w", dir, err)
 	}

--- a/go/database/mpt/tool/check.go
+++ b/go/database/mpt/tool/check.go
@@ -66,7 +66,7 @@ func check(context *cli.Context) error {
 }
 
 func checkLiveDB(dir string, info io.MptInfo) error {
-	live, err := mpt.OpenFileLiveTrie(dir, info.Config, mpt.DefaultMptStateCapacity)
+	live, err := mpt.OpenFileLiveTrie(dir, info.Config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func checkLiveDB(dir string, info io.MptInfo) error {
 }
 
 func checkArchive(dir string, info io.MptInfo) error {
-	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.DefaultMptStateCapacity)
+	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return err
 	}

--- a/go/database/mpt/tool/info.go
+++ b/go/database/mpt/tool/info.go
@@ -56,7 +56,7 @@ func info(context *cli.Context) error {
 
 	// attempt to open the MPT
 	if mptInfo.Mode == mpt.Mutable {
-		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.Config, mpt.DefaultMptStateCapacity)
+		trie, err := mpt.OpenFileLiveTrie(dir, mptInfo.Config, mpt.NodeCacheConfig{})
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil
@@ -78,7 +78,7 @@ func info(context *cli.Context) error {
 			return fmt.Errorf("error closing forest: %v", err)
 		}
 	} else {
-		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config, mpt.DefaultMptStateCapacity)
+		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config, mpt.NodeCacheConfig{})
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -587,7 +587,7 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 	v1[len(v1)-1] = 1
 
 	dir := t.TempDir()
-	forestConfig := ForestConfig{Mode: Mutable, CacheCapacity: 1024}
+	forestConfig := ForestConfig{Mode: Mutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}}
 	forest, err := OpenFileForest(dir, S5LiveConfig, forestConfig)
 	if err != nil {
 		t.Fatalf("failed to start empty forest: %v", err)
@@ -745,7 +745,7 @@ func modifyNode[N any](t *testing.T, directory string, encoder stock.ValueEncode
 
 func fillTestForest(dir string, config MptConfig) (roots []Root, err error) {
 
-	forestConfig := ForestConfig{Mode: Immutable, CacheCapacity: 1024}
+	forestConfig := ForestConfig{Mode: Immutable, NodeCacheConfig: NodeCacheConfig{Capacity: 1024}}
 	forest, err := OpenFileForest(dir, config, forestConfig)
 	if err != nil {
 		return nil, err

--- a/go/database/mpt/visitor_test.go
+++ b/go/database/mpt/visitor_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
-	trie, err := OpenInMemoryLiveTrie(t.TempDir(), S4LiveConfig, 1024)
+	trie, err := OpenInMemoryLiveTrie(t.TempDir(), S4LiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
 
 func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 		t.Errorf("invalid stats for empty archive: %v", stats)
 	}
 
-	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig, 1024)
+	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to re-open empty archive: %v", err)
 	}

--- a/go/state/gostate/configurations.go
+++ b/go/state/gostate/configurations.go
@@ -937,7 +937,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, mpt.DefaultMptStateCapacity)
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, getNodeCacheConfig(params.ArchiveCache))
 		return arch, nil, err
 
 	case state.S5Archive:
@@ -945,7 +945,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, mptStateCapacity(params.ArchiveCache))
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, getNodeCacheConfig(params.ArchiveCache))
 		return arch, nil, err
 	}
 	return nil, nil, fmt.Errorf("unknown archive type: %v", params.Archive)

--- a/go/state/gostate/go_schema4.go
+++ b/go/state/gostate/go_schema4.go
@@ -42,7 +42,7 @@ func newS4State(params state.Parameters, mptState *mpt.MptState) (state.State, e
 }
 
 func newGoMemoryS4State(params state.Parameters) (state.State, error) {
-	state, err := mpt.OpenGoMemoryState(filepath.Join(params.Directory, "live"), mpt.S4LiveConfig, mpt.DefaultMptStateCapacity)
+	state, err := mpt.OpenGoMemoryState(filepath.Join(params.Directory, "live"), mpt.S4LiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func newGoMemoryS4State(params state.Parameters) (state.State, error) {
 }
 
 func newGoFileS4State(params state.Parameters) (state.State, error) {
-	state, err := mpt.OpenGoFileState(filepath.Join(params.Directory, "live"), mpt.S4LiveConfig, mpt.DefaultMptStateCapacity)
+	state, err := mpt.OpenGoFileState(filepath.Join(params.Directory, "live"), mpt.S4LiveConfig, mpt.NodeCacheConfig{})
 	if err != nil {
 		return nil, err
 	}

--- a/go/state/gostate/go_schema5.go
+++ b/go/state/gostate/go_schema5.go
@@ -77,19 +77,18 @@ func newS5State(params state.Parameters, mptState *mpt.MptState) (state.State, e
 	}, arch, []func(){archiveCleanup}), nil
 }
 
-func mptStateCapacity(param int64) int {
-	if param <= 0 {
-		return mpt.DefaultMptStateCapacity
+func getNodeCacheConfig(cacheSize int64) mpt.NodeCacheConfig {
+	capacity := 0
+	if cacheSize > 0 {
+		capacity = int(cacheSize / int64(mpt.EstimatePerNodeMemoryUsage()))
 	}
-	capacity := int(param / int64(mpt.EstimatePerNodeMemoryUsage()))
-	if capacity < mpt.MinMptStateCapacity {
-		capacity = mpt.MinMptStateCapacity
+	return mpt.NodeCacheConfig{
+		Capacity: capacity,
 	}
-	return capacity
 }
 
 func newGoMemoryS5State(params state.Parameters) (state.State, error) {
-	state, err := mpt.OpenGoMemoryState(filepath.Join(params.Directory, "live"), mpt.S5LiveConfig, mptStateCapacity(params.LiveCache))
+	state, err := mpt.OpenGoMemoryState(filepath.Join(params.Directory, "live"), mpt.S5LiveConfig, getNodeCacheConfig(params.LiveCache))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +96,7 @@ func newGoMemoryS5State(params state.Parameters) (state.State, error) {
 }
 
 func newGoFileS5State(params state.Parameters) (state.State, error) {
-	state, err := mpt.OpenGoFileState(filepath.Join(params.Directory, "live"), mpt.S5LiveConfig, mptStateCapacity(params.LiveCache))
+	state, err := mpt.OpenGoFileState(filepath.Join(params.Directory, "live"), mpt.S5LiveConfig, getNodeCacheConfig(params.LiveCache))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds add support for configuring the flush period of the background flusher when creating an MPT State instance.

This is required in order to implement a stress test utility running the database at a higher flush rate than its default rate.

This PR contributes to the investigation of issue #948


**Note for reviewers:**
The main change of this PR is that the former stand-alone `cacheCapacity` parameter is wrapped into a `NodeCacheConfig` struct, extended by the `backgroundFlushPeriod` parameter and requested as a configuration struct in the factory interface. All other changes in the PR are mere adaptations to this interface signature change.
