### PR TITLE
Increase default checkpoint interval

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -119,7 +119,7 @@ func OpenArchiveTrie(
 
 	checkpointInterval := archiveConfig.CheckpointInterval
 	if checkpointInterval <= 0 {
-		checkpointInterval = 1000
+		checkpointInterval = 1_000_000
 	}
 
 	return &ArchiveTrie{


### PR DESCRIPTION
The PR increases the default checkpoint interval to 1M blocks. 

The previous value of creating one checkpoint every 1000 blocks was to aggressive when syncing the archive. It was aiming for ~1 checkpoint every 10 minutes in live mode, but during syncing this would be more like 1 checkpoint every 2 seconds.

This change is a quick-fix to re-enable unit tests. As a follow-up a system-time dependent checkpoint triggering should be added (see #990).