### PR TITLE
Eliminate ineffective cache caching in Archive block state export

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -292,7 +292,11 @@ func (a *ArchiveTrie) GetCode(block uint64, account common.Address) (code []byte
 	if err != nil {
 		return nil, a.addError(err)
 	}
-	return a.head.GetCodeForHash(info.CodeHash), nil
+	return a.GetCodeForHash(info.CodeHash), nil
+}
+
+func (a *ArchiveTrie) GetCodeForHash(hash common.Hash) []byte {
+	return a.head.GetCodeForHash(hash)
 }
 
 func (a *ArchiveTrie) GetCodes() map[common.Hash][]byte {

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -68,7 +68,6 @@ type mptStateVisitor interface {
 type exportableArchiveTrie struct {
 	trie  *mpt.ArchiveTrie
 	block uint64
-	codes map[common.Hash][]byte
 }
 
 func (e exportableArchiveTrie) Visit(visitor mpt.NodeVisitor) error {
@@ -80,10 +79,7 @@ func (e exportableArchiveTrie) GetHash() (common.Hash, error) {
 }
 
 func (e exportableArchiveTrie) GetCodeForHash(hash common.Hash) []byte {
-	if e.codes == nil || len(e.codes) == 0 {
-		e.codes = e.trie.GetCodes()
-	}
-	return e.codes[hash]
+	return e.trie.GetCodeForHash(hash)
 }
 
 // Export opens a LiveDB instance retained in the given directory and writes


### PR DESCRIPTION
This PR improves the block-state exporting performance from an Archive. Before this fix, exporting block 10M from an Archive including 10M blocks took 5.5 minutes. With this change, this time got reduced to 2 minutes.

In the pprof profile the issue was clearly visible:
![image](https://github.com/user-attachments/assets/603fa3dd-604f-495e-a584-9ce10776a9fb)

After this fix, this part of the overall processing is no longer visible in the profile.

In the old version of this code, the full code map was copied for each individual lookup, as the function
```
func (e exportableArchiveTrie) GetCodeForHash(hash common.Hash) []byte
```
accepts `e` by value. Thus, the fetched code map is dropped after each call.

Furthermore, there is no need to cache codes in the first place, as those are also cached by the Archive itself.

This is part of #997