### PR TITLE
Kjezek/improve export tools ux

### DIFF
--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -13,13 +13,12 @@ package io
 import (
 	"bytes"
 	"context"
-	"path"
-	"strings"
-	"testing"
-
 	"github.com/Fantom-foundation/Carmen/go/common"
 	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
+	"path"
+	"strings"
+	"testing"
 )
 
 func TestIO_Archive_ExportAndImport(t *testing.T) {
@@ -47,7 +46,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 
 	// Export the archive into a buffer.
 	buffer := new(bytes.Buffer)
-	if err := ExportArchive(context.Background(), sourceDir, buffer); err != nil {
+	if err := ExportArchive(context.Background(), NewLog(), sourceDir, buffer); err != nil {
 		t.Fatalf("failed to export Archive: %v", err)
 	}
 	genesis := buffer.Bytes()
@@ -113,7 +112,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 
 	// Export the archive into a buffer.
 	buffer := new(bytes.Buffer)
-	if err := ExportArchive(context.Background(), sourceDir, buffer); err != nil {
+	if err := ExportArchive(context.Background(), NewLog(), sourceDir, buffer); err != nil {
 		t.Fatalf("failed to export Archive: %v", err)
 	}
 	genesis := buffer.Bytes()

--- a/go/database/mpt/io/interrupt_test.go
+++ b/go/database/mpt/io/interrupt_test.go
@@ -25,14 +25,14 @@ import (
 func TestExport_CanBeInterrupted(t *testing.T) {
 	type testFuncs struct {
 		// export is the tested export func
-		export func(context.Context, string, io.Writer) error
+		export func(context.Context, *Log, string, io.Writer) error
 		// createDB is an init of the database
 		createDB func(t *testing.T, sourceDir string)
 		// check that the interrupted did not corrupt the db by re-opening it
 		check func(t *testing.T, sourceDir string)
 	}
 
-	exportBlockFromArchive := func(ctx context.Context, dir string, out io.Writer) error {
+	exportBlockFromArchive := func(ctx context.Context, _ *Log, dir string, out io.Writer) error {
 		return ExportBlockFromArchive(ctx, dir, out, 3)
 	}
 
@@ -62,7 +62,7 @@ func TestExport_CanBeInterrupted(t *testing.T) {
 
 			countWriter := &interruptSendingWriter{signalInterrupt: false}
 			// first find number of writes
-			if err := tf.export(context.Background(), sourceDir, countWriter); err != nil {
+			if err := tf.export(context.Background(), NewLog(), sourceDir, countWriter); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -73,7 +73,7 @@ func TestExport_CanBeInterrupted(t *testing.T) {
 
 			writer := &interruptSendingWriter{}
 			writer.signalInterrupt = true
-			err := tf.export(ctx, sourceDir, writer)
+			err := tf.export(ctx, NewLog(), sourceDir, writer)
 			if got, want := err, interrupt.ErrCanceled; !errors.Is(got, want) {
 				t.Errorf("unexpected error: got: %v, want: %v", got, want)
 			}

--- a/go/database/mpt/io/interrupt_test.go
+++ b/go/database/mpt/io/interrupt_test.go
@@ -33,7 +33,7 @@ func TestExport_CanBeInterrupted(t *testing.T) {
 	}
 
 	exportBlockFromArchive := func(ctx context.Context, _ *Log, dir string, out io.Writer) error {
-		return ExportBlockFromArchive(ctx, dir, out, 3)
+		return ExportBlockFromArchive(ctx, NewLog(), dir, out, 3)
 	}
 
 	tests := map[string]testFuncs{

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -118,7 +118,7 @@ func Export(ctx context.Context, logger *Log, directory string, out io.Writer) e
 
 // ExportBlockFromArchive exports LiveDB genesis for a single given block from an Archive.
 // Note: block must be <= of Archive block height.
-func ExportBlockFromArchive(ctx context.Context, directory string, out io.Writer, block uint64) error {
+func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, out io.Writer, block uint64) error {
 	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
@@ -134,7 +134,7 @@ func ExportBlockFromArchive(ctx context.Context, directory string, out io.Writer
 	}
 
 	defer archive.Close()
-	_, err = ExportLive(ctx, nil, exportableArchiveTrie{trie: archive, block: block}, out)
+	_, err = ExportLive(ctx, logger, exportableArchiveTrie{trie: archive, block: block}, out)
 	return err
 }
 
@@ -166,7 +166,7 @@ func ExportLive(ctx context.Context, logger *Log, db mptStateVisitor, out io.Wri
 	logger.Print("exporting codes")
 	codes, err := getReferencedCodes(ctx, logger, db)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to retrieve codes: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to retrieve codes: %w", err)
 	}
 	if err := writeCodes(codes, out); err != nil {
 		return common.Hash{}, err

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -209,7 +209,7 @@ func exportExampleStateWithModification(t *testing.T, modify func(s *mpt.MptStat
 
 	// Export database to buffer.
 	var buffer bytes.Buffer
-	if err := Export(context.Background(), sourceDir, &buffer); err != nil {
+	if err := Export(context.Background(), NewLog(), sourceDir, &buffer); err != nil {
 		t.Fatalf("failed to export DB: %v", err)
 	}
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -330,7 +330,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 	for i := 0; i < M; i++ {
 		// Export live database from archive.
 		buffer := new(bytes.Buffer)
-		if err := ExportBlockFromArchive(context.Background(), sourceDir, buffer, uint64(i)); err != nil {
+		if err := ExportBlockFromArchive(context.Background(), NewLog(), sourceDir, buffer, uint64(i)); err != nil {
 			t.Fatalf("failed to export Archive: %v", err)
 		}
 

--- a/go/database/mpt/io/log.go
+++ b/go/database/mpt/io/log.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package io
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+// Log is a logger customised for the MPT tool output.
+// In particular, it prints the time elapsed since the start of the program.
+type Log struct {
+	start  time.Time
+	logger *log.Logger
+}
+
+// NewLog creates a new logger.
+func NewLog() *Log {
+	return &Log{start: time.Now(), logger: log.Default()}
+}
+
+// Print logs a message that includes the time elapsed since the start of the program.
+func (l *Log) Print(msg string) {
+	now := time.Now()
+	t := uint64(now.Sub(l.start).Seconds())
+	l.logger.Printf("[t=%4d:%02d] - %s\n", t/60, t%60, msg)
+}
+
+// Printf logs a formatted message that includes the time elapsed since the start of the program.
+func (l *Log) Printf(format string, v ...any) {
+	l.Print(fmt.Sprintf(format, v...))
+}
+
+// ProgressLogger is a logger that tracks the progress of a task.
+// It logs the progress at regular intervals configured when creating this logger.
+type ProgressLogger struct {
+	log            *Log
+	start          time.Time
+	format         string
+	window         int
+	counter, steps int
+}
+
+// NewProgressTracker creates a new ProgressLogger.
+func (l *Log) NewProgressTracker(format string, window int) *ProgressLogger {
+	return &ProgressLogger{log: l, start: time.Now(), format: format, window: window}
+}
+
+// Step increments the progress counter by the given number of steps.
+// If the counter reaches the window size, the progress is logged.
+func (p *ProgressLogger) Step(increment int) {
+	p.counter += increment
+	p.steps += increment
+
+	if p.steps >= p.window {
+		now := time.Now()
+
+		p.log.Printf(p.format, p.counter, float64(p.steps)/now.Sub(p.start).Seconds())
+
+		p.steps = 0
+		p.start = now
+	}
+}

--- a/go/database/mpt/io/log_test.go
+++ b/go/database/mpt/io/log_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package io
+
+import (
+	"bytes"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestLog_Print(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := Log{logger: log.New(&buf, "", 0), start: time.Now()}
+	logger.Print("Test message")
+
+	if got, want := buf.String(), regexp.MustCompile(`\[t=.*?] - Test message`); !want.MatchString(got) {
+		t.Errorf("unexpected log content: got %q, want %q", got, want)
+	}
+}
+
+func TestLog_Printf(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := Log{logger: log.New(&buf, "", 0), start: time.Now()}
+	logger.Printf("Test message %d", 42)
+
+	if got, want := buf.String(), regexp.MustCompile(`\[t=.*?] - Test message 42`); !want.MatchString(got) {
+		t.Errorf("unexpected log content: got %q, want %q", got, want)
+	}
+}
+
+func TestProgressLogger_Step(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLog()
+	logger.logger = log.New(&buf, "", 0)
+
+	progressLogger := logger.NewProgressTracker("Progress: %d steps, %.2f steps/sec", 10)
+
+	progressLogger.Step(5)
+	progressLogger.Step(3)
+	progressLogger.Step(2)
+
+	if got, want := buf.String(), regexp.MustCompile(`\[t=.*?] - Progress: 10 steps, \d+\.\d+ steps/sec`); !want.MatchString(got) {
+		t.Errorf("unexpected log content: got %q, want %q", got, want)
+	}
+}

--- a/go/database/mpt/tool/export.go
+++ b/go/database/mpt/tool/export.go
@@ -15,15 +15,12 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	"log"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/Fantom-foundation/Carmen/go/common/interrupt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
+	"os"
+	"strings"
 )
 
 var ExportCmd = cli.Command{
@@ -59,8 +56,8 @@ func doExport(context *cli.Context) error {
 		return err
 	}
 
-	start := time.Now()
-	logFromStart(start, "export started")
+	logger := io.NewLog()
+	logger.Print("export started")
 
 	file, err := os.Create(trg)
 	if err != nil {
@@ -79,12 +76,12 @@ func doExport(context *cli.Context) error {
 			blkNumber := context.Uint64(targetBlockFlag.Name)
 			exportErr = io.ExportBlockFromArchive(ctx, dir, out, blkNumber)
 		} else {
-			// Passed Archive without chosen block
-			exportErr = io.ExportArchive(ctx, dir, out)
+			// Passed Archive without a chosen block
+			exportErr = io.ExportArchive(ctx, logger, dir, out)
 		}
 	} else {
 		// Passed LiveDB
-		exportErr = io.Export(ctx, dir, out)
+		exportErr = io.Export(ctx, logger, dir, out)
 	}
 
 	if err = errors.Join(
@@ -95,12 +92,6 @@ func doExport(context *cli.Context) error {
 	); err != nil {
 		return err
 	}
-	logFromStart(start, "export done")
+	logger.Print("export done")
 	return nil
-}
-
-func logFromStart(start time.Time, msg string) {
-	now := time.Now()
-	t := uint64(now.Sub(start).Seconds())
-	log.Printf("[t=%4d:%02d] - %s.\n", t/60, t%60, msg)
 }

--- a/go/database/mpt/tool/export.go
+++ b/go/database/mpt/tool/export.go
@@ -74,7 +74,7 @@ func doExport(context *cli.Context) error {
 		if context.IsSet(targetBlockFlag.Name) {
 			// Passed Archive and chosen block to export
 			blkNumber := context.Uint64(targetBlockFlag.Name)
-			exportErr = io.ExportBlockFromArchive(ctx, dir, out, blkNumber)
+			exportErr = io.ExportBlockFromArchive(ctx, logger, dir, out, blkNumber)
 		} else {
 			// Passed Archive without a chosen block
 			exportErr = io.ExportArchive(ctx, logger, dir, out)

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -15,13 +15,11 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	mptIo "github.com/Fantom-foundation/Carmen/go/database/mpt/io"
+	"github.com/urfave/cli/v2"
 	"io"
 	"os"
 	"strings"
-	"time"
-
-	mptIo "github.com/Fantom-foundation/Carmen/go/database/mpt/io"
-	"github.com/urfave/cli/v2"
 )
 
 var ImportLiveDbCmd = cli.Command{
@@ -86,8 +84,8 @@ func doImport(context *cli.Context, runImport func(directory string, in io.Reade
 		return fmt.Errorf("error creating output directory: %v", err)
 	}
 
-	start := time.Now()
-	logFromStart(start, "import started")
+	logger := mptIo.NewLog()
+	logger.Print("import started")
 	file, err := os.Open(src)
 	if err != nil {
 		return err
@@ -97,7 +95,7 @@ func doImport(context *cli.Context, runImport func(directory string, in io.Reade
 		return err
 	}
 	defer func() {
-		logFromStart(start, "import done")
+		logger.Printf("import done")
 	}()
 	return errors.Join(
 		runImport(dir, in),

--- a/go/database/mpt/tool/main.go
+++ b/go/database/mpt/tool/main.go
@@ -12,9 +12,8 @@ package main
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/urfave/cli/v2"
+	"os"
 )
 
 // Run using

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -156,7 +156,7 @@ func (s *ArchiveState) Export(ctx context.Context, out io.Writer) (common.Hash, 
 	}
 
 	exportableTrie := mptio.NewExportableArchiveTrie(trie, s.block)
-	rootHash, err := mptio.ExportLive(ctx, nil, exportableTrie, out)
+	rootHash, err := mptio.ExportLive(ctx, mptio.NewLog(), exportableTrie, out)
 	if err != nil {
 		s.archiveError = errors.Join(s.archiveError, err)
 		return common.Hash{}, s.archiveError

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -156,7 +156,7 @@ func (s *ArchiveState) Export(ctx context.Context, out io.Writer) (common.Hash, 
 	}
 
 	exportableTrie := mptio.NewExportableArchiveTrie(trie, s.block)
-	rootHash, err := mptio.ExportLive(ctx, exportableTrie, out)
+	rootHash, err := mptio.ExportLive(ctx, nil, exportableTrie, out)
 	if err != nil {
 		s.archiveError = errors.Join(s.archiveError, err)
 		return common.Hash{}, s.archiveError


### PR DESCRIPTION
This PR improves user experience with MPT export tools. It 

1. adds progress tracking into the output
2. enables ctrl+c at some places, where it was missing - in particular export of codes of liveDB

Furthermore, this PR introduces a simple logging utility that unifies output for export tools.  