### PR TITLE
fixes flaky test of node flusher

### DIFF
--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -81,6 +81,15 @@ func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
 	if err := flusher.Stop(); err != nil {
 		t.Fatalf("failed to stop node flusher: %v", err)
 	}
+
+	// drain potential remaining signals
+	for {
+		select {
+		case <-flushSignal:
+		default:
+			return
+		}
+	}
 }
 
 func TestNodeFlusher_ErrorsAreCollected(t *testing.T) {

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -71,19 +71,19 @@ func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
 		select {
 		case <-flushSignal:
 			// ok, signal received
-		case <-time.After(period * 2 * loops):
+		case <-time.After(period * loops * 100):
 			t.Fatalf("flush signal not received")
 		}
 	}
 	total := time.Since(start)
 
 	expected := period * time.Duration(loops)
-	tolerance := period * time.Duration(loops) / 5
+	lower := period * time.Duration(loops) / 5
 	// Since the ticker in the flusher may adjust ticks for slow consumers,
 	// measure the expected frequency for the whole execution of the test.
 	// Also check the total time fits into a range, not an exact value.
-	if total < expected-tolerance || total > expected+tolerance {
-		t.Errorf("unexpected frequency of flushes")
+	if got, want := total, expected-lower; got < want {
+		t.Errorf("total time below expected: got %v < want %v", got, want)
 	}
 
 	if err := flusher.Stop(); err != nil {

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -72,18 +72,21 @@ func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
 		case <-flushSignal:
 			// ok, signal received
 		case <-time.After(period * 2 * loops):
-			t.Fatalf("flush signal not received")
+			t.Fatalf("flush signal not received in %dms", period*2*loops)
 		}
 	}
 	total := time.Since(start)
 
 	expected := period * time.Duration(loops)
-	tolerance := period * time.Duration(loops) / 5
+	lower := period * time.Duration(loops) / 5
 	// Since the ticker in the flusher may adjust ticks for slow consumers,
 	// measure the expected frequency for the whole execution of the test.
 	// Also check the total time fits into a range, not an exact value.
-	if total < expected-tolerance || total > expected+tolerance {
-		t.Errorf("unexpected frequency of flushes")
+	if got, want := total, expected-lower; got < want {
+		t.Errorf("total time below expected: got %v < want %v", got, want)
+	}
+	if got, want := total, expected*2; got > want {
+		t.Errorf("total time above expected: got %v > want %v", got, want)
 	}
 
 	if err := flusher.Stop(); err != nil {

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -71,19 +71,19 @@ func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
 		select {
 		case <-flushSignal:
 			// ok, signal received
-		case <-time.After(period * loops * 100):
+		case <-time.After(period * 2 * loops):
 			t.Fatalf("flush signal not received")
 		}
 	}
 	total := time.Since(start)
 
 	expected := period * time.Duration(loops)
-	lower := period * time.Duration(loops) / 5
+	tolerance := period * time.Duration(loops) / 5
 	// Since the ticker in the flusher may adjust ticks for slow consumers,
 	// measure the expected frequency for the whole execution of the test.
 	// Also check the total time fits into a range, not an exact value.
-	if got, want := total, expected-lower; got < want {
-		t.Errorf("total time below expected: got %v < want %v", got, want)
+	if total < expected-tolerance || total > expected+tolerance {
+		t.Errorf("unexpected frequency of flushes")
 	}
 
 	if err := flusher.Stop(); err != nil {

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -48,7 +48,7 @@ func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cache := NewMockNodeCache(ctrl)
 
-	const loops = 3
+	const loops = 10
 	flushSignal := make(chan struct{}, loops)
 
 	// The cache is checked at least 'loops+1' times as the flush status is checked 'loops' times


### PR DESCRIPTION
This PR should fix #981 

The key insight is that the flush buffer uses a ticker to trigger flush periodically, and the time delay between each tick was measured. However, when the consumer is slow to consume signal, the ticker may adjust its timing. The documentation says: 
```
The ticker will adjust the time interval or drop ticks to make up for slow receivers 
```
It seems the test cannot rely on a delay between each flusher loop. Even if the delay is not matched precisely, it is still  not reliable as the real delay may be very different from the configured delay, it can span two intervals or ticks can follow quickly one another. 

It was fixed that only the total time is measured and it is checked that it roughly matches expected total time.   

Furthermore, it was expected that the events are triggered exact number of times (3 times). This constraint was relieved to a min number, because before the test ends, and the tested flusher it stoped, it can still produce a few events. 

Finally, it was assured that the flusher has started before running the experiment, and that the flusher channel is drained not to block stoping the flusher. It was added as a precaution as so far it has not been detected as a problematic spot. 