### PR TITLE
introduces immutable bytes and uses it in witness proof

### DIFF
--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -1042,7 +1042,7 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 	}
 
 	// proof properties
-	serialized := make([]string, 0, 1024)
+	serialized := make([]Bytes, 0, 1024)
 	for i := 0; i < numBlocks; i++ {
 		block, err := db.GetHistoricContext(uint64(i))
 		if err != nil {
@@ -1160,7 +1160,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 
 	// proof each account and all keys of the account
 	shadowProofs := make(map[Address]WitnessProof, numAccounts)
-	serialized := make([]string, 0, 1024)
+	serialized := make([]Bytes, 0, 1024)
 	for j := 0; j < numAccounts; j++ {
 		addr := Address{byte(j)}
 		proof, err := block.GetProof(addr, keys...)
@@ -1193,8 +1193,12 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 			}
 			gotElements := got.GetElements()
 			wantElements := want.GetElements()
-			slices.Sort(gotElements)
-			slices.Sort(wantElements)
+			slices.SortFunc(gotElements, func(a, b Bytes) int {
+				return bytes.Compare(a.ToBytes(), b.ToBytes())
+			})
+			slices.SortFunc(wantElements, func(a, b Bytes) int {
+				return bytes.Compare(a.ToBytes(), b.ToBytes())
+			})
 			if got, want := gotElements, wantElements; !slices.Equal(got, want) {
 				t.Errorf("unexpected proof, wanted %v, got %v", want, got)
 			}
@@ -1235,8 +1239,12 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 
 			gotElements := merged.GetElements()
 			wantElements := shadowProofs[addr].GetElements()
-			slices.Sort(gotElements)
-			slices.Sort(wantElements)
+			slices.SortFunc(gotElements, func(a, b Bytes) int {
+				return bytes.Compare(a.ToBytes(), b.ToBytes())
+			})
+			slices.SortFunc(wantElements, func(a, b Bytes) int {
+				return bytes.Compare(a.ToBytes(), b.ToBytes())
+			})
 			if got, want := gotElements, wantElements; !slices.Equal(got, want) {
 				t.Errorf("unexpected proof, wanted %v, got %v", want, got)
 			}

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -325,7 +325,7 @@ func ExampleHistoricBlockContext_GetProof() {
 
 	// ------- Query witness proofs for each block -------
 
-	completeProof := make(map[string]struct{}, 1024)
+	completeProof := make(map[carmen.Bytes]struct{}, 1024)
 	// proof each address and key from each block, and merge all in one proof
 	for i := 0; i < N; i++ {
 		if err := db.QueryBlock(uint64(i), func(ctxt carmen.HistoricBlockContext) error {
@@ -448,7 +448,7 @@ func ExampleWitnessProof_GetStorageElements() {
 
 	// ------- Query witness proofs from a block -------
 
-	var elements []string
+	var elements []carmen.Bytes
 	// proof each address and key from each block, and merge all in one proof
 	if err := db.QueryBlock(0, func(ctxt carmen.HistoricBlockContext) error {
 		proof, err := ctxt.GetProof(carmen.Address{1}, carmen.Key{1})

--- a/go/carmen/proof.go
+++ b/go/carmen/proof.go
@@ -12,13 +12,17 @@ package carmen
 
 import (
 	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/immutable"
 	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 )
 
+// Bytes is an alias for immutable.Bytes.
+type Bytes = immutable.Bytes
+
 // CreateWitnessProofFromNodes creates a witness proof from a list of strings.
 // Each string is an RLP node of the witness proof.
-func CreateWitnessProofFromNodes(elements ...string) WitnessProof {
+func CreateWitnessProofFromNodes(elements ...Bytes) WitnessProof {
 	proof := mpt.CreateWitnessProofFromNodes(elements)
 	return witnessProof{proof}
 }
@@ -42,7 +46,7 @@ type WitnessProof interface {
 	IsValid() bool
 
 	// GetElements returns serialised elements of the witness proof.
-	GetElements() []string
+	GetElements() []Bytes
 
 	// GetStorageElements returns serialised elements of the witness proof for a given account
 	// and selected storage locations from this proof.
@@ -52,7 +56,7 @@ type WitnessProof interface {
 	// This method returns a copy that contains only the data necessary for proving storage keys.
 	// The third return parameter indicates whether everything that was requested could be covered.
 	// If so, it is set to true, otherwise it is set to false.
-	GetStorageElements(root Hash, address Address, keys ...Key) ([]string, Hash, bool)
+	GetStorageElements(root Hash, address Address, keys ...Key) ([]Bytes, Hash, bool)
 
 	// GetBalance extracts a balance from the witness proof for the input root hash and the address.
 	// If the witness proof contains the requested account for the input address for the given root hash, it returns its balance.
@@ -109,11 +113,11 @@ func (w witnessProof) Extract(root Hash, address Address, keys ...Key) (WitnessP
 	return witnessProof{proof}, complete
 }
 
-func (w witnessProof) GetElements() []string {
+func (w witnessProof) GetElements() []Bytes {
 	return w.proof.GetElements()
 }
 
-func (w witnessProof) GetStorageElements(root Hash, address Address, keys ...Key) ([]string, Hash, bool) {
+func (w witnessProof) GetStorageElements(root Hash, address Address, keys ...Key) ([]Bytes, Hash, bool) {
 	commonKeys := make([]common.Key, len(keys))
 	for i, k := range keys {
 		commonKeys[i] = common.Key(k)

--- a/go/carmen/proof_test.go
+++ b/go/carmen/proof_test.go
@@ -11,32 +11,37 @@
 package carmen
 
 import (
-	"slices"
-	"sort"
+	"bytes"
+	"github.com/Fantom-foundation/Carmen/go/common/immutable"
+	"golang.org/x/exp/slices"
 	"testing"
 )
 
 func TestProof_CreateWitnessProofFromNodes(t *testing.T) {
 	const N = 10
 
-	nodes := make([]string, 0, N)
-	var str string
+	wantElements := make([]Bytes, 0, N)
+	b := make([]byte, 0, N)
 	for i := 0; i < N; i++ {
-		str += string(byte(i))
-		nodes = append(nodes, str)
+		b = append(b, byte(i))
+		wantElements = append(wantElements, immutable.NewBytes(b))
 	}
 
 	// proof will not be valid, but it can be still serialised back and forth
-	proof := CreateWitnessProofFromNodes(nodes...)
+	proof := CreateWitnessProofFromNodes(wantElements...)
 	if proof.IsValid() {
 		t.Errorf("proof should be invalid")
 	}
-	recovered := proof.GetElements()
+	gotElements := proof.GetElements()
 
-	sort.Strings(nodes)
-	sort.Strings(recovered)
+	slices.SortFunc(gotElements, func(a, b Bytes) bool {
+		return bytes.Compare(a.ToBytes(), b.ToBytes()) < 0
+	})
+	slices.SortFunc(wantElements, func(a, b Bytes) bool {
+		return bytes.Compare(a.ToBytes(), b.ToBytes()) < 0
+	})
 
-	if got, want := recovered, nodes; !slices.Equal(got, want) {
+	if got, want := gotElements, wantElements; !slices.Equal(got, want) {
 		t.Errorf("unexpected proof elements: got %v, want %v", got, want)
 	}
 }

--- a/go/common/immutable/bytes.go
+++ b/go/common/immutable/bytes.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package immutable
+
+import "fmt"
+
+// Bytes is an immutable slice of bytes that can be trivially cloned.
+type Bytes struct {
+	data string
+}
+
+// NewBytes creates a new Bytes from a slice of bytes.
+func NewBytes(data []byte) Bytes {
+	return Bytes{data: string(data)}
+}
+
+func (b Bytes) ToBytes() []byte {
+	return []byte(b.data)
+}
+
+func (b Bytes) String() string {
+	return fmt.Sprintf("0x%x", b.data)
+}

--- a/go/common/immutable/bytes_test.go
+++ b/go/common/immutable/bytes_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package immutable
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestBytes_EqualWhenContainingSameContent(t *testing.T) {
+	b1 := NewBytes([]byte{1, 2, 3})
+	b2 := NewBytes([]byte{1, 2, 3})
+	b3 := NewBytes([]byte{3, 2, 1})
+
+	if &b1 == &b2 {
+		t.Fatalf("instances are not distinct, got %v and %v", &b1, &b2)
+	}
+
+	if b1 != b2 {
+		t.Errorf("instances are not equal, got %v and %v", b1, b2)
+	}
+
+	if b1 == b3 {
+		t.Errorf("instances are equal, got %v and %v", b1, b3)
+	}
+}
+
+func TestBytes_AssignmentProducesEqualValue(t *testing.T) {
+	b1 := NewBytes([]byte{1, 2, 3})
+	b2 := b1
+
+	if b1 != b2 {
+		t.Errorf("assigned value is not equal: %v vs %v", b1, b2)
+	}
+}
+
+func TestBytes_CanBeConverted_Back_And_Forth(t *testing.T) {
+	original := []byte{1, 2, 3}
+	b := NewBytes(original)
+
+	if got, want := b.ToBytes(), original; !bytes.Equal(got, want) {
+		t.Errorf("conversion failed, got %v, want %v", got, want)
+	}
+}
+
+func TestBytes_String(t *testing.T) {
+	original := []byte{1, 2, 3}
+	b := NewBytes(original)
+
+	if got, want := fmt.Sprintf("%s", b), "0x010203"; got != want {
+		t.Errorf("string failed, got %v, want %v", got, want)
+	}
+}

--- a/go/common/witness/proof.go
+++ b/go/common/witness/proof.go
@@ -13,6 +13,7 @@ package witness
 import (
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/common/amount"
+	"github.com/Fantom-foundation/Carmen/go/common/immutable"
 	"github.com/Fantom-foundation/Carmen/go/common/tribool"
 )
 
@@ -35,7 +36,7 @@ type Proof interface {
 	IsValid() bool
 
 	// GetElements returns serialised elements of the witness proof.
-	GetElements() []string
+	GetElements() []immutable.Bytes
 
 	// GetStorageElements returns serialised elements of the witness proof for a given account
 	// and selected storage locations from this proof.
@@ -45,7 +46,7 @@ type Proof interface {
 	// This method returns a copy that contains only the data necessary for proving storage keys.
 	// The third return parameter indicates whether everything that was requested could be covered.
 	// If so, it is set to true, otherwise it is set to false.
-	GetStorageElements(root common.Hash, address common.Address, keys ...common.Key) ([]string, common.Hash, bool)
+	GetStorageElements(root common.Hash, address common.Address, keys ...common.Key) ([]immutable.Bytes, common.Hash, bool)
 
 	// GetBalance extracts a balance from the witness proof for the input root hash and the address.
 	// If the witness proof contains the requested account for the input address for the given root hash, it returns its balance.

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/immutable"
 	"reflect"
 	"testing"
 
@@ -1245,7 +1246,7 @@ func TestWitnessProof_String(t *testing.T) {
 }
 
 func TestProof_Equals(t *testing.T) {
-	proof := CreateWitnessProofFromNodes([]string{"a"})
+	proof := CreateWitnessProofFromNodes([]immutable.Bytes{immutable.NewBytes([]byte{0xA})})
 
 	if proof.Equals(nil) {
 		t.Errorf("proofs should not be equal")
@@ -1255,7 +1256,7 @@ func TestProof_Equals(t *testing.T) {
 		t.Errorf("proofs should be equal")
 	}
 
-	other := CreateWitnessProofFromNodes([]string{"a"})
+	other := CreateWitnessProofFromNodes([]immutable.Bytes{immutable.NewBytes([]byte{0xA})})
 	if !proof.Equals(other) {
 		t.Errorf("proofs should be equal")
 	}


### PR DESCRIPTION
This PR introduces a new `immutable.Bytes`, which is a wrapped around bytes (strings) that cannot be modified from the outside, i.e. they are immutable. 

This new type is used in the Witness proof to represent original `[]string`, which could cause confusions as the string type was used to implement an immutable byte slice.  