### PR TITLE
Make CreateWitnessProof accessible through StateDB interface

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -14,6 +14,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/common/witness"
 	"maps"
 	"math/big"
 	"sync"
@@ -159,6 +160,11 @@ type NonCommittableStateDB interface {
 	// Available for non-committable states only, as a commit to the backing state
 	// makes all other StateDBs with the same backing state invalid.
 	Copy() NonCommittableStateDB
+
+	// CreateWitnessProof creates a witness proof for the given account and keys.
+	// Error may be produced when it occurs in the underlying database;
+	// otherwise, the proof is returned.
+	CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error)
 
 	// Release should be called whenever this instance is no longer needed to allow
 	// held resources to be reused for future requests. After the release, no more
@@ -1477,6 +1483,10 @@ func (db *nonCommittableStateDB) Copy() NonCommittableStateDB {
 	// which are reset at the end of every tx
 
 	return &nonCommittableStateDB{cp}
+}
+
+func (db *nonCommittableStateDB) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	return db.state.CreateWitnessProof(address, keys...)
 }
 
 func (db *nonCommittableStateDB) Release() {

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -24,6 +24,7 @@ import (
 
 	common "github.com/Fantom-foundation/Carmen/go/common"
 	amount "github.com/Fantom-foundation/Carmen/go/common/amount"
+	witness "github.com/Fantom-foundation/Carmen/go/common/witness"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -1411,6 +1412,26 @@ func (m *MockNonCommittableStateDB) CreateContract(arg0 common.Address) {
 func (mr *MockNonCommittableStateDBMockRecorder) CreateContract(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContract", reflect.TypeOf((*MockNonCommittableStateDB)(nil).CreateContract), arg0)
+}
+
+// CreateWitnessProof mocks base method.
+func (m *MockNonCommittableStateDB) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{address}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateWitnessProof", varargs...)
+	ret0, _ := ret[0].(witness.Proof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWitnessProof indicates an expected call of CreateWitnessProof.
+func (mr *MockNonCommittableStateDBMockRecorder) CreateWitnessProof(address any, keys ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{address}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWitnessProof", reflect.TypeOf((*MockNonCommittableStateDB)(nil).CreateWitnessProof), varargs...)
 }
 
 // Empty mocks base method.

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -3272,6 +3272,29 @@ func TestStateDB_Copy(t *testing.T) {
 	}
 }
 
+func TestStateDB_CreateWitnessProofCallsAreForwarded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockState(ctrl)
+	db := CreateNonCommittableStateDBUsing(mock)
+
+	address1 := common.Address{0xA}
+	key1 := common.Key{0xB}
+	key2 := common.Key{0xC}
+
+	injectedError := fmt.Errorf("injected error")
+
+	mock.EXPECT().CreateWitnessProof(address1, key1, key2)
+	mock.EXPECT().CreateWitnessProof(address1, key2).Return(nil, injectedError)
+
+	if _, err := db.CreateWitnessProof(address1, key1, key2); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if _, err := db.CreateWitnessProof(address1, key2); !errors.Is(err, injectedError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestStateDB_LogsCanBeAddedAndRetrieved(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)


### PR DESCRIPTION
The whole RPC layer of Sonic currently use StateDB interface and migration to Carmen facade is not in sight. To avoid the need of passing the unwrapped State reference into the RPC, I want to add `CreateWitnessProof` method into the NonCommittableStateDB interface.