### PR TITLE
extends log output for import tools

### DIFF
--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -2228,7 +2228,7 @@ func TestDatabase_Export(t *testing.T) {
 	if err := os.MkdirAll(liveDbLocation, 0755); err != nil {
 		t.Fatalf("cannot create live db location: %v", err)
 	}
-	if err = io.ImportLiveDb(liveDbLocation, b); err != nil {
+	if err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b); err != nil {
 		t.Fatalf("cannot import live db: %v", err)
 	}
 

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -574,7 +574,7 @@ func ExampleHistoricBlockContext_Export() {
 	}
 	liveDbLocation := filepath.Join(importedDbPath, "live")
 
-	err = io.ImportLiveDb(liveDbLocation, b)
+	err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b)
 	if err != nil {
 		log.Fatalf("cannot import live db")
 	}

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -54,7 +54,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 	// Import the archive into a new directory.
 	targetDir := t.TempDir()
 	buffer = bytes.NewBuffer(genesis)
-	if err := ImportArchive(targetDir, buffer); err != nil {
+	if err := ImportArchive(NewLog(), targetDir, buffer); err != nil {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
@@ -120,7 +120,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 	// Import the archive into a new directory.
 	targetDir := t.TempDir()
 	buffer = bytes.NewBuffer(genesis)
-	if err := ImportLiveAndArchive(targetDir, buffer); err != nil {
+	if err := ImportLiveAndArchive(NewLog(), targetDir, buffer); err != nil {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
@@ -178,7 +178,7 @@ func TestIO_LiveAndArchive_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot write magic number: %v", err)
 	}
-	err = importArchive(t.TempDir(), t.TempDir(), b)
+	err = importArchive(nil, t.TempDir(), t.TempDir(), b)
 	if err == nil {
 		t.Fatal("import must fail")
 	}

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -28,7 +28,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 
 	buffer := bytes.NewBuffer(genesis)
 	targetDir := t.TempDir()
-	if err := ImportLiveDb(targetDir, buffer); err != nil {
+	if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 	buffer := bytes.NewBuffer(genesis)
 	targetDir := t.TempDir()
 	genesisBlock := uint64(12)
-	if err := InitializeArchive(targetDir, buffer, genesisBlock); err != nil {
+	if err := InitializeArchive(NewLog(), targetDir, buffer, genesisBlock); err != nil {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestImport_ImportIntoNonEmptyTargetDirectoryFails(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := ImportLiveDb(dir, nil); err == nil || !strings.Contains(err.Error(), "is not empty") {
+	if err := ImportLiveDb(NewLog(), dir, nil); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -233,7 +233,7 @@ func TestInitializeArchive_ImportIntoNonEmptyTargetDirectoryFails(t *testing.T) 
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := InitializeArchive(dir, nil, 0); err == nil || !strings.Contains(err.Error(), "is not empty") {
+	if err := InitializeArchive(NewLog(), dir, nil, 0); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -336,7 +336,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 
 		// Import live database.
 		targetDir := t.TempDir()
-		if err := ImportLiveDb(targetDir, buffer); err != nil {
+		if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
 			t.Fatalf("failed to import DB: %v", err)
 		}
 
@@ -373,7 +373,7 @@ func TestIO_Live_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot write magic number: %v", err)
 	}
-	_, _, err = runImport(t.TempDir(), b, mpt.MptConfig{})
+	_, _, err = runImport(NewLog(), t.TempDir(), b, mpt.MptConfig{})
 	if err == nil {
 		t.Fatal("import must fail")
 	}

--- a/go/database/mpt/io/log.go
+++ b/go/database/mpt/io/log.go
@@ -64,9 +64,15 @@ func (p *ProgressLogger) Step(increment int) {
 	if p.steps >= p.window {
 		now := time.Now()
 
-		p.log.Printf(p.format, p.counter, float64(p.steps)/now.Sub(p.start).Seconds())
+		count := p.counter / p.window * p.window // round down to the nearest window size
+		p.log.Printf(p.format, count, float64(p.steps)/now.Sub(p.start).Seconds())
 
 		p.steps = 0
 		p.start = now
 	}
+}
+
+// GetCounter returns the current value of the progress counter.
+func (p *ProgressLogger) GetCounter() int {
+	return p.counter
 }

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -55,7 +55,7 @@ func doLiveAndArchiveImport(context *cli.Context) error {
 	return doImport(context, mptIo.ImportLiveAndArchive)
 }
 
-func doImport(context *cli.Context, runImport func(directory string, in io.Reader) error) error {
+func doImport(context *cli.Context, runImport func(logger *mptIo.Log, directory string, in io.Reader) error) error {
 	if context.Args().Len() != 2 {
 		return fmt.Errorf("missing source file and/or target directory parameter")
 	}
@@ -80,7 +80,7 @@ func doImport(context *cli.Context, runImport func(directory string, in io.Reade
 		logger.Printf("import done")
 	}()
 	return errors.Join(
-		runImport(dir, in),
+		runImport(logger, dir, in),
 		file.Close(),
 	)
 }

--- a/go/database/mpt/tool/init_archive.go
+++ b/go/database/mpt/tool/init_archive.go
@@ -52,6 +52,7 @@ func doArchiveInit(context *cli.Context) error {
 
 	height := context.Uint64(blockHeightFlag.Name)
 
+	logger := mptIo.NewLog()
 	file, err := os.Open(src)
 	if err != nil {
 		return err
@@ -61,7 +62,7 @@ func doArchiveInit(context *cli.Context) error {
 		return err
 	}
 	return errors.Join(
-		mptIo.InitializeArchive(dir, in, height),
+		mptIo.InitializeArchive(logger, dir, in, height),
 		file.Close(),
 	)
 }


### PR DESCRIPTION
this PR extends log output of database import tools. It now prints either the number of processed Accounts for liveDB or the number of processed blocks for Archive  