### PR TITLE
Add ability to restore codes and stocks from pending commits

### DIFF
--- a/go/database/mpt/codes.go
+++ b/go/database/mpt/codes.go
@@ -220,6 +220,15 @@ func (r codeRestorer) Restore(checkpoint checkpoint.Checkpoint) error {
 	if err != nil {
 		return err
 	}
+
+	// If the given checkpoint is one step in the future, check whether there is a pending checkpoint.
+	if meta.Checkpoint+1 == checkpoint {
+		pending, err := readCodeCheckpointMetaData(filepath.Join(r.directory, fileNameCodesPrepareCheckpoint))
+		if err == nil && pending.Checkpoint == checkpoint {
+			meta = pending
+		}
+	}
+
 	if meta.Checkpoint != checkpoint {
 		return fmt.Errorf("cannot restore checkpoint %d, committed checkpoint is %d", checkpoint, meta.Checkpoint)
 	}


### PR DESCRIPTION
This PR add support or restoring the state of a pending checkpoint to file stocks and code stores.

This requirement was missed initially and discovered while working on the restoration of archives.

This PR contributes to #946.