### PR TITLE
Pre-allocate slice for Archive roots

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -601,8 +601,13 @@ func loadRoots(archiveDirectory string) (*rootList, error) {
 		return nil, err
 	}
 	defer f.Close()
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
 	reader := bufio.NewReader(f)
-	roots, err := loadRootsFrom(reader)
+	roots, err := loadRootsFrom(reader, stat.Size())
 	if err != nil {
 		return nil, err
 	}
@@ -615,9 +620,9 @@ func loadRoots(archiveDirectory string) (*rootList, error) {
 	}, nil
 }
 
-func loadRootsFrom(reader io.Reader) ([]Root, error) {
-	res := []Root{}
+func loadRootsFrom(reader io.Reader, sizeInBytes int64) ([]Root, error) {
 	encoder := NodeIdEncoder{}
+	res := make([]Root, 0, sizeInBytes/int64(encoder.GetEncodedSize()))
 	buffer := make([]byte, encoder.GetEncodedSize())
 	var hash common.Hash
 	for {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1577,7 +1577,7 @@ func TestArchiveTrie_CanLoadRootsFromJunkySource(t *testing.T) {
 
 	for _, size := range []int{1, 2, 4, 1024} {
 		reader := utils.NewChunkReader(b.Bytes(), size)
-		res, err := loadRootsFrom(reader)
+		res, err := loadRootsFrom(reader, int64(b.Len()))
 		if err != nil {
 			t.Fatalf("error loading roots: %v", err)
 		}


### PR DESCRIPTION
This PR adds a minor performance fix for opening Archives. Instead of gradually growing the root slice, it is allocated once while loading root node data from the disk.

This reduced loading time for the command
```
go run ./database/mpt/tool info /mnt/sonicdb/mainnet/carmen/archive
```
for an Archive with 88M blocks from 20 to 10 seconds.

The reduction can be seen in the CPU profile. Before:
![image](https://github.com/user-attachments/assets/da6eacb3-5165-41f3-aa1e-00da7d334753)

After:
![image](https://github.com/user-attachments/assets/47477259-6891-4233-9539-17d53f0108f6)


