### PR TITLE
WIP: Add recovery support to archive

### DIFF
--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -67,7 +67,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S4",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig, mpt.NodeCacheConfig{})
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S4ArchiveConfig, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 				if err != nil {
 					tb.Fatalf("failed to open S4 archive: %v", err)
 				}
@@ -78,7 +78,7 @@ func getArchiveFactories(tb testing.TB) []archiveFactory {
 		{
 			label: "S5",
 			getArchive: func(tempDir string) archive.Archive {
-				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
+				archive, err := mpt.OpenArchiveTrie(tempDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 				if err != nil {
 					tb.Fatalf("failed to open S5 archive: %v", err)
 				}

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -16,10 +16,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"unsafe"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/archive"
+	"github.com/Fantom-foundation/Carmen/go/backend/stock/file"
+	"github.com/Fantom-foundation/Carmen/go/backend/utils"
+	"github.com/Fantom-foundation/Carmen/go/backend/utils/checkpoint"
 	"github.com/Fantom-foundation/Carmen/go/common/witness"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -37,45 +41,94 @@ type ArchiveTrie struct {
 	head         LiveState // the current head-state
 	forest       Database  // global forest with all versions of LiveState
 	nodeSource   NodeSource
-	roots        rootList   // the roots of individual blocks indexed by block height
+	roots        *rootList  // the roots of individual blocks indexed by block height
 	rootsMutex   sync.Mutex // protecting access to the roots list
-	rootFile     string     // the file storing the list of roots
 	addMutex     sync.Mutex // a mutex to make sure that at any time only one thread is adding new blocks
 	errorMutex   sync.RWMutex
 	archiveError error // a non-nil error will be stored here should it occur during any archive operation
+
+	// Check-point support for DB healing.
+	checkpointCoordinator checkpoint.Coordinator
+	checkpointInterval    int
 }
 
-func OpenArchiveTrie(directory string, config MptConfig, cacheConfig NodeCacheConfig) (*ArchiveTrie, error) {
+// ArchiveConfig is the configuration for the archive trie.
+type ArchiveConfig struct {
+	// The number of blocks after which a checkpoint is created.
+	CheckpointInterval int
+}
+
+const (
+	fileNameArchiveCheckpointDirectory      = "checkpoint"
+	fileNameArchiveRoots                    = "roots.dat"
+	fileNameArchiveRootsCheckpointDirectory = "roots"
+	fileNameArchiveRootsCommittedCheckpoint = "committed.json"
+	fileNameArchiveRootsPreparedCheckpoint  = "prepare.json"
+)
+
+func OpenArchiveTrie(
+	directory string,
+	config MptConfig,
+	cacheConfig NodeCacheConfig,
+	archiveConfig ArchiveConfig,
+) (*ArchiveTrie, error) {
 	lock, err := openStateDirectory(directory)
 	if err != nil {
 		return nil, err
 	}
-	rootfile := directory + "/roots.dat"
-	roots, err := loadRoots(rootfile)
+	roots, err := loadRoots(directory)
 	if err != nil {
 		return nil, err
 	}
+
 	forestConfig := ForestConfig{Mode: Immutable, NodeCacheConfig: cacheConfig}
 	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
 		return nil, err
 	}
+
 	head, err := makeTrie(directory, forest)
 	if err != nil {
-		forest.Close()
-		return nil, err
+		return nil, errors.Join(err, forest.Close())
 	}
+
+	root := NewNodeReference(EmptyId())
+	if roots.length() > 0 {
+		root = roots.get(uint64(roots.length() - 1)).NodeRef
+	}
+	head.root = root
+
 	state, err := newMptState(directory, lock, head)
 	if err != nil {
-		head.Close()
-		return nil, err
+		return nil, errors.Join(err, head.Close())
 	}
+
+	checkpointDir := filepath.Join(directory, fileNameArchiveCheckpointDirectory)
+	coordinator, err := checkpoint.NewCoordinator(
+		checkpointDir,
+		forest.accounts,
+		forest.branches,
+		forest.extensions,
+		forest.values,
+		state.codes,
+		roots,
+	)
+	if err != nil {
+		return nil, errors.Join(err, head.Close())
+	}
+
+	checkpointInterval := archiveConfig.CheckpointInterval
+	if checkpointInterval <= 0 {
+		checkpointInterval = 10_000
+	}
+
 	return &ArchiveTrie{
-		head:       state,
-		forest:     forest,
-		nodeSource: forest,
-		roots:      roots,
-		rootFile:   rootfile,
+		head:                  state,
+		forest:                forest,
+		nodeSource:            forest,
+		roots:                 roots,
+		checkpointCoordinator: coordinator,
+		checkpointInterval:    checkpointInterval,
 	}, nil
 }
 
@@ -83,7 +136,7 @@ func OpenArchiveTrie(directory string, config MptConfig, cacheConfig NodeCacheCo
 // If the test passes, the data stored in the respective directory
 // can be considered a valid archive database of the given configuration.
 func VerifyArchiveTrie(directory string, config MptConfig, observer VerificationObserver) error {
-	roots, err := loadRoots(directory + "/roots.dat")
+	roots, err := loadRoots(directory)
 	if err != nil {
 		return err
 	}
@@ -104,7 +157,8 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 	defer a.addMutex.Unlock()
 
 	a.rootsMutex.Lock()
-	if uint64(a.roots.length()) > block {
+	previousRootsLength := a.roots.length()
+	if uint64(previousRootsLength) > block {
 		a.rootsMutex.Unlock()
 		return fmt.Errorf("block %d already present", block)
 	}
@@ -156,6 +210,22 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 	a.rootsMutex.Lock()
 	a.roots.append(Root{a.head.Root(), hash})
 	a.rootsMutex.Unlock()
+
+	// Create a new checkpoint if we crossed an interval boundary.
+	shouldCheckpoint := false
+	if previousRootsLength == 0 {
+		shouldCheckpoint = block >= uint64(a.checkpointInterval)
+	} else {
+		oldCheckpointInterval := (previousRootsLength - 1) / a.checkpointInterval
+		newCheckpointInterval := int(block) / a.checkpointInterval
+		shouldCheckpoint = oldCheckpointInterval != newCheckpointInterval
+	}
+	if shouldCheckpoint {
+		if err := a.createCheckpoint(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -342,6 +412,75 @@ func (a *ArchiveTrie) Close() error {
 		a.head.closeWithError(a.Flush()))
 }
 
+func (a *ArchiveTrie) GetCheckpointBlock() (uint64, error) {
+	numRoots := a.roots.checkpointNumRoots
+	if numRoots > 0 {
+		return uint64(numRoots - 1), nil
+	}
+	return 0, fmt.Errorf("archive has no checkpoint")
+}
+
+func (a *ArchiveTrie) createCheckpoint() error {
+	// Before the checkpoint can be created, all data needs
+	// to be flushed to the underlying storage.
+	if err := a.Flush(); err != nil {
+		return err
+	}
+	// The creation of the checkpoint makes the current
+	// state recoverable in case of a crash.
+	_, err := a.checkpointCoordinator.CreateCheckpoint()
+	return err
+}
+
+func RestoreBlockHeight(directory string, config MptConfig, block uint64) (err error) {
+
+	// Make sure access to the directory is exclusive.
+	lock, err := LockDirectory(directory)
+	if err != nil {
+		return fmt.Errorf("failed to get exclusive access to directory: %v", err)
+	}
+	defer lock.Release()
+
+	// Check available block height -- stop recovery if there are not enough blocks.
+	rootRestore := getRootListRestorer(directory)
+	checkpointHeight, err := rootRestore.getNumRootsInCheckpoint()
+	if err != nil {
+		return fmt.Errorf("failed to get checkpoint height: %v", err)
+	}
+	if block >= uint64(checkpointHeight) {
+		return fmt.Errorf("block %d is beyond the last checkpoint height of %d", block, checkpointHeight-1)
+	}
+
+	// Mark this directory as dirty at least for the duration of the recovery.
+	if err := markDirty(directory); err != nil {
+		return fmt.Errorf("failed to mark directory %s as dirty: %w", directory, err)
+	}
+	defer func() {
+		// Only remove dirty flag is the recovery was successful.
+		if err == nil {
+			err = markClean(directory)
+		}
+	}()
+
+	// Restore the last checkpoint created by the archive.
+	accountsDir, branchesDir, extensionsDir, valuesDir := getForestDirectories(directory)
+	restorers := []checkpoint.Restorer{
+		file.GetRestorer(accountsDir),
+		file.GetRestorer(branchesDir),
+		file.GetRestorer(extensionsDir),
+		file.GetRestorer(valuesDir),
+		getCodeRestorer(directory),
+		rootRestore,
+	}
+
+	checkpointDir := filepath.Join(directory, "checkpoint")
+	if err := checkpoint.Restore(checkpointDir, restorers...); err != nil {
+		return fmt.Errorf("failed to restore checkpoint: %w", err)
+	}
+
+	return truncateRootsFile(rootRestore.rootsFile, int(block+1))
+}
+
 func (a *ArchiveTrie) getView(block uint64) (*LiveTrie, error) {
 	if err := a.CheckErrors(); err != nil {
 		return nil, err
@@ -384,8 +523,12 @@ func (a *ArchiveTrie) addError(err error) error {
 // of an archive and its synchronization with an on-disk file copy.
 type rootList struct {
 	roots          []Root
-	filename       string
+	filename       string // < the file storing the list of roots
+	directory      string // < the directory for checkpoint data
 	numRootsInFile int
+
+	checkpoint         checkpoint.Checkpoint
+	checkpointNumRoots int
 }
 
 func (l *rootList) length() int {
@@ -400,26 +543,45 @@ func (l *rootList) append(r Root) {
 	l.roots = append(l.roots, r)
 }
 
-func loadRoots(filename string) (rootList, error) {
+func loadRoots(archiveDirectory string) (*rootList, error) {
+	filename := filepath.Join(archiveDirectory, fileNameArchiveRoots)
+	directory := filepath.Join(archiveDirectory, fileNameArchiveRootsCheckpointDirectory)
+
+	// Create the directory for commit files if it does not exist.
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
 	// If there is no file, initialize and return an empty list.
 	if _, err := os.Stat(filename); err != nil {
-		return rootList{filename: filename}, nil
+		return &rootList{
+			filename:  filename,
+			directory: directory,
+		}, nil
+	}
+
+	committedCheckpointFile := filepath.Join(directory, fileNameArchiveRootsCommittedCheckpoint)
+	checkpointData, err := readRootListCheckpointData(committedCheckpointFile)
+	if err != nil {
+		return nil, err
 	}
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return rootList{}, err
+		return nil, err
 	}
 	defer f.Close()
 	reader := bufio.NewReader(f)
 	roots, err := loadRootsFrom(reader)
 	if err != nil {
-		return rootList{}, err
+		return nil, err
 	}
-	return rootList{
-		roots:          roots,
-		filename:       filename,
-		numRootsInFile: len(roots),
+	return &rootList{
+		roots:              roots,
+		filename:           filename,
+		directory:          directory,
+		numRootsInFile:     len(roots),
+		checkpoint:         checkpointData.Checkpoint,
+		checkpointNumRoots: checkpointData.NumRoots,
 	}, nil
 }
 
@@ -487,4 +649,116 @@ func storeRootsTo(writer io.Writer, roots []Root) error {
 		}
 	}
 	return nil
+}
+
+func (l *rootList) GuaranteeCheckpoint(checkpoint checkpoint.Checkpoint) error {
+	if l.checkpoint == checkpoint {
+		return nil
+	}
+	if l.checkpoint+1 == checkpoint {
+		pendingFile := filepath.Join(l.directory, fileNameArchiveRootsPreparedCheckpoint)
+		if _, err := os.Stat(pendingFile); err == nil {
+			return l.Commit(checkpoint)
+		}
+	}
+	return fmt.Errorf("unable to guarantee checkpoint %v, current checkpoint is %v", checkpoint, l.checkpoint)
+}
+
+func (l *rootList) Prepare(checkpoint checkpoint.Checkpoint) error {
+	if l.checkpoint+1 != checkpoint {
+		return fmt.Errorf("checkpoint mismatch, expected %v, got %v", l.checkpoint+1, checkpoint)
+	}
+	pendingFile := filepath.Join(l.directory, fileNameArchiveRootsPreparedCheckpoint)
+	return writeRootListCheckpointData(pendingFile, rootListCheckpointData{
+		Checkpoint: checkpoint,
+		NumRoots:   l.length(),
+	})
+}
+
+func (l *rootList) Commit(checkpoint checkpoint.Checkpoint) error {
+	if l.checkpoint+1 != checkpoint {
+		return fmt.Errorf("checkpoint mismatch, expected %v, got %v", l.checkpoint+1, checkpoint)
+	}
+	committedFile := filepath.Join(l.directory, fileNameArchiveRootsCommittedCheckpoint)
+	pendingFile := filepath.Join(l.directory, fileNameArchiveRootsPreparedCheckpoint)
+	meta, err := readRootListCheckpointData(pendingFile)
+	if err != nil {
+		return err
+	}
+	if meta.Checkpoint != checkpoint {
+		return fmt.Errorf("checkpoint mismatch, prepared %v, committed %v", meta.Checkpoint, checkpoint)
+	}
+	l.checkpoint = checkpoint
+	l.checkpointNumRoots = meta.NumRoots
+	return os.Rename(pendingFile, committedFile)
+}
+
+func (l *rootList) Abort(checkpoint checkpoint.Checkpoint) error {
+	if l.checkpoint+1 != checkpoint {
+		return fmt.Errorf("checkpoint mismatch, expected %v, got %v", l.checkpoint+1, checkpoint)
+	}
+	pendingFile := filepath.Join(l.directory, fileNameArchiveRootsPreparedCheckpoint)
+	return os.Remove(pendingFile)
+}
+
+type rootListRestorer struct {
+	rootsFile string
+	directory string
+}
+
+func getRootListRestorer(archiveDir string) rootListRestorer {
+	return rootListRestorer{
+		rootsFile: filepath.Join(archiveDir, fileNameArchiveRoots),
+		directory: filepath.Join(archiveDir, fileNameArchiveRootsCheckpointDirectory),
+	}
+}
+
+func (r rootListRestorer) Restore(checkpoint checkpoint.Checkpoint) error {
+	meta, err := readRootListCheckpointData(filepath.Join(r.directory, fileNameArchiveRootsCommittedCheckpoint))
+	if err != nil {
+		return err
+	}
+
+	// If the given checkpoint is one step in the future, check whether there is a pending checkpoint.
+	if meta.Checkpoint+1 == checkpoint {
+		pending, err := readRootListCheckpointData(filepath.Join(r.directory, fileNameArchiveRootsPreparedCheckpoint))
+		if err == nil && pending.Checkpoint == checkpoint {
+			meta = pending
+		}
+	}
+
+	if meta.Checkpoint != checkpoint {
+		return fmt.Errorf("checkpoint mismatch, expected %v, got %v", checkpoint, meta.Checkpoint)
+	}
+
+	return truncateRootsFile(r.rootsFile, meta.NumRoots)
+}
+
+func (r rootListRestorer) getNumRootsInCheckpoint() (int, error) {
+	meta, err := utils.ReadJsonFile[rootListCheckpointData](filepath.Join(r.directory, fileNameArchiveRootsCommittedCheckpoint))
+	if err != nil {
+		return 0, err
+	}
+	return meta.NumRoots, nil
+}
+
+func truncateRootsFile(path string, length int) error {
+	return os.Truncate(path, int64(length*(NodeIdEncoder{}.GetEncodedSize()+32)))
+}
+
+type rootListCheckpointData struct {
+	Checkpoint checkpoint.Checkpoint
+	NumRoots   int
+}
+
+func readRootListCheckpointData(file string) (rootListCheckpointData, error) {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return rootListCheckpointData{}, nil
+	}
+	return utils.ReadJsonFile[rootListCheckpointData](file)
+}
+
+func writeRootListCheckpointData(file string, data rootListCheckpointData) error {
+	return utils.WriteJsonFile(file, data)
 }

--- a/go/database/mpt/archive_trie_fuzzing_test.go
+++ b/go/database/mpt/archive_trie_fuzzing_test.go
@@ -964,7 +964,7 @@ func (c *archiveTrieAccountFuzzingCampaign[T, C]) Init() []fuzzing.OperationSequ
 // the created context.
 func (c *archiveTrieAccountFuzzingCampaign[T, C]) CreateContext(t fuzzing.TestingT) *C {
 	path := t.TempDir()
-	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, NodeCacheConfig{Capacity: 10_000})
+	archiveTrie, err := OpenArchiveTrie(path, S5LiveConfig, NodeCacheConfig{Capacity: 10_000}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open archive trie: %v", err)
 	}

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Carmen/go/backend/archive"
+	"github.com/Fantom-foundation/Carmen/go/backend/utils/checkpoint"
 	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	"golang.org/x/exp/maps"
 
@@ -44,7 +45,7 @@ import (
 func TestArchiveTrie_OpenAndClose(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -57,11 +58,11 @@ func TestArchiveTrie_OpenAndClose(t *testing.T) {
 
 func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open test archive: %v", err)
 	}
-	if _, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if _, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		t.Fatalf("archive should not be accessible by more than one instance")
 	}
 	if err := archive.Close(); err != nil {
@@ -72,7 +73,7 @@ func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
 func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < 5; i++ {
-		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 		if err != nil {
 			t.Fatalf("failed to open test archive: %v", err)
 		}
@@ -84,7 +85,7 @@ func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -93,19 +94,19 @@ func TestArchiveTrie_Open_Fails_Wrong_Roots(t *testing.T) {
 	}
 
 	// corrupt the roots
-	if err := os.WriteFile(filepath.Join(dir, "roots.dat"), []byte("Hello, World!"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, fileNameArchiveRoots), []byte("Hello, World!"), 0644); err != nil {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
 	}
 }
 
 func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -114,11 +115,11 @@ func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 	}
 
 	// corrupt the roots
-	if err := os.WriteFile(filepath.Join(dir, "roots.dat"), []byte("H"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, fileNameArchiveRoots), []byte("H"), 0644); err != nil {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
 		t.Errorf("opening archive should not succeed")
 	}
@@ -126,7 +127,7 @@ func TestArchiveTrie_Open_Fails_Too_Short_Roots(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -135,11 +136,11 @@ func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 	}
 
 	// remove read access
-	if err := os.Chmod(filepath.Join(dir, "roots.dat"), 0); err != nil {
+	if err := os.Chmod(filepath.Join(dir, fileNameArchiveRoots), 0); err != nil {
 		t.Fatalf("cannot chmod roots file: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
 		t.Errorf("opening archive should not succeed")
 	}
@@ -147,7 +148,7 @@ func TestArchiveTrie_Open_Fails_CannotOpen_Roots(t *testing.T) {
 
 func TestArchiveTrie_Open_Fails_Wrong_ForestMeta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -160,15 +161,15 @@ func TestArchiveTrie_Open_Fails_Wrong_ForestMeta(t *testing.T) {
 		t.Fatalf("cannot update meta: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
 	}
 }
 
 func TestArchiveTrie_Open_Fails_Wrong_TrieMeta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -181,15 +182,15 @@ func TestArchiveTrie_Open_Fails_Wrong_TrieMeta(t *testing.T) {
 		t.Fatalf("cannot update meta: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
 	}
 }
 
 func TestArchiveTrie_Open_Fails_Wrong_Codes(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -202,16 +203,174 @@ func TestArchiveTrie_Open_Fails_Wrong_Codes(t *testing.T) {
 		t.Fatalf("cannot update codes: %v", err)
 	}
 
-	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}); err == nil {
+	if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
 		_ = archive.Close()
-		t.Errorf("openning archive should not succeed")
+		t.Errorf("opening archive should not succeed")
+	}
+}
+
+func TestArchiveTrie_Open_Fails_InconsistentCheckpoints(t *testing.T) {
+	openForest := func(dir string) (*Forest, error) {
+		cacheConfig := NodeCacheConfig{Capacity: 1024}
+		forestConfig := ForestConfig{Mode: Immutable, NodeCacheConfig: cacheConfig}
+		config := S5ArchiveConfig
+		return OpenFileForest(dir, config, forestConfig)
+	}
+
+	// This test checks that misalignments in the checkpoints of various
+	// components of the archive are detected and cause the opening of the
+	// archive to fail. Implicitly, it also checks that all relevant parts
+	// of the archive are covered by the checkpoint mechanism.
+	tests := map[string]func(dir string) error{
+		"invalid top-level checkpoint": func(dir string) error {
+			checkpointDirectory := filepath.Join(dir, fileNameArchiveCheckpointDirectory)
+			coordinator, err := checkpoint.NewCoordinator(checkpointDirectory)
+			if err != nil {
+				return err
+			}
+			_, err = coordinator.CreateCheckpoint()
+			return err
+		},
+		"invalid accounts checkpoint": func(dir string) error {
+			forest, err := openForest(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				forest.accounts.Prepare(checkpoint),
+				forest.accounts.Commit(checkpoint),
+				forest.Close(),
+			)
+		},
+		"invalid branches checkpoint": func(dir string) error {
+			forest, err := openForest(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				forest.branches.Prepare(checkpoint),
+				forest.branches.Commit(checkpoint),
+				forest.Close(),
+			)
+		},
+		"invalid extension checkpoint": func(dir string) error {
+			forest, err := openForest(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				forest.extensions.Prepare(checkpoint),
+				forest.extensions.Commit(checkpoint),
+				forest.Close(),
+			)
+		},
+		"invalid values checkpoint": func(dir string) error {
+			forest, err := openForest(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				forest.values.Prepare(checkpoint),
+				forest.values.Commit(checkpoint),
+				forest.Close(),
+			)
+		},
+		"invalid codes checkpoint": func(dir string) error {
+			codes, err := openCodes(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				codes.Prepare(checkpoint),
+				codes.Commit(checkpoint),
+			)
+		},
+		"invalid roots checkpoint": func(dir string) error {
+			roots, err := loadRoots(dir)
+			if err != nil {
+				return err
+			}
+			checkpoint := checkpoint.Checkpoint(1)
+			return errors.Join(
+				roots.Prepare(checkpoint),
+				roots.Commit(checkpoint),
+			)
+		},
+	}
+
+	for name, corrupt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			if err != nil {
+				t.Fatalf("cannot init archive trie: %v", err)
+			}
+			if err := archive.Close(); err != nil {
+				t.Fatalf("cannot init archive trie: %v", err)
+			}
+
+			// corrupt the codes
+			if err := corrupt(dir); err != nil {
+				t.Fatalf("failed to corrupt test Archive: %v", err)
+			}
+
+			if archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{}); err == nil {
+				_ = archive.Close()
+				t.Errorf("opening archive should not succeed")
+			}
+		})
+	}
+}
+
+func TestArchiveTrie_CanTrackBlocksHeight(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			if err != nil {
+				t.Fatalf("failed to open empty archive: %v", err)
+			}
+			defer archive.Close()
+
+			block, empty, err := archive.GetBlockHeight()
+			if err != nil {
+				t.Fatalf("failed to get block height: %v", err)
+			}
+			if !empty || block != 0 {
+				t.Errorf("archive should be initially empty, got %t, %d", empty, block)
+			}
+
+			archive.Add(1, common.Update{}, nil)
+
+			block, empty, err = archive.GetBlockHeight()
+			if err != nil {
+				t.Fatalf("failed to get block height: %v", err)
+			}
+			if empty || block != 1 {
+				t.Errorf("archive should be have height 1, got %t, %d", empty, block)
+			}
+
+			archive.Add(3, common.Update{}, nil)
+
+			block, empty, err = archive.GetBlockHeight()
+			if err != nil {
+				t.Fatalf("failed to get block height: %v", err)
+			}
+			if empty || block != 3 {
+				t.Errorf("archive should be have height 3, got %t, %d", empty, block)
+			}
+		})
 	}
 }
 
 func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -249,7 +408,7 @@ func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -293,7 +452,7 @@ func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 
 func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("cannot init archive trie: %v", err)
 	}
@@ -302,7 +461,7 @@ func TestArchiveTrie_VerifyArchive_Failure_Meta(t *testing.T) {
 	}
 
 	// corrupt the roots
-	if err := os.WriteFile(filepath.Join(dir, "roots.dat"), []byte("Hello, World!"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, fileNameArchiveRoots), []byte("Hello, World!"), 0644); err != nil {
 		t.Fatalf("cannot update roots: %v", err)
 	}
 
@@ -323,7 +482,7 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 			}
 
 			archiveDir := t.TempDir()
-			archive, err := OpenArchiveTrie(archiveDir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(archiveDir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -413,7 +572,7 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -464,7 +623,7 @@ func TestArchiveTrie_Add_DuplicatedBlock(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -489,7 +648,7 @@ func TestArchiveTrie_Add_UpdateFailsHashing(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -514,49 +673,164 @@ func TestArchiveTrie_Add_UpdateFailsHashing(t *testing.T) {
 	}
 }
 
-func TestArchive_RootsGrowSubLinearly(t *testing.T) {
-	for _, config := range allMptConfigs {
-		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
-			if err != nil {
-				t.Fatalf("failed to create empty archive, err %v", err)
+func TestArchiveTrie_Add_CreatesCheckpointPeriodically(t *testing.T) {
+	for _, interval := range []int{1, 2, 3, 5, 7, 11} {
+		t.Run(fmt.Sprintf("interval-%d", interval), func(t *testing.T) {
+			dir := t.TempDir()
+			archiveConfig := ArchiveConfig{
+				CheckpointInterval: interval,
 			}
-			defer func() {
-				if err := archive.Close(); err != nil {
-					t.Fatalf("cannot close archive: %v", err)
-				}
-			}()
+			archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, archiveConfig)
+			if err != nil {
+				t.Fatalf("failed to open empty archive: %v", err)
+			}
+			defer archive.Close()
 
-			// Golang slices grow by the factor of 2 when they are small,
-			// while they grow slower when they become huge.
-			// The slice 'archive.roots' contains millions of elements
-			// stored as GiBs in memory.
-			// This test verifies that the slices grow slower for huge arrays
-			// to ensure that memory consumption is not doubled every time
-			// the slice grows.
-			// This feature cannot be customized, i.e., this test verifies
-			// that the described assumption will hold in future versions
-			// of golang and/or runtime configurations.
-
-			const size = 100_000
-			const threshold = 10_000
-			const factor = 1.3
-
-			var prevCap int
-			for i := 0; i < size; i++ {
+			for i := 0; i < 20; i++ {
 				if err := archive.Add(uint64(i), common.Update{}, nil); err != nil {
-					t.Fatalf("failed to add block 1; %s", err)
+					t.Fatalf("failed to apply update: %v", err)
+				}
+				cpWanted := checkpoint.Checkpoint(i / interval)
+				cpGot := archive.checkpointCoordinator.GetCurrentCheckpoint()
+				if cpWanted != cpGot {
+					t.Errorf("wrong checkpoint after block %d, want %d, have %d", i, cpWanted, cpGot)
 				}
 
-				if i > threshold {
-					if got, want := cap(archive.roots.roots), int(factor*float64(prevCap)); got >= want {
-						t.Fatalf("array grows too fast: %d >= %d", got, want)
+				cpBlockWanted := int(cpWanted) * interval
+				cpBlockGot, err := archive.GetCheckpointBlock()
+
+				if cpBlockWanted == 0 {
+					if err == nil {
+						t.Fatalf("expected error indicating no available checkpoint")
+					}
+				} else {
+					if err != nil {
+						t.Fatalf("failed to get checkpoint block: %v", err)
+					}
+
+					if cpBlockWanted != int(cpBlockGot) {
+						t.Errorf("wrong checkpoint block, want %d, have %d", cpBlockWanted, cpBlockGot)
 					}
 				}
-
-				prevCap = cap(archive.roots.roots)
 			}
 		})
+	}
+}
+
+func TestArchiveTrie_Add_CheckpointsAreCreatedForMissingBlocks(t *testing.T) {
+	dir := t.TempDir()
+	archiveConfig := ArchiveConfig{
+		CheckpointInterval: 5,
+	}
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, archiveConfig)
+	if err != nil {
+		t.Fatalf("failed to open empty archive: %v", err)
+	}
+	defer archive.Close()
+
+	// Adding block 4 should not create a checkpoint.
+	if err := archive.Add(4, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to apply update: %v", err)
+	}
+
+	if want, got := checkpoint.Checkpoint(0), archive.checkpointCoordinator.GetCurrentCheckpoint(); want != got {
+		t.Fatalf("wrong checkpoint, want %d, have %d", want, got)
+	}
+
+	// Adding block 7 should create a checkpoint, although it is not a multiple of 5.
+	if err := archive.Add(7, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to apply update: %v", err)
+	}
+
+	if want, got := checkpoint.Checkpoint(1), archive.checkpointCoordinator.GetCurrentCheckpoint(); want != got {
+		t.Fatalf("wrong checkpoint, want %d, have %d", want, got)
+	}
+
+	if got, err := archive.GetCheckpointBlock(); err != nil || got != 7 {
+		t.Fatalf("wrong checkpoint block, want %d, have %d, err %v", 7, got, err)
+	}
+
+	// Adding block 50 should should also create a checkpoint, although many blocks have been skipped.
+	if err := archive.Add(50, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to apply update: %v", err)
+	}
+
+	if want, got := checkpoint.Checkpoint(2), archive.checkpointCoordinator.GetCurrentCheckpoint(); want != got {
+		t.Fatalf("wrong checkpoint, want %d, have %d", want, got)
+	}
+
+	if got, err := archive.GetCheckpointBlock(); err != nil || got != 50 {
+		t.Fatalf("wrong checkpoint block, want %d, have %d, err %v", 50, got, err)
+	}
+}
+
+func TestArchiveTrie_Add_FailingToCreateCheckpointsIsDetected(t *testing.T) {
+	dir := t.TempDir()
+	archiveConfig := ArchiveConfig{
+		CheckpointInterval: 5,
+	}
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, archiveConfig)
+	if err != nil {
+		t.Fatalf("failed to open empty archive: %v", err)
+	}
+	defer archive.Close()
+
+	// by creating a checkpoint only for the roots, the checkpoints
+	// of the various components will be out of sync, sabotaging the
+	// creation of a new checkpoint.
+	cp := checkpoint.Checkpoint(1)
+	err = errors.Join(
+		archive.roots.Prepare(cp),
+		archive.roots.Commit(cp),
+	)
+	if err != nil {
+		t.Fatalf("failed to create checkpoint for the root list: %v", err)
+	}
+
+	// Adding block 4 should not create a checkpoint, and thus passes.
+	if err := archive.Add(4, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to apply update: %v", err)
+	}
+
+	// Adding block 5 should add a checkpoint, and an error should be detected.
+	if err := archive.Add(5, common.Update{}, nil); err == nil || !strings.Contains(err.Error(), "checkpoint mismatch") {
+		t.Errorf("adding block should fail due to checkpoint creation issue, got: %v", err)
+	}
+}
+
+func TestArchiveTrie_RootsGrowSubLinearly(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to create empty root list: %v", err)
+	}
+
+	// Golang slices grow by the factor of 2 when they are small,
+	// while they grow slower when they become huge.
+	// The slice 'archive.roots' contains millions of elements
+	// stored as GiBs in memory.
+	// This test verifies that the slices grow slower for huge arrays
+	// to ensure that memory consumption is not doubled every time
+	// the slice grows.
+	// This feature cannot be customized, i.e., this test verifies
+	// that the described assumption will hold in future versions
+	// of golang and/or runtime configurations.
+
+	const size = 100_000
+	const threshold = 10_000
+	const factor = 1.3
+
+	var prevCap int
+	for i := 0; i < size; i++ {
+		roots.append(Root{})
+
+		if i > threshold {
+			if got, want := cap(roots.roots), int(factor*float64(prevCap)); got >= want {
+				t.Fatalf("array grows too fast: %d >= %d", got, want)
+			}
+		}
+
+		prevCap = cap(roots.roots)
 	}
 }
 
@@ -565,7 +839,7 @@ func TestArchiveTrie_Add_LiveStateFailsHashing(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -592,7 +866,7 @@ func TestArchiveTrie_Add_LiveStateFailsCreateAccount(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -619,7 +893,7 @@ func TestArchiveTrie_Add_FreezingFails(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open archive, err %v", err)
 			}
@@ -647,7 +921,7 @@ func TestArchiveTrie_GettingView_Block_OutOfRange(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -676,7 +950,7 @@ func TestArchiveTrie_GetCodes(t *testing.T) {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -724,7 +998,7 @@ func TestArchiveTrie_GetHash(t *testing.T) {
 			dir := t.TempDir()
 
 			{
-				archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+				archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 				if err != nil {
 					t.Fatalf("failed to create empty archive, err %v", err)
 				}
@@ -740,7 +1014,7 @@ func TestArchiveTrie_GetHash(t *testing.T) {
 				}
 			}
 
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -765,7 +1039,7 @@ func TestArchiveTrie_CannotGet_AccountHash(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -779,7 +1053,7 @@ func TestArchiveTrie_CannotGet_AccountHash(t *testing.T) {
 func TestArchiveTrie_CreateWitnessProof(t *testing.T) {
 	for _, config := range []MptConfig{S5LiveConfig, S5ArchiveConfig} {
 		t.Run(config.Name, func(t *testing.T) {
-			arch, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			arch, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			defer func() {
 				if err := arch.Close(); err != nil {
 					t.Fatalf("failed to close archive; %s", err)
@@ -841,7 +1115,7 @@ func TestArchiveTrie_GetDiffProducesValidResults(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -940,7 +1214,7 @@ func TestArchiveTrie_GetDiffDetectsInvalidInput(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -991,7 +1265,7 @@ func TestArchiveTrie_GetDiffForBlockProducesValidResults(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1051,7 +1325,7 @@ func TestArchiveTrie_GetDiffForBlockDetectsEmptyArchive(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1069,7 +1343,7 @@ func TestArchiveTrie_GetMemoryFootprint(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1089,7 +1363,7 @@ func TestArchiveTrie_Dump(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1109,7 +1383,7 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1149,7 +1423,7 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to create empty archive, err %v", err)
 			}
@@ -1217,8 +1491,8 @@ func TestArchiveTrie_CanLoadRootsFromJunkySource(t *testing.T) {
 }
 
 func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "roots.dat")
-	original, err := loadRoots(file)
+	dir := t.TempDir()
+	original, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1236,7 +1510,7 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
-	restored, err := loadRoots(file)
+	restored, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1254,8 +1528,8 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 }
 
 func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "roots.dat")
-	list, err := loadRoots(file)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1269,15 +1543,21 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	}
 
 	// We redirect the incremental update into another file to see what is written.
-	list.filename = filepath.Join(t.TempDir(), "roots2.dat")
+	oldFile := list.filename
+	newFile := filepath.Join(dir, "new-roots.dat")
+	list.filename = newFile
 	list.append(Root{})
 	list.append(Root{})
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
+	if err := os.Rename(newFile, oldFile); err != nil {
+		t.Fatalf("failed to rename file: %v", err)
+	}
+
 	// Loading the second file should only produce 2 roots.
-	restored, err := loadRoots(list.filename)
+	restored, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1287,8 +1567,8 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 }
 
 func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "roots.dat")
-	list, err := loadRoots(file)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1307,7 +1587,7 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 			t.Fatalf("failed to store roots: %v", err)
 		}
 
-		restored, err := loadRoots(file)
+		restored, err := loadRoots(dir)
 		if err != nil {
 			t.Fatalf("failed to reload roots: %v", err)
 		}
@@ -1319,7 +1599,8 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 }
 
 func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "roots.dat")
+	dir := t.TempDir()
+	file := filepath.Join(dir, fileNameArchiveRoots)
 	roots := []Root{
 		{NewNodeReference(ValueId(12)), common.Hash{12}},
 		{NewNodeReference(ValueId(14)), common.Hash{14}},
@@ -1328,7 +1609,7 @@ func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
 	if err := StoreRoots(file, roots); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
-	restored, err := loadRoots(file)
+	restored, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1338,8 +1619,8 @@ func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
 }
 
 func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "roots.dat")
-	list, err := loadRoots(file)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
@@ -1348,7 +1629,7 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 	}
 
 	// remove write access
-	if err := os.Chmod(file, 0x400); err != nil {
+	if err := os.Chmod(list.filename, 0x400); err != nil {
 		t.Fatalf("cannot chmod roots file: %v", err)
 	}
 
@@ -1358,10 +1639,44 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 	}
 }
 
+func TestRootList_CanParticipateToCheckpointOperations(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
+
+	if want, got := 2, roots.length(); want != got {
+		t.Fatalf("invalid number of roots, wanted %d, got %d", want, got)
+	}
+
+	coordinator, err := checkpoint.NewCoordinator(t.TempDir(), roots)
+	if err != nil {
+		t.Fatalf("failed to create coordinator: %v", err)
+	}
+
+	_, err = coordinator.CreateCheckpoint()
+	if err != nil {
+		t.Fatalf("failed to create checkpoint: %v", err)
+	}
+
+	roots.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	if err := roots.storeRoots(); err != nil {
+		t.Fatalf("failed to store roots: %v", err)
+	}
+
+	if want, got := 3, roots.length(); want != got {
+		t.Fatalf("invalid number of roots, wanted %d, got %d", want, got)
+	}
+}
+
 func TestArchiveTrie_RecreateAccount_ClearStorage(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -1412,7 +1727,7 @@ func TestArchiveTrie_RecreateAccount_ClearStorage(t *testing.T) {
 
 func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 	// Goal: stress-test an archive with a limited node cache.
-	archive, err := OpenArchiveTrie(t.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 30_000})
+	archive, err := OpenArchiveTrie(t.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 30_000}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -1511,7 +1826,7 @@ func TestStoreRootsTo_SecondWriterFailures(t *testing.T) {
 func TestStoreRoots_Cannot_Create(t *testing.T) {
 	var roots []Root
 	dir := t.TempDir()
-	file := filepath.Join(dir, "roots")
+	file := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory)
 	if err := os.Mkdir(file, os.FileMode(0644)); err != nil {
 		t.Fatalf("cannot create dir: %s", err)
 	}
@@ -1546,7 +1861,7 @@ func TestArchiveTrie_FailingGetterOperation_InvalidatesArchive(t *testing.T) {
 			db.EXPECT().GetAccountInfo(gomock.Any(), gomock.Any()).Return(AccountInfo{}, false, injectedErr).MaxTimes(1)
 			db.EXPECT().GetValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Value{}, injectedErr).MaxTimes(1)
 
-			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000})
+			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("cannot open archive: %v", err)
 			}
@@ -1631,7 +1946,7 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			db.EXPECT().Freeze(gomock.Any()).AnyTimes()
 			db.EXPECT().CheckAll(gomock.Any()).AnyTimes()
 
-			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000})
+			archive, err := OpenArchiveTrie(t.TempDir(), S4ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("cannot open archive: %v", err)
 			}
@@ -1684,6 +1999,29 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 	}
 }
 
+var archiveGetters = map[string]func(archive archive.Archive) error{
+	"exists": func(archive archive.Archive) error {
+		_, err := archive.Exists(uint64(0), common.Address{})
+		return err
+	},
+	"balance": func(archive archive.Archive) error {
+		_, err := archive.GetBalance(uint64(0), common.Address{})
+		return err
+	},
+	"code": func(archive archive.Archive) error {
+		_, err := archive.GetCode(uint64(0), common.Address{})
+		return err
+	},
+	"nonce": func(archive archive.Archive) error {
+		_, err := archive.GetNonce(uint64(0), common.Address{})
+		return err
+	},
+	"storage": func(archive archive.Archive) error {
+		_, err := archive.GetStorage(uint64(0), common.Address{}, common.Key{})
+		return err
+	},
+}
+
 func TestArchiveTrie_VisitTrie_CorrectDataIsVisited(t *testing.T) {
 	addr := common.Address{1}
 
@@ -1725,7 +2063,7 @@ func TestArchiveTrie_VisitTrie_CorrectDataIsVisited(t *testing.T) {
 			t.Run(config.Name+" "+test.name, func(t *testing.T) {
 				ctrl := gomock.NewController(t)
 
-				archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+				archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 				if err != nil {
 					t.Fatalf("failed to open empty archive: %v", err)
 				}
@@ -1737,6 +2075,9 @@ func TestArchiveTrie_VisitTrie_CorrectDataIsVisited(t *testing.T) {
 						{Account: addr, Nonce: common.ToNonce(1)},
 					},
 				}, nil)
+				if err != nil {
+					t.Fatalf("failed to add update: %v", err)
+				}
 
 				var found bool
 
@@ -1768,7 +2109,7 @@ func TestArchiveTrie_VisitTrie_InvalidBlock(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			nodeVisitor := NewMockNodeVisitor(ctrl)
 
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			if err != nil {
 				t.Fatalf("failed to open empty archive: %v", err)
 			}
@@ -1782,6 +2123,9 @@ func TestArchiveTrie_VisitTrie_InvalidBlock(t *testing.T) {
 					{Account: addr, Nonce: common.ToNonce(1)},
 				},
 			}, nil)
+			if err != nil {
+				t.Fatalf("failed to add update: %v", err)
+			}
 
 			err = archive.VisitTrie(1, nodeVisitor)
 			if err == nil {
@@ -1796,31 +2140,697 @@ func TestArchiveTrie_VisitTrie_InvalidBlock(t *testing.T) {
 	}
 }
 
-var archiveGetters = map[string]func(archive archive.Archive) error{
-	"exists": func(archive archive.Archive) error {
-		_, err := archive.Exists(uint64(0), common.Address{})
-		return err
-	},
-	"balance": func(archive archive.Archive) error {
-		_, err := archive.GetBalance(uint64(0), common.Address{})
-		return err
-	},
-	"code": func(archive archive.Archive) error {
-		_, err := archive.GetCode(uint64(0), common.Address{})
-		return err
-	},
-	"nonce": func(archive archive.Archive) error {
-		_, err := archive.GetNonce(uint64(0), common.Address{})
-		return err
-	},
-	"storage": func(archive archive.Archive) error {
-		_, err := archive.GetStorage(uint64(0), common.Address{}, common.Key{})
-		return err
-	},
+func TestArchiveTrie_createCheckpoint_forwardsErrors(t *testing.T) {
+	tests := map[string]func(archive *ArchiveTrie) error{
+		"failing flush": func(archive *ArchiveTrie) error {
+			// Registering a pre-observed error causes the flush operation to fail.
+			archive.addError(fmt.Errorf("injected error"))
+			return nil
+		},
+		"out-of-sync components": func(archive *ArchiveTrie) error {
+			cp := checkpoint.Checkpoint(1)
+			return errors.Join(
+				archive.roots.Prepare(cp),
+				archive.roots.Commit(cp),
+			)
+		},
+	}
+
+	for name, sabotage := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
+			if err != nil {
+				t.Fatalf("cannot open archive: %v", err)
+			}
+			defer archive.Close()
+
+			if err := sabotage(archive); err != nil {
+				t.Fatalf("failed to sabotage archive: %v", err)
+			}
+
+			if err := archive.createCheckpoint(); err == nil {
+				t.Errorf("expected checkpoint creation to fail")
+			}
+		})
+	}
+}
+
+func TestArchiveTrie_RestoreBlockHeight(t *testing.T) {
+
+	addBlocks := func(archive *ArchiveTrie, from int, to int) error {
+		for i := from; i < to; i++ {
+			err := archive.Add(uint64(i), common.Update{
+				CreatedAccounts: []common.Address{{byte(i)}},
+				Nonces: []common.NonceUpdate{
+					{Account: common.Address{byte(i)}, Nonce: common.Nonce{byte(i)}},
+				},
+				Codes: []common.CodeUpdate{
+					{Account: common.Address{byte(i)}, Code: []byte{byte(i)}},
+				},
+			}, nil)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	tests := map[string]func(*ArchiveTrie) error{
+		"clean_close": func(archive *ArchiveTrie) error {
+			return archive.Close()
+		},
+		"clean_close_with_extra_blocks": func(archive *ArchiveTrie) error {
+			return errors.Join(
+				addBlocks(archive, 92, 98),
+				archive.Close(),
+			)
+		},
+		"no_close": func(archive *ArchiveTrie) error {
+			// In order to allow the recovery to access the directory, the lock needs to be released
+			return archive.head.(*MptState).lock.Release()
+		},
+		"no_close_with_extra_blocks": func(archive *ArchiveTrie) error {
+			return errors.Join(
+				addBlocks(archive, 92, 98),
+				archive.head.(*MptState).lock.Release(),
+			)
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create an archive and fill it with blocks.
+			{
+				archive, err := OpenArchiveTrie(
+					dir, S5ArchiveConfig,
+					NodeCacheConfig{
+						Capacity: 1000,
+					},
+					ArchiveConfig{
+						CheckpointInterval: 10,
+					},
+				)
+				if err != nil {
+					t.Fatalf("cannot open archive: %v", err)
+				}
+
+				if err := addBlocks(archive, 0, 92); err != nil {
+					t.Fatalf("failed to add blocks: %v", err)
+				}
+
+				// check that the archive has a checkpoint at block 90
+				checkpoint, err := archive.GetCheckpointBlock()
+				if err != nil {
+					t.Fatalf("failed to get checkpoint block: %v", err)
+				}
+				if want, got := uint64(90), checkpoint; want != got {
+					t.Errorf("unexpected checkpoint block, wanted %d, got %d", want, got)
+				}
+
+				if err := test(archive); err != nil {
+					t.Fatalf("failed to close archive: %v", err)
+				}
+			}
+
+			// The archive can not be reset to a block after the last checkpoint.
+			if err := RestoreBlockHeight(dir, S5ArchiveConfig, 91); err == nil {
+				t.Fatalf("expected error when restoring to block after last checkpoint")
+			}
+
+			// Blocks older than the last checkpoint can be restored.
+			lastBlock := uint64(92)
+			for _, block := range []uint64{90, 89, 85, 85, 47} {
+				if err := RestoreBlockHeight(dir, S5ArchiveConfig, block); err != nil {
+					t.Fatalf("failed to restore block height %d: %v", block, err)
+				}
+
+				// Check that the archive can be verified.
+				if err := VerifyArchiveTrie(dir, S5ArchiveConfig, nil); err != nil {
+					t.Fatalf("failed to verify archive after reset to block %d: %v", block, err)
+				}
+
+				// Check that the correct block has been restored.
+				archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
+				if err != nil {
+					t.Fatalf("failed to open archive: %v", err)
+				}
+				height, _, err := archive.GetBlockHeight()
+				if err != nil {
+					t.Fatalf("failed to get block height: %v", err)
+				}
+				if want, got := block, height; want != got {
+					t.Fatalf("unexpected block height, wanted %d, got %d", want, got)
+				}
+				if err := archive.Close(); err != nil {
+					t.Fatalf("failed to close archive: %v", err)
+				}
+
+				lastBlock = block
+			}
+
+			// Check that restored archive can be opened again.
+			{
+				archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
+				if err != nil {
+					t.Fatalf("cannot open archive: %v", err)
+				}
+
+				block, _, err := archive.GetBlockHeight()
+				if err != nil {
+					t.Fatalf("cannot get block height: %v", err)
+				}
+				if want, got := lastBlock, block; want != got {
+					t.Errorf("unexpected block height, wanted %d, got %d", want, got)
+				}
+
+				// check that the archive has a checkpoint at block 90
+				checkpoint, err := archive.GetCheckpointBlock()
+				if err != nil {
+					t.Fatalf("failed to get checkpoint block: %v", err)
+				}
+				if want, got := uint64(90), checkpoint; want != got {
+					t.Errorf("unexpected checkpoint block, wanted %d, got %d", want, got)
+				}
+
+				// additional blocks can be added
+				if err := addBlocks(archive, int(lastBlock+2), int(lastBlock+7)); err != nil {
+					t.Fatalf("failed to add blocks: %v", err)
+				}
+
+				if err := archive.Close(); err != nil {
+					t.Fatalf("failed to close archive: %v", err)
+				}
+			}
+
+			// Check that the restored and extended archive can be verified.
+			if err := VerifyArchiveTrie(dir, S5ArchiveConfig, nil); err != nil {
+				t.Fatalf("failed to verify archive: %v", err)
+			}
+
+		})
+	}
+}
+
+func TestArchiveTrie_RestoreBlockHeightFailsOnEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := RestoreBlockHeight(dir, S5ArchiveConfig, 0); err == nil {
+		t.Fatalf("expected error when restoring block height in empty directory")
+	}
+}
+
+func TestArchiveTrie_RestoreBlockHeightFailsOnBlockBeyondTheLastCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{
+		CheckpointInterval: 10,
+	})
+	if err != nil {
+		t.Fatalf("cannot open archive: %v", err)
+	}
+
+	if err := archive.Add(10, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to add update: %v", err)
+	}
+
+	if err := archive.Add(15, common.Update{}, nil); err != nil {
+		t.Fatalf("failed to add update: %v", err)
+	}
+
+	cpHeight, err := archive.GetCheckpointBlock()
+	if err != nil || cpHeight != 10 {
+		t.Fatalf("unexpected checkpoint block: %d, %v", cpHeight, err)
+	}
+
+	if err := archive.Close(); err != nil {
+		t.Fatalf("failed to close archive: %v", err)
+	}
+
+	for _, block := range []uint64{11, 12, 15, 16, 20, 123} {
+		if err := RestoreBlockHeight(dir, S5ArchiveConfig, block); err == nil || !strings.Contains(err.Error(), "beyond the last checkpoint") {
+			t.Fatalf("expected error when restoring block height beyond the last checkpoint, got %v", err)
+		}
+	}
+}
+
+func TestArchiveTrie_RestoreBlockHeight_DetectsIssuesAndForwardsThose(t *testing.T) {
+	tests := map[string]struct {
+		sabotage                     func(t *testing.T, dir string) error
+		expectedErrorMessageFragment string
+		directoryShouldBeDirtyAfter  bool
+	}{
+		"directory in use": {
+			sabotage: func(_ *testing.T, dir string) error {
+				_, err := LockDirectory(dir)
+				return err
+			},
+			expectedErrorMessageFragment: "exclusive access",
+		},
+		"unable to determine num roots in checkpoint": {
+			sabotage: func(_ *testing.T, dir string) error {
+				return os.Remove(filepath.Join(dir,
+					fileNameArchiveRootsCheckpointDirectory,
+					fileNameArchiveRootsCommittedCheckpoint,
+				))
+			},
+			expectedErrorMessageFragment: "failed to get checkpoint height",
+		},
+		"failed checkpoint restore": {
+			sabotage: func(_ *testing.T, dir string) error {
+				// The checkpoint recovery fails when the checkpoint data is corrupted.
+				return utils.WriteJsonFile(
+					filepath.Join(dir,
+						fileNameArchiveRootsCheckpointDirectory,
+						fileNameArchiveRootsCommittedCheckpoint,
+					),
+					rootListCheckpointData{
+						Checkpoint: 10,
+						NumRoots:   100,
+					},
+				)
+			},
+			expectedErrorMessageFragment: "failed to restore checkpoint",
+			directoryShouldBeDirtyAfter:  true,
+		},
+		"missing permissions": {
+			sabotage: func(t *testing.T, dir string) error {
+				t.Cleanup(func() {
+					_ = os.Chmod(dir, 0700)
+				})
+				return os.Chmod(dir, 0500)
+			},
+		},
+		"fail to mark as dirty": {
+			sabotage: func(t *testing.T, dir string) error {
+				return os.Mkdir(filepath.Join(dir, dirtyFileName), 0700)
+			},
+			expectedErrorMessageFragment: "failed to mark directory",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{
+				CheckpointInterval: 10,
+			})
+			if err != nil {
+				t.Fatalf("cannot open archive: %v", err)
+			}
+
+			if err := archive.Add(10, common.Update{}, nil); err != nil {
+				t.Fatalf("failed to add update: %v", err)
+			}
+
+			if err := archive.Add(15, common.Update{}, nil); err != nil {
+				t.Fatalf("failed to add update: %v", err)
+			}
+			if err := archive.Close(); err != nil {
+				t.Fatalf("failed to close archive: %v", err)
+			}
+
+			if err := test.sabotage(t, dir); err != nil {
+				t.Fatalf("failed to sabotage archive: %v", err)
+			}
+
+			if err := RestoreBlockHeight(dir, S5ArchiveConfig, 10); err == nil || !strings.Contains(err.Error(), test.expectedErrorMessageFragment) {
+				t.Fatalf("expected error containing \"%s\", got %v", test.expectedErrorMessageFragment, err)
+			}
+
+			dirty, err := isDirty(dir)
+			if err != nil {
+				t.Fatalf("failed to check if directory is dirty: %v", err)
+			}
+			if want, got := test.directoryShouldBeDirtyAfter, dirty; want != got {
+				t.Errorf("expected dirty state of directory to be %t, got %t", want, got)
+			}
+		})
+	}
+}
+
+func TestRootList_LoadRoots_ForwardsIoIssues(t *testing.T) {
+	tests := map[string]func(t *testing.T, dir string) error{
+		"fail to create directory": func(t *testing.T, dir string) error {
+			// this case creates a file with the given directory name,
+			// making it impossible to re-create the directory.
+			if err := os.RemoveAll(dir); err != nil {
+				return err
+			}
+			t.Cleanup(func() {
+				os.Remove(dir)
+			})
+			return os.WriteFile(dir, []byte{}, 0700)
+		},
+		"corrupted checkpoint file": func(_ *testing.T, dir string) error {
+			return utils.WriteJsonFile(
+				filepath.Join(dir,
+					fileNameArchiveRootsCheckpointDirectory,
+					fileNameArchiveRootsCommittedCheckpoint,
+				), "corrupted data")
+		},
+	}
+
+	for name, sabotage := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			roots, err := loadRoots(dir)
+			if err != nil {
+				t.Fatalf("failed to load roots: %v", err)
+			}
+			roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+
+			cp := checkpoint.Checkpoint(1)
+			err = errors.Join(
+				roots.Prepare(cp),
+				roots.Commit(cp),
+				roots.storeRoots(),
+			)
+			if err != nil {
+				t.Fatalf("failed to prepare test list for roots: %v", err)
+			}
+
+			if err := sabotage(t, dir); err != nil {
+				t.Fatalf("failed to sabotage roots list: %v", err)
+			}
+
+			if _, err := loadRoots(dir); err == nil {
+				t.Fatalf("expected error when loading roots")
+			}
+		})
+	}
+}
+
+func TestRootList_storeRootsTo_HandlesWriteIssues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	writeCounter := utils.NewMockOsFile(ctrl)
+
+	roots := make([]Root, 10)
+
+	counter := 0
+	writeCounter.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
+		counter++
+		return len(p), nil
+	}).AnyTimes()
+
+	if err := storeRootsTo(writeCounter, roots); err != nil {
+		t.Fatalf("failed to store roots: %v", err)
+	}
+
+	if counter == 0 {
+		t.Fatalf("expected write to be called")
+	}
+
+	for i := 0; i < counter; i++ {
+		t.Run(fmt.Sprintf("write_%d", i), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			out := utils.NewMockOsFile(ctrl)
+
+			inducedError := fmt.Errorf("induced error")
+			gomock.InOrder(
+				out.EXPECT().Write(gomock.Any()).Return(0, nil).Times(i),
+				out.EXPECT().Write(gomock.Any()).Return(0, inducedError),
+			)
+
+			if err := storeRootsTo(out, roots); !errors.Is(err, inducedError) {
+				t.Fatalf("expected error when writing roots")
+			}
+		})
+	}
+}
+
+func TestRootList_GuaranteeCheckpoint_EmptyListSupportsCheckpointZero(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	if err := roots.GuaranteeCheckpoint(checkpoint.Checkpoint(0)); err != nil {
+		t.Fatalf("failed to guarantee checkpoint: %v", err)
+	}
+}
+
+func TestRootList_GuaranteeCheckpoint_CreatedCheckpointsCanBeGuaranteed(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		cp := checkpoint.Checkpoint(i + 1)
+		err := errors.Join(
+			roots.Prepare(cp),
+			roots.Commit(cp),
+		)
+		if err != nil {
+			t.Fatalf("failed to create new checkpoint: %v", err)
+		}
+		if err := roots.GuaranteeCheckpoint(cp); err != nil {
+			t.Fatalf("failed to guarantee checkpoint: %v", err)
+		}
+	}
+}
+
+func TestRootList_GuaranteeCheckpoint_FailsForNonExistingCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		cp := checkpoint.Checkpoint(i + 1)
+		err := errors.Join(
+			roots.Prepare(cp),
+			roots.Commit(cp),
+		)
+		if err != nil {
+			t.Fatalf("failed to create new checkpoint: %v", err)
+		}
+	}
+
+	// should not work for outdated checkpoint
+	cp := checkpoint.Checkpoint(9)
+	if err := roots.GuaranteeCheckpoint(cp); err == nil {
+		t.Fatalf("expected error when checking outdated checkpoint")
+	}
+
+	// should also fail for future checkpoint
+	cp = checkpoint.Checkpoint(11)
+	if err := roots.GuaranteeCheckpoint(cp); err == nil {
+		t.Fatalf("expected error when checking future checkpoint")
+	}
+}
+
+func TestRootList_GuaranteeCheckpoint_CommitsPendingCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	cp0 := checkpoint.Checkpoint(0)
+	cp1 := checkpoint.Checkpoint(1)
+	if err := roots.Prepare(cp1); err != nil {
+		t.Fatalf("failed to prepare checkpoint: %v", err)
+	}
+
+	if want, got := cp0, roots.checkpoint; want != got {
+		t.Fatalf("unexpected checkpoint, wanted %v, got %v", want, got)
+	}
+
+	if err := roots.GuaranteeCheckpoint(cp1); err != nil {
+		t.Fatalf("failed to guarantee checkpoint: %v", err)
+	}
+
+	if want, got := cp1, roots.checkpoint; want != got {
+		t.Fatalf("unexpected checkpoint, wanted %v, got %v", want, got)
+	}
+}
+
+func TestRootList_Prepare_OnlyAcceptsIncrementalCheckpoints(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(2)
+	if err := roots.Prepare(cp); err == nil {
+		t.Fatalf("expected error when preparing non-incremental checkpoint")
+	}
+}
+
+func TestRootList_Prepare_FailsOnIOError(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	prepareFile := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory, fileNameArchiveRootsPreparedCheckpoint)
+	if err := os.Mkdir(prepareFile, 0700); err != nil {
+		t.Fatalf("failed to create prepare directory blocking prepare file: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(1)
+	if err := roots.Prepare(cp); err == nil {
+		t.Fatalf("expected error when prepare file cannot be created")
+	}
+}
+
+func TestRootList_Commit_OnlyAcceptsIncrementalCheckpoints(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(2)
+	if err := roots.Commit(cp); err == nil {
+		t.Fatalf("expected error when committing non-incremental checkpoint")
+	}
+}
+
+func TestRootList_Commit_FailsOnMissingPreparationStep(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(1)
+	if err := roots.Commit(cp); err == nil {
+		t.Fatalf("expected error when committing non-incremental checkpoint")
+	}
+}
+
+func TestRootList_Commit_FailsOnUnreadablePreparationFile(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	prepareFile := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory, fileNameArchiveRootsPreparedCheckpoint)
+	if err := os.WriteFile(prepareFile, []byte("not in JSON format"), 0700); err != nil {
+		t.Fatalf("failed to create unreadable prepare file: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(1)
+	if err := roots.Commit(cp); err == nil {
+		t.Fatalf("expected error when committing non-incremental checkpoint")
+	}
+}
+
+func TestRootList_Abort_DeletesPendingCheckpointFile(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	prepareFile := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory, fileNameArchiveRootsPreparedCheckpoint)
+	if err := os.WriteFile(prepareFile, []byte{}, 0700); err != nil {
+		t.Fatalf("failed to create prepare file: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(1)
+	if err := roots.Abort(cp); err != nil {
+		t.Fatalf("failed to abort checkpoint: %v", err)
+	}
+
+	if _, err := os.Stat(prepareFile); !os.IsNotExist(err) {
+		t.Fatalf("expected prepare file to be deleted")
+	}
+}
+
+func TestRootList_Abort_OnlyAcceptsIncrementalCheckpoints(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := loadRoots(dir)
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(2)
+	if err := roots.Abort(cp); err == nil {
+		t.Fatalf("expected error when aborting non-incremental checkpoint")
+	}
+}
+
+func TestRootList_Restore_CanRecoverCorruptedRoots(t *testing.T) {
+	for _, name := range []string{"prepared", "committed"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			roots, err := loadRoots(dir)
+			if err != nil {
+				t.Fatalf("failed to load roots: %v", err)
+			}
+			roots.append(Root{NodeRef: NewNodeReference(ValueId(123))})
+			roots.append(Root{NodeRef: NewNodeReference(ValueId(123))})
+
+			if err := roots.storeRoots(); err != nil {
+				t.Fatalf("failed to store roots: %v", err)
+			}
+
+			cp := checkpoint.Checkpoint(1)
+			if err := roots.Prepare(cp); err != nil {
+				t.Fatalf("failed to prepare checkpoint: %v", err)
+			}
+			if name == "committed" {
+				if err := roots.Commit(cp); err != nil {
+					t.Fatalf("failed to commit checkpoint: %v", err)
+				}
+			}
+
+			backup, err := os.ReadFile(roots.filename)
+			if err != nil {
+				t.Fatalf("failed to read backup file: %v", err)
+			}
+
+			modified := append(backup, []byte("corrupted data")...)
+			if err := os.WriteFile(roots.filename, modified, 0700); err != nil {
+				t.Fatalf("failed to corrupt roots file: %v", err)
+			}
+
+			if err := getRootListRestorer(dir).Restore(cp); err != nil {
+				t.Fatalf("failed to restore roots: %v", err)
+			}
+
+			restored, err := os.ReadFile(roots.filename)
+			if err != nil {
+				t.Fatalf("failed to read restored file: %v", err)
+			}
+
+			if !bytes.Equal(backup, restored) {
+				t.Fatalf("unexpected restored file content")
+			}
+		})
+	}
+}
+
+func TestRootList_Restore_FailsIfCheckpointFileCanNotBeRead(t *testing.T) {
+	dir := t.TempDir()
+
+	directory := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory)
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		t.Fatalf("failed to create checkpoint directory: %v", err)
+	}
+	checkpointFile := filepath.Join(directory, fileNameArchiveRootsCommittedCheckpoint)
+	if err := os.WriteFile(checkpointFile, []byte("corrupted data"), 0700); err != nil {
+		t.Fatalf("failed to create corrupted checkpoint file: %v", err)
+	}
+
+	cp := checkpoint.Checkpoint(1)
+	if err := getRootListRestorer(dir).Restore(cp); err == nil {
+		t.Fatalf("expected recovery error due to invalid checkpoint file")
+	}
 }
 
 func BenchmarkArchiveFlush_Roots(b *testing.B) {
-	archive, err := OpenArchiveTrie(b.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 1000})
+	archive, err := OpenArchiveTrie(b.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 1000}, ArchiveConfig{})
 	if err != nil {
 		b.Fatalf("cannot open archive: %v", err)
 	}

--- a/go/database/mpt/dirty_directory_mark.go
+++ b/go/database/mpt/dirty_directory_mark.go
@@ -35,12 +35,12 @@ func isDirty(directory string) (bool, error) {
 	}
 
 	// Check for the dirty flag.
-	_, err = os.Stat(filepath.Join(directory, dirtyFileName))
+	stat, err := os.Stat(filepath.Join(directory, dirtyFileName))
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 
-	return true, err
+	return !stat.IsDir(), err
 }
 
 // markDirty marks the given directory as dirty, and thus, potentially

--- a/go/database/mpt/dirty_directory_mark_test.go
+++ b/go/database/mpt/dirty_directory_mark_test.go
@@ -63,3 +63,13 @@ func TestDirtyDirectoryMark_DirectoryCanBeMarkedDirtyAndCleanedAgain(t *testing.
 		t.Fatalf("unexpected state of cleaned directory: %t, %v", dirty, err)
 	}
 }
+
+func TestDirtyDirectoryMark_DirtyFlagMustBeAFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, dirtyFileName), 0700); err != nil {
+		t.Fatalf("failed to create a directory with the dirty flag: %v", err)
+	}
+	if dirty, err := isDirty(dir); dirty || err != nil {
+		t.Fatalf("a directory with the dirty-file name should not be considered a valid dirty mark")
+	}
+}

--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -67,7 +67,7 @@ func ExportArchive(ctx context.Context, directory string, out io.Writer) error {
 		return fmt.Errorf("can only support export of S5 Archive instances, found %v in directory", info.Config.Name)
 	}
 
-	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{})
+	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func importArchive(liveDbDir, archiveDbDir string, in io.Reader) (err error) {
 	}()
 
 	// Create an empty archive.
-	archive, err := mpt.OpenArchiveTrie(archiveDbDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
+	archive, err := mpt.OpenArchiveTrie(archiveDbDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to create empty state: %w", err)
 	}

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -25,7 +25,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 
 	// Create a small Archive to be exported.
 	sourceDir := t.TempDir()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
-	target, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	target, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 
 	// Create a small Archive to be exported.
 	sourceDir := t.TempDir()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 		t.Fatalf("verification of imported Archive failed: %v", err)
 	}
 
-	archive, err := mpt.OpenArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	archive, err := mpt.OpenArchiveTrie(path.Join(targetDir, "archive"), mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}

--- a/go/database/mpt/io/interrupt_test.go
+++ b/go/database/mpt/io/interrupt_test.go
@@ -98,7 +98,7 @@ func createTestLive(t *testing.T, sourceDir string) {
 
 func createTestArchive(t *testing.T, sourceDir string) {
 	t.Helper()
-	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	source, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -122,7 +122,7 @@ func checkCanOpenLiveDB(t *testing.T, sourceDir string) {
 
 // checkCanOpenLiveDB makes sure Archive is not corrupted and can be opened (and closed)
 func checkCanOpenArchive(t *testing.T, sourceDir string) {
-	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{})
+	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open archive: %v", err)
 	}

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -121,7 +121,7 @@ func ExportBlockFromArchive(ctx context.Context, directory string, out io.Writer
 		return fmt.Errorf("can only support export of S5 Archive instances, found %v in directory", info.Config.Name)
 	}
 
-	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{})
+	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 	if err != nil {
 		return err
 	}

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -68,7 +68,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("verification of imported DB failed: %v", err)
 	}
 
-	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	db, err := mpt.OpenArchiveTrie(targetDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestCheckEmptyDirectory_FailsIfDirectoryContainsADirectory(t *testing.T) {
 func TestIO_ExportBlockFromArchive(t *testing.T) {
 	// Create a small Archive from which we export LiveDB genesis.
 	sourceDir := t.TempDir()
-	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+	archive, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -42,7 +42,7 @@ var stateFactories = map[string]func(string) (io.Closer, error){
 		return OpenGoFileState(dir, S5LiveConfig, NodeCacheConfig{Capacity: 1024})
 	},
 	"archive": func(dir string) (io.Closer, error) {
-		return OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+		return OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	},
 	"verify": func(dir string) (io.Closer, error) { return openVerificationNodeSource(dir, S5LiveConfig) },
 }

--- a/go/database/mpt/tool/block.go
+++ b/go/database/mpt/tool/block.go
@@ -59,7 +59,7 @@ func block(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.NodeCacheConfig{Capacity: 1024})
+	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to open archive in %s: %w", dir, err)
 	}

--- a/go/database/mpt/tool/info.go
+++ b/go/database/mpt/tool/info.go
@@ -78,7 +78,7 @@ func info(context *cli.Context) error {
 			return fmt.Errorf("error closing forest: %v", err)
 		}
 	} else {
-		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config, mpt.NodeCacheConfig{})
+		archive, err := mpt.OpenArchiveTrie(dir, mptInfo.Config, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 		if err != nil {
 			fmt.Printf("\tFailed to open:    %v\n", err)
 			return nil
@@ -93,6 +93,13 @@ func info(context *cli.Context) error {
 			fmt.Printf("\tBlock height:      empty\n")
 		} else {
 			fmt.Printf("\tBlock height:      %d\n", height)
+		}
+
+		checkpoint, err := archive.GetCheckpointBlock()
+		if err != nil {
+			fmt.Printf("\tCheckpoint block:  %v\n", err)
+		} else {
+			fmt.Printf("\tCheckpoint block:  %d\n", checkpoint)
 		}
 
 		if err := archive.Close(); err != nil {

--- a/go/database/mpt/tool/main.go
+++ b/go/database/mpt/tool/main.go
@@ -38,6 +38,7 @@ func main() {
 			&Benchmark,
 			&Block,
 			&StressTestCmd,
+			&Reset,
 		},
 	}
 

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -206,11 +206,11 @@ func verifyForest(directory string, config MptConfig, roots []Root, source *veri
 		if err != nil {
 			return err
 		}
-		for _, root := range roots {
+		for block, root := range roots {
 			want := hashes[root.NodeRef.Id()]
 			got := root.Hash
 			if want != got {
-				return fmt.Errorf("inconsistent hash for root node %v, want %v, got %v", root.NodeRef.Id(), want, got)
+				return fmt.Errorf("inconsistent hash for root node %v of block %d, want %v, got %v", root.NodeRef.Id(), block, want, got)
 			}
 		}
 	}

--- a/go/database/mpt/visitor_test.go
+++ b/go/database/mpt/visitor_test.go
@@ -46,7 +46,7 @@ func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
 
 func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 	dir := t.TempDir()
-	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 		t.Errorf("invalid stats for empty archive: %v", stats)
 	}
 
-	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024})
+	archive, err = OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to re-open empty archive: %v", err)
 	}

--- a/go/state/gostate/configurations.go
+++ b/go/state/gostate/configurations.go
@@ -938,7 +938,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, getNodeCacheConfig(params.ArchiveCache))
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, getNodeCacheConfig(params.ArchiveCache), mpt.ArchiveConfig{})
 		return arch, nil, err
 
 	case state.S5Archive:
@@ -946,7 +946,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, getNodeCacheConfig(params.ArchiveCache))
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, getNodeCacheConfig(params.ArchiveCache), mpt.ArchiveConfig{})
 		return arch, nil, err
 	}
 	return nil, nil, fmt.Errorf("unknown archive type: %v", params.Archive)


### PR DESCRIPTION
This PR adds automated checkpoint creation and recovery support to MPT Archives. The major changes include:
- the support for check-pointing the list of root nodes
- the integration of checkpoint creation in the Archive
- configuration support for the check-pointing interval
- the integration of checkpoint information into the mpt-tool `info` command
- the integration of a recovery command into the mpt-tool

This PR contributes to #946  