### PR TITLE
Add diagnoses to MPT tests and start fixing memory leaks

### DIFF
--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -2262,6 +2262,13 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot open archive: %v", err)
 			}
+			defer archive.Close()
+			headBackup := archive.head
+			forestBackup := archive.forest
+			defer func() {
+				archive.head = headBackup
+				archive.forest = forestBackup
+			}()
 			archive.head = liveState
 			archive.forest = db
 			archive.roots.roots = append(archive.roots.roots, Root{NodeRef: NewNodeReference(ValueId(1))})

--- a/go/database/mpt/diagnostics_test.go
+++ b/go/database/mpt/diagnostics_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package mpt
 
 import (

--- a/go/database/mpt/diagnostics_test.go
+++ b/go/database/mpt/diagnostics_test.go
@@ -1,0 +1,22 @@
+package mpt
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"runtime"
+)
+
+func init() {
+	port := 6060
+	fmt.Printf("Starting diagnostic server at port http://localhost:%d\n", port)
+	fmt.Printf("(see https://pkg.go.dev/net/http/pprof#hdr-Usage_examples for usage examples)\n")
+	fmt.Printf("Block and mutex sampling rate is set to 100%% for diagnostics, which may impact overall performance\n")
+	go func() {
+		addr := fmt.Sprintf("localhost:%d", port)
+		log.Println(http.ListenAndServe(addr, nil))
+	}()
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(1)
+}

--- a/go/database/mpt/diagnostics_test.go
+++ b/go/database/mpt/diagnostics_test.go
@@ -5,11 +5,31 @@ import (
 	"log"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"runtime"
+	"strconv"
 )
 
 func init() {
-	port := 6060
+	// This init function starts a diagnostic server running in parallel to the unit tests
+	// of this package. The main intention of the server is to facilitate the diagnoses of
+	// performance issues and memory leaks tests. The server is started only if the
+	// environment variable MPT_DIAGNOSTIC_PORT is set to a valid port number.
+	//
+	// Example:
+	// $ MPT_DIAGNOSTIC_PORT=6060 go test -v ./database/mpt
+	//
+	portSpec := os.Getenv("MPT_DIAGNOSTIC_PORT")
+	if portSpec == "" {
+		return
+	}
+
+	port, err := strconv.Atoi(portSpec)
+	if err != nil {
+		fmt.Printf("invalid diagnostic port: %s\n", portSpec)
+		os.Exit(1)
+	}
+
 	fmt.Printf("Starting diagnostic server at port http://localhost:%d\n", port)
 	fmt.Printf("(see https://pkg.go.dev/net/http/pprof#hdr-Usage_examples for usage examples)\n")
 	fmt.Printf("Block and mutex sampling rate is set to 100%% for diagnostics, which may impact overall performance\n")

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -256,7 +256,6 @@ func TestForest_CreatingAccountInfo_Fails(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call New")
@@ -296,7 +295,6 @@ func TestForest_setHashesFor_Getting_Node_Fails(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call Get")
@@ -326,7 +324,6 @@ func TestForest_Freeze_Fails(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to open forest: %v", err)
 				}
-				defer forest.Close()
 
 				// inject failing stock to trigger an error applying the update
 				var injectedErr = errors.New("failed to call Get")
@@ -444,7 +441,6 @@ func TestForest_Release_Queue_Error_Get_Node(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call Get")
@@ -513,7 +509,6 @@ func TestForest_getAccess_Fails(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call Get")
@@ -616,7 +611,6 @@ func TestForest_Flush_Fail_MissingCachedNode(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					ctrl := gomock.NewController(t)
@@ -645,7 +639,6 @@ func TestForest_Flush_Fail_CannotReadNode(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call Set")
@@ -758,7 +751,6 @@ func TestForest_getMutableNodeByPath_CannotReadNode(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to open forest: %v", err)
 					}
-					defer forest.Close()
 
 					// inject failing stock to trigger an error applying the update
 					var injectedErr = errors.New("failed to call Get")

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -863,6 +863,10 @@ func TestForest_Dump(t *testing.T) {
 					ctrl := gomock.NewController(t)
 					accounts := stock.NewMockStock[uint64, AccountNode](ctrl)
 					accounts.EXPECT().Get(gomock.Any()).AnyTimes().Return(AccountNode{}, errors.New("failed to call Get"))
+					accountsBackup := forest.accounts
+					defer func() {
+						forest.accounts = accountsBackup
+					}()
 					forest.accounts = accounts
 
 					root2 := NewNodeReference(AccountId(2))

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -14,12 +14,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Fantom-foundation/Carmen/go/database/mpt/shared"
 
 	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	"go.uber.org/mock/gomock"

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -44,7 +44,7 @@ func TestNodeFlusher_StartAndStopWithDisabledFlusher(t *testing.T) {
 }
 
 func TestNodeFlusher_TriggersFlushesPeriodically(t *testing.T) {
-	const period = time.Millisecond * 100
+	const period = 1 * time.Second
 	ctrl := gomock.NewController(t)
 	cache := NewMockNodeCache(ctrl)
 

--- a/go/database/mpt/root_hash_test.go
+++ b/go/database/mpt/root_hash_test.go
@@ -397,8 +397,6 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 			t.Errorf("invalid hash, wanted %v, got %v", want, got)
 		}
 
-		state.trie.Dump()
-
 		if err := state.Close(); err != nil {
 			t.Fatalf("failed to close state: %v", err)
 		}


### PR DESCRIPTION
This PR adds optional diagnostics support to the MPT unit test. The main motivation is to identify memory leaks in the tests.

To enable diagnostic, export the `MPT_DIAGNOSTIC_PORT` environment variable before running tests, similar to this:
```
MPT_DIAGNOSTIC_PORT=6060 go test -v ./database/mpt
```
 While the tests are running, the following command can be used to obtain a heap profile from the tests:
```
go tool pprof -http "localhost:8000" http://localhost:6060/debug/pprof/heap
```

In this profile, tests failing to free all their memory allocations (in particular failing to close all their MPT instances) can be identified.