### PR TITLE
Fix conversion of cache size to cache capacity

### DIFF
--- a/go/state/gostate/go_schema5.go
+++ b/go/state/gostate/go_schema5.go
@@ -81,6 +81,14 @@ func getNodeCacheConfig(cacheSize int64) mpt.NodeCacheConfig {
 	capacity := 0
 	if cacheSize > 0 {
 		capacity = int(cacheSize / int64(mpt.EstimatePerNodeMemoryUsage()))
+
+		// If a cache size is given, the resulting capacity should be at least 1.
+		// A capacity of 0 would signal the MPT implementation to use the default
+		// cache size. However, if a cache size is given that is small enough to
+		// not even cover a single node, the minimum MPT cache size should be used.
+		if capacity == 0 {
+			capacity = 1
+		}
 	}
 	return mpt.NodeCacheConfig{
 		Capacity: capacity,

--- a/go/state/gostate/go_schema5_test.go
+++ b/go/state/gostate/go_schema5_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/common/amount"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/state"
 )
 
@@ -129,5 +130,44 @@ func TestCarmen_Empty_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 	// opening archive should fail as archive and non-archive is not in-sync
 	if _, err := archiveConfig.createState(dir); err == nil {
 		t.Errorf("opening database should fail")
+	}
+}
+
+func TestGetNodeCacheConfig(t *testing.T) {
+	tests := map[string]struct {
+		cacheSize int64 // in bytes
+		capacity  int   // in number of nodes
+	}{
+		"zero": {
+			cacheSize: 0,
+			capacity:  0,
+		},
+		"none-zero": {
+			cacheSize: 1, // < if the cache size is greater than 0,
+			capacity:  1, // < than the capacity should be greater than 0 to trigger
+			// the usage of the minimum cache size instead of the default
+			// cache size
+		},
+		"one node": {
+			cacheSize: int64(mpt.EstimatePerNodeMemoryUsage()),
+			capacity:  1,
+		},
+		"ten nodes": {
+			cacheSize: 10 * int64(mpt.EstimatePerNodeMemoryUsage()),
+			capacity:  10,
+		},
+		"negative": {
+			cacheSize: -1,
+			capacity:  0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := getNodeCacheConfig(test.cacheSize)
+			if cfg.Capacity != test.capacity {
+				t.Errorf("unexpected capacity: %d != %d", cfg.Capacity, test.capacity)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR fixes an issue introduced by #950 related to the definition of very small node cache sizes.

Before #950, if a node cache size of less than a single node was specified, the MPT implementation would increase it to a minimum value of `2_000` nodes.

After #950, if a node cache size of less than a single node is specified, it got converted to a `capacity` definition of `0`, which lead to the utilization of the default cache size of `10_000_000` nodes. This lead to memory issue problems in Sonic tests.

With this fix, the old behavior was recovered. 