### PR TITLE
allows for cancelling witness proof creation

### DIFF
--- a/go/backend/archive/archive_mock.go
+++ b/go/backend/archive/archive_mock.go
@@ -85,7 +85,7 @@ func (m *MockArchive) CreateWitnessProof(block uint64, address common.Address, k
 	for _, a := range keys {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "CreateWitnessProof", varargs...)
+	ret := m.ctrl.Call(m, "createCancellableWitnessProof", varargs...)
 	ret0, _ := ret[0].(witness.Proof)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -95,7 +95,7 @@ func (m *MockArchive) CreateWitnessProof(block uint64, address common.Address, k
 func (mr *MockArchiveMockRecorder) CreateWitnessProof(block, address any, keys ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{block, address}, keys...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWitnessProof", reflect.TypeOf((*MockArchive)(nil).CreateWitnessProof), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createCancellableWitnessProof", reflect.TypeOf((*MockArchive)(nil).CreateWitnessProof), varargs...)
 }
 
 // Exists mocks base method.

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -2269,11 +2269,12 @@ func TestForest_HasEmptyStorage(t *testing.T) {
 
 func TestVisitPathTo_Node_Hashes_Same_S5_Archive_non_Archive_Config_For_Witness_Proof(t *testing.T) {
 	addresses := getTestAddresses(61)
-	keys := getTestKeys(63)
+	keys := getTestKeys(132)
 	for _, variant := range fileAndMemVariants {
 		for forestConfigName, forestConfig := range forestConfigs {
 			for _, config := range []MptConfig{S5LiveConfig, S5ArchiveConfig} {
 				t.Run(fmt.Sprintf("%s-%s-%s", variant.name, forestConfigName, config.Name), func(t *testing.T) {
+					t.Parallel()
 					dir := t.TempDir()
 					forest, err := variant.factory(dir, config, forestConfig)
 					if err != nil {

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -11,6 +11,7 @@
 package mpt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -160,6 +161,12 @@ func (s *LiveTrie) VisitTrie(visitor NodeVisitor) error {
 
 func (s *LiveTrie) CreateWitnessProof(addr common.Address, keys ...common.Key) (witness.Proof, error) {
 	return CreateWitnessProof(s.forest, &s.root, addr, keys...)
+}
+
+// createContextWitnessProof creates a witness proof for the given address and keys.
+// The method is cancellable and can be interrupted by the provided context.
+func (s *LiveTrie) createContextWitnessProof(context context.Context, addr common.Address, keys ...common.Key) (witness.Proof, error) {
+	return CreateContextWitnessProof(context, s.forest, &s.root, addr, keys...)
 }
 
 func (s *LiveTrie) Flush() error {

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -331,9 +331,11 @@ func TestCreateWitnessProof_SourceError_All_Paths(t *testing.T) {
 						dirtyChildHashes: []int{1},
 						children: Children{
 							addressNibbles[1]: &Extension{
-								path: addressNibbles[2:20],
+								nextHashDirty: true,
+								path:          addressNibbles[2:20],
 								next: &Account{address: address, pathLength: 14, info: AccountInfo{common.Nonce{1}, common.Balance{1}, common.Hash{0xAA}},
-									storage: &Empty{}}},
+									storageHashDirty: true,
+									storage:          &Empty{}}},
 						}}}}
 
 			root, _ := ctxt.Build(desc)


### PR DESCRIPTION
This PR allows for the witness proof creation to be cancelled via a context. 

It is useful when running verification of the witness proof, so far this step could not be interrupted. 
In the future this may be also useful for instance when a proof is generated via an RPC request and this request is interrupted, the proof generation can be interrupted as well  - though more adaptaions would be needed to reach this functionality.  