### PR TITLE
Ignore directories when checking for dirty flags in directories

### DIFF
--- a/go/database/mpt/dirty_directory_mark.go
+++ b/go/database/mpt/dirty_directory_mark.go
@@ -35,12 +35,12 @@ func isDirty(directory string) (bool, error) {
 	}
 
 	// Check for the dirty flag.
-	_, err = os.Stat(filepath.Join(directory, dirtyFileName))
+	stat, err := os.Stat(filepath.Join(directory, dirtyFileName))
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 
-	return true, err
+	return !stat.IsDir(), err
 }
 
 // markDirty marks the given directory as dirty, and thus, potentially

--- a/go/database/mpt/dirty_directory_mark_test.go
+++ b/go/database/mpt/dirty_directory_mark_test.go
@@ -63,3 +63,13 @@ func TestDirtyDirectoryMark_DirectoryCanBeMarkedDirtyAndCleanedAgain(t *testing.
 		t.Fatalf("unexpected state of cleaned directory: %t, %v", dirty, err)
 	}
 }
+
+func TestDirtyDirectoryMark_DirtyFlagMustBeAFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, dirtyFileName), 0700); err != nil {
+		t.Fatalf("failed to create a directory with the dirty flag: %v", err)
+	}
+	if dirty, err := isDirty(dir); dirty || err != nil {
+		t.Fatalf("a directory with the dirty-file name should not be considered a valid dirty mark")
+	}
+}


### PR DESCRIPTION
This PR fixes a minor issue encountered while preparing test cases. A directory is not only identified as dirty if there is a file named `dirty` but also if there is a directory named `dirty`. This is not as it was originally intended.

By fixing this, it becomes simpler to create test cases where marking of a directory as dirty should fail.