### PR TITLE
extends tracking of error states

### DIFF
--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -554,7 +554,7 @@ func (s *Forest) Flush() error {
 
 	errs = append(errs, s.flushDirtyIds(ids))
 
-	return errors.Join(
+	err := errors.Join(
 		errors.Join(errs...),
 		s.writeBuffer.Flush(),
 		s.accounts.Flush(),
@@ -562,6 +562,12 @@ func (s *Forest) Flush() error {
 		s.extensions.Flush(),
 		s.values.Flush(),
 	)
+
+	if err != nil {
+		s.errors = append(s.errors, err)
+	}
+
+	return err
 }
 
 func (s *Forest) flushDirtyIds(ids []NodeId) error {


### PR DESCRIPTION
this PR extends tracking of erroneous state of archive and forest. It seems it was forgotten to add this check at some newer code. 