### PR TITLE
Introduce VisitAccount, GetAccountInfo, CreateWitnessProof methods for tries

### DIFF
--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -1906,12 +1906,17 @@ func (n *AccountNode) Visit(source NodeSource, thisRef *NodeReference, depth int
 	case VisitResponsePrune:
 		return false, nil
 	}
+	return n.visitStorage(source, depth+1, visitor)
+}
+
+// visitStorage is a helper function to visit the storage trie of an account.
+func (n *AccountNode) visitStorage(source NodeSource, depth int, visitor NodeVisitor) (bool, error) {
 	if n.storage.Id().IsEmpty() {
 		return false, nil
 	}
 	if node, err := source.getViewAccess(&n.storage); err == nil {
 		defer node.Release()
-		return node.Get().Visit(source, &n.storage, depth+1, visitor)
+		return node.Get().Visit(source, &n.storage, depth, visitor)
 	} else {
 		return false, err
 	}

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -3568,6 +3568,29 @@ func TestAccountNode_VisitPrune(t *testing.T) {
 	}
 }
 
+func TestAccountNode_visitStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctxt := newNodeContext(t, ctrl)
+
+	storage := NewMockNode(ctrl)
+	storage.EXPECT().Visit(gomock.Any(), gomock.Any(), 2, gomock.Any()).Return(false, nil)
+
+	_, node := ctxt.Build(&Account{
+		info:    AccountInfo{Nonce: common.Nonce{1}},
+		storage: &Mock{storage},
+	})
+
+	handle := node.GetWriteHandle()
+	defer handle.Release()
+
+	visitor := NewMockNodeVisitor(ctrl)
+
+	accountNode := handle.Get().(*AccountNode)
+	if abort, err := accountNode.visitStorage(ctxt, 2, visitor); abort || err != nil {
+		t.Errorf("unexpected result of visit, wanted (false,nil), got(%v,%v)", abort, err)
+	}
+}
+
 func TestAccountNode_VisitAbort(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctxt := newNodeContext(t, ctrl)

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -42,6 +42,7 @@ import (
 type Database interface {
 	common.FlushAndCloser
 	common.MemoryFootprintProvider
+	NodeSource
 
 	// GetAccountInfo retrieves account information for input root and account address.
 	GetAccountInfo(rootRef *NodeReference, addr common.Address) (AccountInfo, bool, error)

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -15,7 +15,6 @@
 //
 //	mockgen -source state.go -destination state_mocks.go -package mpt
 //
-
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -25,6 +24,7 @@ import (
 	backend "github.com/Fantom-foundation/Carmen/go/backend"
 	common "github.com/Fantom-foundation/Carmen/go/common"
 	amount "github.com/Fantom-foundation/Carmen/go/common/amount"
+	shared "github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -264,6 +264,93 @@ func (m *MockDatabase) VisitTrie(rootRef *NodeReference, visitor NodeVisitor) er
 func (mr *MockDatabaseMockRecorder) VisitTrie(rootRef, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockDatabase)(nil).VisitTrie), rootRef, visitor)
+}
+
+// getConfig mocks base method.
+func (m *MockDatabase) getConfig() MptConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getConfig")
+	ret0, _ := ret[0].(MptConfig)
+	return ret0
+}
+
+// getConfig indicates an expected call of getConfig.
+func (mr *MockDatabaseMockRecorder) getConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getConfig", reflect.TypeOf((*MockDatabase)(nil).getConfig))
+}
+
+// getHashFor mocks base method.
+func (m *MockDatabase) getHashFor(arg0 *NodeReference) (common.Hash, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getHashFor", arg0)
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getHashFor indicates an expected call of getHashFor.
+func (mr *MockDatabaseMockRecorder) getHashFor(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getHashFor", reflect.TypeOf((*MockDatabase)(nil).getHashFor), arg0)
+}
+
+// getReadAccess mocks base method.
+func (m *MockDatabase) getReadAccess(arg0 *NodeReference) (shared.ReadHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getReadAccess", arg0)
+	ret0, _ := ret[0].(shared.ReadHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getReadAccess indicates an expected call of getReadAccess.
+func (mr *MockDatabaseMockRecorder) getReadAccess(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getReadAccess", reflect.TypeOf((*MockDatabase)(nil).getReadAccess), arg0)
+}
+
+// getViewAccess mocks base method.
+func (m *MockDatabase) getViewAccess(arg0 *NodeReference) (shared.ViewHandle[Node], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getViewAccess", arg0)
+	ret0, _ := ret[0].(shared.ViewHandle[Node])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getViewAccess indicates an expected call of getViewAccess.
+func (mr *MockDatabaseMockRecorder) getViewAccess(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getViewAccess", reflect.TypeOf((*MockDatabase)(nil).getViewAccess), arg0)
+}
+
+// hashAddress mocks base method.
+func (m *MockDatabase) hashAddress(address common.Address) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashAddress", address)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashAddress indicates an expected call of hashAddress.
+func (mr *MockDatabaseMockRecorder) hashAddress(address any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashAddress", reflect.TypeOf((*MockDatabase)(nil).hashAddress), address)
+}
+
+// hashKey mocks base method.
+func (m *MockDatabase) hashKey(arg0 common.Key) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hashKey", arg0)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// hashKey indicates an expected call of hashKey.
+func (mr *MockDatabaseMockRecorder) hashKey(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hashKey", reflect.TypeOf((*MockDatabase)(nil).hashKey), arg0)
 }
 
 // setHashesFor mocks base method.


### PR DESCRIPTION
This PR introduces `VisitAccount`, `GetAccountInfo` and `CreateWitnessProof` method for tries. This method will be later needed for #947 to get nodes exclusively for accounts. 