### PR TITLE
Expand performance diagnosing utilities to all commands

### DIFF
--- a/go/database/mpt/tool/block.go
+++ b/go/database/mpt/tool/block.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
@@ -21,12 +20,11 @@ import (
 )
 
 var Block = cli.Command{
-	Action:    block,
+	Action:    addPerformanceDiagnoses(block),
 	Name:      "block",
 	Usage:     "retrieves information about a given block",
 	ArgsUsage: "<archive-director>",
 	Flags: []cli.Flag{
-		&cpuProfileFlag,
 		&targetBlockFlag,
 	},
 }
@@ -40,15 +38,6 @@ func block(context *cli.Context) error {
 	// parse the directory argument
 	if context.Args().Len() != 1 {
 		return fmt.Errorf("missing directory storing archive")
-	}
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
 	}
 
 	dir := context.Args().Get(0)

--- a/go/database/mpt/tool/check.go
+++ b/go/database/mpt/tool/check.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
@@ -20,28 +19,16 @@ import (
 )
 
 var Check = cli.Command{
-	Action:    check,
+	Action:    addPerformanceDiagnoses(check),
 	Name:      "check",
 	Usage:     "performs extensive invariants checks",
 	ArgsUsage: "<director>",
-	Flags: []cli.Flag{
-		&cpuProfileFlag,
-	},
 }
 
 func check(context *cli.Context) error {
 	// parse the directory argument
 	if context.Args().Len() != 1 {
 		return fmt.Errorf("missing directory storing state")
-	}
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
 	}
 
 	dir := context.Args().Get(0)

--- a/go/database/mpt/tool/export.go
+++ b/go/database/mpt/tool/export.go
@@ -15,21 +15,20 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/Fantom-foundation/Carmen/go/common/interrupt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
-	"os"
-	"strings"
 )
 
 var ExportCmd = cli.Command{
-	Action:    doExport,
+	Action:    addPerformanceDiagnoses(doExport),
 	Name:      "export",
 	Usage:     "exports a LiveDB or Archive instance into a file",
 	ArgsUsage: "<db director> <target-file>",
 	Flags: []cli.Flag{
-		&cpuProfileFlag,
 		&targetBlockFlag,
 	},
 }
@@ -40,15 +39,6 @@ func doExport(context *cli.Context) error {
 	}
 	dir := context.Args().Get(0)
 	trg := context.Args().Get(1)
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
-	}
 
 	// check the type of target database
 	mptInfo, err := io.CheckMptDirectoryAndGetInfo(dir)

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -15,41 +15,32 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	mptIo "github.com/Fantom-foundation/Carmen/go/database/mpt/io"
-	"github.com/urfave/cli/v2"
 	"io"
 	"os"
-	"strings"
+
+	mptIo "github.com/Fantom-foundation/Carmen/go/database/mpt/io"
+	"github.com/urfave/cli/v2"
 )
 
 var ImportLiveDbCmd = cli.Command{
-	Action:    doLiveDbImport,
+	Action:    addPerformanceDiagnoses(doLiveDbImport),
 	Name:      "import-live-db",
 	Usage:     "imports a LiveDB instance from a file",
 	ArgsUsage: "<source-file> <target director>",
-	Flags: []cli.Flag{
-		&cpuProfileFlag,
-	},
 }
 
 var ImportArchiveCmd = cli.Command{
-	Action:    doArchiveImport,
+	Action:    addPerformanceDiagnoses(doArchiveImport),
 	Name:      "import-archive",
 	Usage:     "imports an Archive instance from a file",
 	ArgsUsage: "<source-file> <target director>",
-	Flags: []cli.Flag{
-		&cpuProfileFlag,
-	},
 }
 
 var ImportLiveAndArchiveCmd = cli.Command{
-	Action:    doLiveAndArchiveImport,
+	Action:    addPerformanceDiagnoses(doLiveAndArchiveImport),
 	Name:      "import",
 	Usage:     "imports both LiveDB and Archive instance from a file",
 	ArgsUsage: "<source-file> <target director>",
-	Flags: []cli.Flag{
-		&cpuProfileFlag,
-	},
 }
 
 func doLiveDbImport(context *cli.Context) error {
@@ -70,15 +61,6 @@ func doImport(context *cli.Context, runImport func(directory string, in io.Reade
 	}
 	src := context.Args().Get(0)
 	dir := context.Args().Get(1)
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
-	}
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("error creating output directory: %v", err)

--- a/go/database/mpt/tool/info.go
+++ b/go/database/mpt/tool/info.go
@@ -19,7 +19,7 @@ import (
 )
 
 var Info = cli.Command{
-	Action: info,
+	Action: addPerformanceDiagnoses(info),
 	Name:   "info",
 	Usage:  "lists information about a Carmen MTP state repository",
 	Flags: []cli.Flag{

--- a/go/database/mpt/tool/init_archive.go
+++ b/go/database/mpt/tool/init_archive.go
@@ -23,7 +23,7 @@ import (
 )
 
 var InitArchive = cli.Command{
-	Action:    doArchiveInit,
+	Action:    addPerformanceDiagnoses(doArchiveInit),
 	Name:      "init-archive",
 	Usage:     "initializes an Archive instance from a file",
 	ArgsUsage: "<source-file> <archive target director>",

--- a/go/database/mpt/tool/main.go
+++ b/go/database/mpt/tool/main.go
@@ -12,19 +12,48 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli/v2"
+	"log"
+	"net/http"
 	"os"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+
+	"github.com/urfave/cli/v2"
 )
 
 // Run using
 //  go run ./database/mpt/tool <command> <flags>
 
+var (
+	diagnosticsFlag = cli.IntFlag{
+		Name:  "diagnostic-port",
+		Usage: "enable hosting of a realtime diagnostic server by providing a port",
+		Value: 0,
+	}
+	cpuProfileFlag = cli.StringFlag{
+		Name:  "cpuprofile",
+		Usage: "sets the target file for storing CPU profiles to, disabled if empty",
+		Value: "",
+	}
+	traceFlag = cli.StringFlag{
+		Name:  "tracefile",
+		Usage: "sets the target file for traces to, disabled if empty",
+		Value: "",
+	}
+)
+
 func main() {
 	app := &cli.App{
 		Name:      "tool",
 		Usage:     "Carmen MPT toolbox",
-		Copyright: "(c) 2022-23 Fantom Foundation",
-		Flags:     []cli.Flag{},
+		Copyright: "(c) 2022-24 Fantom Foundation",
+		Flags: []cli.Flag{
+			&diagnosticsFlag,
+			&cpuProfileFlag,
+			&traceFlag,
+		},
 		Commands: []*cli.Command{
 			&Check,
 			&ExportCmd,
@@ -45,4 +74,78 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func addPerformanceDiagnoses(action cli.ActionFunc) cli.ActionFunc {
+	return func(context *cli.Context) error {
+
+		// Start the diagnostic service if requested.
+		diagnosticPort := context.Int(diagnosticsFlag.Name)
+		startDiagnosticServer(diagnosticPort)
+
+		// Start CPU profiling.
+		cpuProfileFileName := context.String(cpuProfileFlag.Name)
+		if strings.TrimSpace(cpuProfileFileName) != "" {
+			if err := startCpuProfiler(cpuProfileFileName); err != nil {
+				return err
+			}
+			defer stopCpuProfiler()
+		}
+
+		// Start recording a trace.
+		traceFileName := context.String(traceFlag.Name)
+		if strings.TrimSpace(traceFileName) != "" {
+			if err := startTracer(traceFileName); err != nil {
+				return err
+			}
+			defer stopTracer()
+		}
+
+		return action(context)
+	}
+}
+
+func startDiagnosticServer(port int) {
+	if port <= 0 || port >= (1<<16) {
+		return
+	}
+	fmt.Printf("Starting diagnostic server at port http://localhost:%d\n", port)
+	fmt.Printf("(see https://pkg.go.dev/net/http/pprof#hdr-Usage_examples for usage examples)\n")
+	fmt.Printf("Block and mutex sampling rate is set to 100%% for diagnostics, which may impact overall performance\n")
+	go func() {
+		addr := fmt.Sprintf("localhost:%d", port)
+		log.Println(http.ListenAndServe(addr, nil))
+	}()
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(1)
+}
+
+func startCpuProfiler(filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("could not create CPU profile: %s", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		return fmt.Errorf("could not start CPU profile: %s", err)
+	}
+	return nil
+}
+
+func stopCpuProfiler() {
+	pprof.StopCPUProfile()
+}
+
+func startTracer(filename string) error {
+	traceFile, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create trace file: %v", err)
+	}
+	if err := trace.Start(traceFile); err != nil {
+		return fmt.Errorf("failed to start trace: %v", err)
+	}
+	return nil
+}
+
+func stopTracer() {
+	trace.Stop()
 }

--- a/go/database/mpt/tool/reset.go
+++ b/go/database/mpt/tool/reset.go
@@ -13,7 +13,6 @@ package main
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
@@ -21,12 +20,11 @@ import (
 )
 
 var Reset = cli.Command{
-	Action:    reset,
+	Action:    addPerformanceDiagnoses(reset),
 	Name:      "reset",
 	Usage:     "resets the given archive to a selected block",
 	ArgsUsage: "<director> <block>",
 	Flags: []cli.Flag{
-		&cpuProfileFlag,
 		&forceUnlockFlag,
 	},
 }
@@ -42,15 +40,6 @@ func reset(context *cli.Context) error {
 	// parse the directory argument
 	if context.Args().Len() != 2 {
 		return fmt.Errorf("missing directory and/or block height parameter")
-	}
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
 	}
 
 	dir := context.Args().Get(0)

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -31,7 +31,7 @@ import (
 // an MPT data base with the aim of stress-testing core components like the
 // node cache, the write buffer, and the background flush mechanism.
 var StressTestCmd = cli.Command{
-	Action: stressTest,
+	Action: addPerformanceDiagnoses(stressTest),
 	Name:   "stress-test",
 	Usage:  "stress test an MPT database",
 	Flags: []cli.Flag{

--- a/go/database/mpt/tool/verify.go
+++ b/go/database/mpt/tool/verify.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
@@ -21,28 +20,16 @@ import (
 )
 
 var Verify = cli.Command{
-	Action:    verify,
+	Action:    addPerformanceDiagnoses(verify),
 	Name:      "verify",
 	Usage:     "verifies the consistency of an MPT",
 	ArgsUsage: "<director>",
-	Flags: []cli.Flag{
-		&cpuProfileFlag,
-	},
 }
 
 func verify(context *cli.Context) error {
 	// parse the directory argument
 	if context.Args().Len() != 1 {
 		return fmt.Errorf("missing directory storing state")
-	}
-
-	// Start profiling ...
-	cpuProfileFileName := context.String(cpuProfileFlag.Name)
-	if strings.TrimSpace(cpuProfileFileName) != "" {
-		if err := startCpuProfiler(cpuProfileFileName); err != nil {
-			return err
-		}
-		defer stopCpuProfiler()
 	}
 
 	dir := context.Args().Get(0)


### PR DESCRIPTION
This PR adds general support for optional CPU coverage, tracing, and diagnoses services to all sub-commands of the MPT tool.