### PR TITLE
Introduce method to export a LiveDB dump from a running Archive

### DIFF
--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -54,15 +54,6 @@ const (
 	EthereumHash = HashType(0)
 )
 
-// NewExportableArchiveTrie allows visiting mpt.ArchiveTrie at given block
-// and getting its properties such as Code Hashes or Root Hash.
-func NewExportableArchiveTrie(trie *mpt.ArchiveTrie, block uint64) mptStateVisitor {
-	return exportableArchiveTrie{
-		trie:  trie,
-		block: block,
-	}
-}
-
 // mptStateVisitor is an interface for Tries that allows for visiting the Trie nodes
 // and furthermore getting its properties such as a root hash and contract codes.
 type mptStateVisitor interface {
@@ -135,6 +126,30 @@ func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, 
 
 	defer archive.Close()
 	_, err = ExportLive(ctx, logger, exportableArchiveTrie{trie: archive, block: block}, out)
+	return err
+}
+
+// ExportBlockFromOnlineArchive exports a LiveDB dump for a single given block from an Archive.
+// This method exports from an online archive, i.e, an archive that is being updated with new blocks.
+// To ensure the exported data is up-to-date, this method flushes the archive to disk before exporting.
+// Expected usage is, for instance, the creation of database dumps once in many blocks to backup the state.
+func ExportBlockFromOnlineArchive(ctx context.Context, logger *Log, archive *mpt.ArchiveTrie, out io.Writer, block uint64) error {
+	logger.Printf("exporting block %d from online archive", block)
+	defer func() {
+		logger.Printf("exported block %d from online archive", block)
+	}()
+
+	logger.Printf("flushing archive")
+	// before doing anything, flush the archive to ensure the data is up-to-date
+	if err := archive.Flush(); err != nil {
+		return err
+	}
+
+	logger.Printf("exporting")
+	_, err := ExportLive(ctx, logger, exportableArchiveTrie{
+		trie:  archive,
+		block: block,
+	}, out)
 	return err
 }
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -291,17 +291,17 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 		t.Fatalf("failed to create archive: %v", err)
 	}
 	const (
-		M = 10
-		N = 3
+		Blocks   = 10
+		Accounts = 3
 	)
 
 	var expectedHashes []common.Hash
 
-	for i := 0; i < M; i++ {
+	for i := 0; i < Blocks; i++ {
 		code := []byte{1, 2, 3, byte(i)}
 		u := uint64(i)
 		update := common.Update{}
-		for j := 0; j < N; j++ {
+		for j := 0; j < Accounts; j++ {
 			newAddr := common.AddressFromNumber(j)
 
 			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
@@ -327,7 +327,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 		t.Fatalf("failed to close archive archive: %v", err)
 	}
 
-	for i := 0; i < M; i++ {
+	for i := 0; i < Blocks; i++ {
 		// Export live database from archive.
 		buffer := new(bytes.Buffer)
 		if err := ExportBlockFromArchive(context.Background(), NewLog(), sourceDir, buffer, uint64(i)); err != nil {
@@ -364,6 +364,81 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 		}
 	}
 
+}
+
+func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
+	archive, err := mpt.OpenArchiveTrie(t.TempDir(), mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
+	if err != nil {
+		t.Fatalf("failed to create archive: %v", err)
+	}
+	defer func() {
+		if err := archive.Close(); err != nil {
+			t.Fatalf("failed to close archive archive: %v", err)
+		}
+	}()
+
+	const (
+		Blocks   = 10
+		Accounts = 3
+	)
+
+	for i := 0; i < Blocks; i++ {
+		code := []byte{1, 2, 3, byte(i)}
+		u := uint64(i)
+		update := common.Update{}
+		for j := 0; j < Accounts; j++ {
+			newAddr := common.AddressFromNumber(j)
+
+			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
+			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})
+			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: newAddr, Nonce: common.ToNonce(u + 1)})
+			update.Codes = append(update.Codes, common.CodeUpdate{Account: newAddr, Code: code})
+			update.Slots = append(update.Slots, common.SlotUpdate{Account: newAddr, Key: common.Key{byte(j)}, Value: common.Value{byte(i)}})
+		}
+		err = archive.Add(u, update, nil)
+		if err != nil {
+			t.Fatalf("failed to create block in archive: %v", err)
+		}
+		hashArchive, err := archive.GetHash(u)
+		if err != nil {
+			t.Fatalf("cannot get hash: %v", err)
+		}
+
+		// while the archive has not been explicitly flushed or closed, the data should be available when exporting
+		buffer := new(bytes.Buffer)
+		if err := ExportBlockFromOnlineArchive(context.Background(), NewLog(), archive, buffer, uint64(i)); err != nil {
+			t.Fatalf("failed to export Archive: %v", err)
+		}
+
+		// Import live database.
+		targetDir := t.TempDir()
+		if err := ImportLiveDb(nil, targetDir, buffer); err != nil {
+			t.Fatalf("failed to import DB: %v", err)
+		}
+
+		if err := mpt.VerifyFileLiveTrie(targetDir, mpt.S5LiveConfig, nil); err != nil {
+			t.Fatalf("verification of imported DB failed: %v", err)
+		}
+
+		db, err := mpt.OpenGoFileState(targetDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+		if err != nil {
+			t.Fatalf("failed to open recovered DB: %v", err)
+		}
+
+		hashLive, err := db.GetHash()
+		if err != nil {
+			t.Fatalf("cannot get hash: %v", err)
+		}
+
+		if got, want := hashLive, hashArchive; got != want {
+			t.Errorf("restored DB failed to reproduce same hash\nwanted %x\n got %x", want, got)
+		}
+
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("cannot close database: %v", err)
+		}
+	}
 }
 
 func TestIO_Live_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {

--- a/go/database/mpt/io/log.go
+++ b/go/database/mpt/io/log.go
@@ -30,6 +30,9 @@ func NewLog() *Log {
 
 // Print logs a message that includes the time elapsed since the start of the program.
 func (l *Log) Print(msg string) {
+	if l == nil {
+		return
+	}
 	now := time.Now()
 	t := uint64(now.Sub(l.start).Seconds())
 	l.logger.Printf("[t=%4d:%02d] - %s\n", t/60, t%60, msg)

--- a/go/database/mpt/io/log_test.go
+++ b/go/database/mpt/io/log_test.go
@@ -55,3 +55,15 @@ func TestProgressLogger_Step(t *testing.T) {
 		t.Errorf("unexpected log content: got %q, want %q", got, want)
 	}
 }
+
+func TestLog_CanBeNil(t *testing.T) {
+	var logger *Log
+
+	logger.Print("Test message")
+	logger.Printf("%d", 1)
+	progress := logger.NewProgressTracker("Progress: %d steps, %.2f steps/sec", 10)
+	for i := 0; i < 100; i++ {
+		progress.Step(1)
+	}
+
+}

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -155,8 +155,17 @@ func (s *ArchiveState) Export(ctx context.Context, out io.Writer) (common.Hash, 
 		return common.Hash{}, state.ExportNotSupported
 	}
 
-	exportableTrie := mptio.NewExportableArchiveTrie(trie, s.block)
-	rootHash, err := mptio.ExportLive(ctx, mptio.NewLog(), exportableTrie, out)
+	err := mptio.ExportBlockFromOnlineArchive(ctx, nil, trie, out, s.block)
+	// trie could get corrupted during export, practically just by flushing it
+	s.archiveError = errors.Join(s.archiveError, trie.CheckErrors())
+	if err != nil || s.archiveError != nil {
+		// export opens the trie parallel to the current program,
+		// possible error is sent to the caller but should not corrupt
+		// the database on error.
+		return common.Hash{}, errors.Join(err, s.archiveError)
+	}
+
+	rootHash, err := trie.GetHash(s.block)
 	if err != nil {
 		s.archiveError = errors.Join(s.archiveError, err)
 		return common.Hash{}, s.archiveError


### PR DESCRIPTION
this PR introduces a method to export a livedb view from an archive, that is being currently online, accepting new blocks. This method accesses the archive independently on the main program by do not checking if the directory is locked, and allowing for accessing directly the directory. 