### PR TITLE
uses async MPT reading to speed up live db export

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -598,6 +598,11 @@ func (a *ArchiveTrie) Directory() string {
 	return a.directory
 }
 
+// GetConfig returns the configuration of the archive.
+func (a *ArchiveTrie) GetConfig() MptConfig {
+	return a.nodeSource.getConfig()
+}
+
 // ---- Reading and Writing Root Node ID Lists ----
 
 // rootList is a utility type managing an in-memory copy of the list of roots

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -3034,6 +3034,26 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 	}
 }
 
+func TestArchiveTrie_GetConfig(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			if err != nil {
+				t.Fatalf("cannot open archive: %v", err)
+			}
+			defer func() {
+				if err := archive.Close(); err != nil {
+					t.Fatalf("failed to close archive: %v", err)
+				}
+			}()
+
+			if got, want := archive.GetConfig(), config; got.Name != want.Name {
+				t.Errorf("unexpected config, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
 func TestRootList_LoadRoots_ForwardsIoIssues(t *testing.T) {
 	tests := map[string]func(t *testing.T, dir string) error{
 		"fail to create directory": func(t *testing.T, dir string) error {

--- a/go/database/mpt/config.go
+++ b/go/database/mpt/config.go
@@ -10,6 +10,8 @@
 
 package mpt
 
+import "github.com/Fantom-foundation/Carmen/go/backend/stock"
+
 // MptConfig defines a set of configuration options for customizing the MPT
 // implementation. It is mainly intended to facilitate the accurate modeling
 // of Ethereum's MPT implementation (see schema 5) but may also be used for
@@ -82,6 +84,17 @@ func GetConfigByName(name string) (MptConfig, bool) {
 		}
 	}
 	return MptConfig{}, false
+}
+
+// GetEncoders returns the value encoders for the given MPT configuration.
+func (c MptConfig) GetEncoders() (
+	stock.ValueEncoder[AccountNode],
+	stock.ValueEncoder[BranchNode],
+	stock.ValueEncoder[ExtensionNode],
+	stock.ValueEncoder[ValueNode],
+) {
+
+	return getEncoder(c)
 }
 
 type HashStorageLocation bool

--- a/go/database/mpt/config_test.go
+++ b/go/database/mpt/config_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package mpt
+
+import "testing"
+
+func TestMptConfig_GetEncoders(t *testing.T) {
+	for _, config := range allMptConfigs {
+		a1, b1, e1, v1 := config.GetEncoders()
+		a2, b2, e2, v2 := getEncoder(config)
+
+		if a1 != a2 {
+			t.Errorf("unexpected account node encoder, got %v, want %v", a1, a2)
+		}
+		if b1 != b2 {
+			t.Errorf("unexpected branch node encoder, got %v, want %v", b1, b2)
+		}
+		if e1 != e2 {
+			t.Errorf("unexpected extension node encoder, got %v, want %v", e1, e2)
+		}
+		if v1 != v2 {
+			t.Errorf("unexpected value node encoder, got %v, want %v", v1, v2)
+		}
+	}
+}

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -99,7 +99,7 @@ func (e exportableArchiveTrie) Visit(visitor noResponseNodeVisitor, pruneStorage
 		return err
 	}
 
-	return visitAll(e.trie.Directory(), root, visitor, pruneStorage)
+	return visitAll(e.trie.Directory(), e.trie.GetConfig(), root, visitor, pruneStorage)
 }
 
 func (e exportableArchiveTrie) GetHash() (common.Hash, error) {
@@ -119,7 +119,7 @@ type exportableLiveTrie struct {
 
 func (e *exportableLiveTrie) Visit(visitor noResponseNodeVisitor, pruneStorage bool) error {
 	root := e.db.Root()
-	return visitAllWithSources(&nodeSourceHashWithChildNodesFactory{e.directory}, root.Id(), visitor, pruneStorage)
+	return visitAll(e.directory, e.db.GetConfig(), root.Id(), visitor, pruneStorage)
 }
 
 func (e *exportableLiveTrie) GetHash() (common.Hash, error) {

--- a/go/database/mpt/io/parallel_visit_test.go
+++ b/go/database/mpt/io/parallel_visit_test.go
@@ -15,16 +15,21 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Fantom-foundation/Carmen/go/backend/stock/file"
+	"github.com/Fantom-foundation/Carmen/go/common"
+	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
-	"github.com/Fantom-foundation/Carmen/go/common"
-	"github.com/Fantom-foundation/Carmen/go/common/amount"
 	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"go.uber.org/mock/gomock"
 )
+
+var allMptConfigs = []mpt.MptConfig{
+	mpt.S4LiveConfig, mpt.S4ArchiveConfig,
+	mpt.S5LiveConfig, mpt.S5ArchiveConfig,
+}
 
 func TestPosition_CanBeCreatedAndPrinted(t *testing.T) {
 	tests := []struct {
@@ -109,101 +114,115 @@ func TestPosition_AreOrderedAndWorkWithSharedPrefixes(t *testing.T) {
 }
 
 func TestNodeSource_CanRead_Nodes(t *testing.T) {
-	runTestWithArchive(t, func(trie *mpt.ArchiveTrie) {
-		// trie must be flushed before opening the parallel source
-		if err := trie.Flush(); err != nil {
-			t.Fatalf("failed to flush archive: %v", err)
-		}
+	for _, config := range allMptConfigs {
+		config := config
+		t.Run(config.Name, func(t *testing.T) {
+			runTestWithArchive(t, config, func(trie *mpt.ArchiveTrie) {
+				t.Parallel()
 
-		blocks, _, err := trie.GetBlockHeight()
-		if err != nil {
-			t.Fatalf("failed to get block height: %v", err)
-		}
-
-		factory := nodeSourceHashWithNodesFactory{directory: trie.Directory()}
-		source, err := factory.open()
-		if err != nil {
-			t.Fatalf("failed to open node source: %v", err)
-		}
-
-		// iterate all nodes in the trie for all blocks
-		for i := uint64(0); i <= blocks; i++ {
-			if err := trie.VisitTrie(i, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
-				nodeHash, dirty := node.GetHash()
-				if dirty {
-					t.Fatalf("node %v is dirty", info.Id)
+				// trie must be flushed before opening the parallel source
+				if err := trie.Flush(); err != nil {
+					t.Fatalf("failed to flush archive: %v", err)
 				}
 
-				sourceNode, err := source.get(info.Id)
+				blocks, _, err := trie.GetBlockHeight()
 				if err != nil {
-					t.Fatalf("failed to get node from source: %v", err)
-				}
-				nodeSourceHash, dirty := sourceNode.GetHash()
-				if dirty {
-					t.Fatalf("node %v is dirty", info.Id)
+					t.Fatalf("failed to get block height: %v", err)
 				}
 
-				if nodeHash != nodeSourceHash {
-					t.Errorf("node %v hash mismatch, wanted %v, got %v", info.Id, nodeHash, nodeSourceHash)
+				factory := stockNodeSourceFactory{directory: trie.Directory(), config: trie.GetConfig()}
+				source, err := factory.open()
+				if err != nil {
+					t.Fatalf("failed to open node source: %v", err)
 				}
 
-				return mpt.VisitResponseContinue
-			})); err != nil {
-				t.Fatalf("failed to visit trie: %v", err)
-			}
-		}
-	})
+				// iterate all nodes in the trie for all blocks
+				for i := uint64(0); i <= blocks; i++ {
+					if err := trie.VisitTrie(i, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+						sourceNode, err := source.get(info.Id)
+						if err != nil {
+							t.Fatalf("failed to get node from source: %v", err)
+						}
+						matchNodes(t, node, sourceNode)
+						return mpt.VisitResponseContinue
+					})); err != nil {
+						t.Fatalf("failed to visit trie: %v", err)
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestVisit_Nodes_Failing_CannotOpenDir(t *testing.T) {
-	dir := path.Join(t.TempDir(), "missing")
-	if err := visitAll(dir, mpt.EmptyId(), nil, false); err == nil {
-		t.Errorf("expected error, got nil")
+	for _, config := range allMptConfigs {
+		config := config
+		t.Run(config.Name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := path.Join(t.TempDir(), "missing")
+			if err := visitAll(dir, config, mpt.EmptyId(), nil, false); err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
 	}
 }
 
 func TestVisit_Nodes_Failing_MissingDir(t *testing.T) {
-	dir := t.TempDir()
-	trie := createArchive(t, dir)
-	root, err := trie.GetBlockRoot(0)
-	if err != nil {
-		t.Fatalf("failed to get block root: %v", err)
-	}
+	for _, config := range allMptConfigs {
+		config := config
+		t.Run(config.Name, func(t *testing.T) {
+			t.Parallel()
 
-	if err := trie.Close(); err != nil {
-		t.Fatalf("failed to close archive: %v", err)
-	}
+			dir := t.TempDir()
+			trie := createArchive(t, dir, config)
+			root, err := trie.GetBlockRoot(0)
+			if err != nil {
+				t.Fatalf("failed to get block root: %v", err)
+			}
 
-	// break the directory by removing the files
-	if err := os.RemoveAll(path.Join(dir, "accounts")); err != nil {
-		t.Fatalf("failed to remove directory: %v", err)
-	}
+			if err := trie.Close(); err != nil {
+				t.Fatalf("failed to close archive: %v", err)
+			}
 
-	if err := visitAll(dir, root, nil, false); err == nil {
-		t.Errorf("expected error, got nil")
-	}
+			// corrupt the directory by removing the files
+			if err := os.RemoveAll(path.Join(dir, "accounts")); err != nil {
+				t.Fatalf("failed to remove directory: %v", err)
+			}
 
+			if err := visitAll(dir, config, root, nil, false); err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
 }
 
 func TestVisit_Nodes_Failing_MissingData(t *testing.T) {
-	runTestWithArchive(t, func(trie *mpt.ArchiveTrie) {
-		// truncate file to simulate missing data
-		file, err := os.OpenFile(path.Join(trie.Directory(), "accounts", "values.dat"), os.O_WRONLY|os.O_TRUNC, 0666)
-		if err != nil {
-			t.Fatalf("failed to open file: %v", err)
-		}
-		if err := file.Close(); err != nil {
-			t.Fatalf("failed to close file: %v", err)
-		}
+	for _, config := range allMptConfigs {
+		config := config
+		t.Run(config.Name, func(t *testing.T) {
+			runTestWithArchive(t, config, func(trie *mpt.ArchiveTrie) {
+				t.Parallel()
 
-		nodeId, err := trie.GetBlockRoot(0)
-		if err != nil {
-			t.Fatalf("failed to get block root: %v", err)
-		}
-		if err := visitAll(trie.Directory(), nodeId, nil, false); err == nil {
-			t.Errorf("expected error, got nil")
-		}
-	})
+				// truncate file to simulate missing data
+				file, err := os.OpenFile(path.Join(trie.Directory(), "accounts", "values.dat"), os.O_WRONLY|os.O_TRUNC, 0666)
+				if err != nil {
+					t.Fatalf("failed to open file: %v", err)
+				}
+				if err := file.Close(); err != nil {
+					t.Fatalf("failed to close file: %v", err)
+				}
+
+				nodeId, err := trie.GetBlockRoot(0)
+				if err != nil {
+					t.Fatalf("failed to get block root: %v", err)
+				}
+				if err := visitAll(trie.Directory(), config, nodeId, nil, false); err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			})
+		})
+	}
 }
 
 func TestVisit_Nodes_CannotOpenFiles(t *testing.T) {
@@ -219,84 +238,75 @@ func TestVisit_Nodes_CannotOpenFiles(t *testing.T) {
 }
 
 func TestVisit_Nodes_CannotCloseSources(t *testing.T) {
-	sourceFactories := []struct {
-		name       string
-		factory    func(dir string) nodeSourceFactory
-		createData func(t *testing.T, dir string) (root mpt.NodeId)
+	sourceFactories := map[string]struct {
+		createData func(t *testing.T, dir string, config mpt.MptConfig) (root mpt.NodeId)
 	}{
-		{"hashWithNodes", func(dir string) nodeSourceFactory { return &nodeSourceHashWithNodesFactory{directory: dir} }, func(t *testing.T, dir string) (root mpt.NodeId) {
-			trie := createArchive(t, dir)
-			root, err := trie.GetBlockRoot(0)
-			if err != nil {
-				t.Fatalf("failed to get block root: %v", err)
-			}
-			if err := trie.Close(); err != nil {
-				t.Fatalf("failed to close archive: %v", err)
-			}
-			return root
-		}},
-		{"hashWithChildNodes", func(dir string) nodeSourceFactory { return &nodeSourceHashWithChildNodesFactory{directory: dir} }, func(t *testing.T, dir string) (root mpt.NodeId) {
-			trie := createMptState(t, dir)
-			rootId := trie.GetRootId()
-			if err := trie.Close(); err != nil {
-				t.Fatalf("failed to close live db: %v", err)
-			}
-			return rootId
-		}},
+		"archive": {
+			createData: func(t *testing.T, dir string, config mpt.MptConfig) (root mpt.NodeId) {
+				trie := createArchive(t, dir, config)
+				root, err := trie.GetBlockRoot(0)
+				if err != nil {
+					t.Fatalf("failed to get block root: %v", err)
+				}
+				if err := trie.Close(); err != nil {
+					t.Fatalf("failed to close archive: %v", err)
+				}
+				return root
+			}},
+		"live": {
+			createData: func(t *testing.T, dir string, config mpt.MptConfig) (root mpt.NodeId) {
+				trie := createMptState(t, dir, config)
+				rootId := trie.GetRootId()
+				if err := trie.Close(); err != nil {
+					t.Fatalf("failed to close live db: %v", err)
+				}
+				return rootId
+			}},
 	}
 
 	injectedError := fmt.Errorf("injected error")
 
-	for _, factory := range sourceFactories {
-		t.Run(factory.name, func(t *testing.T) {
-			dir := t.TempDir()
-			rootId := factory.createData(t, dir)
-			parentFc := factory.factory(dir)
-			ctrl := gomock.NewController(t)
+	for _, config := range allMptConfigs {
+		config := config
+		for name, factory := range sourceFactories {
+			factory := factory
+			t.Run(fmt.Sprintf("%s_%s", name, config.Name), func(t *testing.T) {
+				t.Parallel()
 
-			mockFc := NewMocknodeSourceFactory(ctrl)
-			mockFc.EXPECT().open().DoAndReturn(func() (nodeSource, error) {
-				parentSource, err := parentFc.open()
-				if err != nil {
-					t.Fatalf("failed to open source: %v", err)
+				dir := t.TempDir()
+				rootId := factory.createData(t, dir, config)
+				parentFc := stockNodeSourceFactory{directory: dir, config: config}
+				ctrl := gomock.NewController(t)
+
+				mockFc := NewMocknodeSourceFactory(ctrl)
+				mockFc.EXPECT().open().DoAndReturn(func() (nodeSource, error) {
+					parentSource, err := parentFc.open()
+					if err != nil {
+						t.Fatalf("failed to open source: %v", err)
+					}
+					mockSource := NewMocknodeSource(ctrl)
+					mockSource.EXPECT().get(gomock.Any()).DoAndReturn(parentSource.get).AnyTimes()
+					mockSource.EXPECT().Close().Return(injectedError)
+					return mockSource, nil
+				}).Times(16)
+
+				visitor := NewMocknoResponseNodeVisitor(ctrl)
+				visitor.EXPECT().Visit(gomock.Any(), gomock.Any()).AnyTimes()
+
+				if err := visitAllWithSources(mockFc, rootId, visitor, false); !errors.Is(err, injectedError) {
+					t.Errorf("expected error %v, got %v", injectedError, err)
 				}
-				mockSource := NewMocknodeSource(ctrl)
-				mockSource.EXPECT().get(gomock.Any()).DoAndReturn(parentSource.get).AnyTimes()
-				mockSource.EXPECT().Close().Return(injectedError)
-				return mockSource, nil
-			}).Times(16)
-
-			visitor := NewMocknoResponseNodeVisitor(ctrl)
-			visitor.EXPECT().Visit(gomock.Any(), gomock.Any()).AnyTimes()
-
-			if err := visitAllWithSources(mockFc, rootId, visitor, false); !errors.Is(err, injectedError) {
-				t.Errorf("expected error %v, got %v", injectedError, err)
-			}
-		})
+			})
+		}
 	}
-
 }
 
 func TestVisit_Nodes_CannotGetNode_FailingSource(t *testing.T) {
 	injectedError := fmt.Errorf("injected error")
 
-	trie := createArchive(t, t.TempDir())
-
-	nodeId, err := trie.GetBlockRoot(0)
-	if err != nil {
-		t.Fatalf("failed to get block root: %v", err)
-	}
-	if err := trie.Close(); err != nil {
-		t.Fatalf("failed to close archive: %v", err)
-	}
-
 	ctrl := gomock.NewController(t)
-
 	mockFc := NewMocknodeSourceFactory(ctrl)
 	mockFc.EXPECT().open().DoAndReturn(func() (nodeSource, error) {
-		if err != nil {
-			t.Fatalf("failed to open source: %v", err)
-		}
 		mockSource := NewMocknodeSource(ctrl)
 		mockSource.EXPECT().get(gomock.Any()).Return(nil, injectedError).AnyTimes()
 		mockSource.EXPECT().Close().Return(nil)
@@ -306,6 +316,7 @@ func TestVisit_Nodes_CannotGetNode_FailingSource(t *testing.T) {
 	visitor := NewMocknoResponseNodeVisitor(ctrl)
 	visitor.EXPECT().Visit(gomock.Any(), gomock.Any()).AnyTimes()
 
+	var nodeId mpt.NodeId
 	if err := visitAllWithSources(mockFc, nodeId, visitor, false); !errors.Is(err, injectedError) {
 		t.Errorf("expected error %v, got %v", injectedError, err)
 	}
@@ -313,56 +324,62 @@ func TestVisit_Nodes_CannotGetNode_FailingSource(t *testing.T) {
 
 func TestVisit_Nodes_Iterated_Deterministic(t *testing.T) {
 	const N = 15
-	runTestWithArchive(t, func(trie *mpt.ArchiveTrie) {
-		// trie must be flushed before opening the parallel source
-		if err := trie.Flush(); err != nil {
-			t.Fatalf("failed to flush archive: %v", err)
-		}
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			runTestWithArchive(t, config, func(trie *mpt.ArchiveTrie) {
+				// trie must be flushed before opening the parallel source
+				if err := trie.Flush(); err != nil {
+					t.Fatalf("failed to flush archive: %v", err)
+				}
 
-		blocks, _, err := trie.GetBlockHeight()
-		if err != nil {
-			t.Fatalf("failed to get block height: %v", err)
-		}
+				blocks, _, err := trie.GetBlockHeight()
+				if err != nil {
+					t.Fatalf("failed to get block height: %v", err)
+				}
 
-		// iterate all nodes in the trie for all blocks
-		for block := uint64(0); block <= blocks; block++ {
-			var nodes []mpt.NodeId
-			if err := trie.VisitTrie(block, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
-				nodes = append(nodes, info.Id)
-				return mpt.VisitResponseContinue
-			})); err != nil {
-				t.Fatalf("failed to visit trie: %v", err)
-			}
-
-			nodeId, err := trie.GetBlockRoot(block)
-			if err != nil {
-				t.Fatalf("failed to get block root: %v", err)
-			}
-
-			// visit all nodes in the trie and compare that the nodes are visited in the same order
-			// as the nodes in the trie
-			// run the experiment N times to ensure that the order is deterministic
-			for i := 0; i < N; i++ {
-				t.Run(fmt.Sprintf("block=%d,iteration=%d", block, i), func(t *testing.T) {
-					t.Parallel()
-					var position int
-					ctrl := gomock.NewController(t)
-					visitor := NewMocknoResponseNodeVisitor(ctrl)
-					visitor.EXPECT().Visit(gomock.Any(), gomock.Any()).DoAndReturn(func(_ mpt.Node, info mpt.NodeInfo) error {
-						if got, want := info.Id, nodes[position]; got != want {
-							t.Errorf("expected node %v, got %v", want, got)
-						}
-						position++
-						return nil
-					}).Times(len(nodes))
-
-					if err := visitAll(trie.Directory(), nodeId, visitor, false); err != nil {
-						t.Fatalf("failed to visit nodes: %v", err)
+				// iterate all nodes in the trie for all blocks
+				for block := uint64(0); block <= blocks; block++ {
+					var nodes []mpt.NodeId
+					if err := trie.VisitTrie(block, mpt.MakeVisitor(
+						func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+							nodes = append(nodes, info.Id)
+							return mpt.VisitResponseContinue
+						})); err != nil {
+						t.Fatalf("failed to visit trie: %v", err)
 					}
-				})
-			}
-		}
-	})
+
+					nodeId, err := trie.GetBlockRoot(block)
+					if err != nil {
+						t.Fatalf("failed to get block root: %v", err)
+					}
+
+					// visit all nodes in the trie and compare that the nodes are visited in the same order
+					// as the nodes in the trie
+					// run the experiment N times to ensure that the order is deterministic
+					for i := 0; i < N; i++ {
+						t.Run(fmt.Sprintf("block=%d,iteration=%d", block, i), func(t *testing.T) {
+							t.Parallel()
+							var position int
+							ctrl := gomock.NewController(t)
+							visitor := NewMocknoResponseNodeVisitor(ctrl)
+							visitor.EXPECT().Visit(gomock.Any(), gomock.Any()).DoAndReturn(
+								func(_ mpt.Node, info mpt.NodeInfo) error {
+									if got, want := info.Id, nodes[position]; got != want {
+										t.Errorf("expected node %v, got %v", want, got)
+									}
+									position++
+									return nil
+								}).Times(len(nodes))
+
+							if err := visitAll(trie.Directory(), config, nodeId, visitor, false); err != nil {
+								t.Fatalf("failed to visit nodes: %v", err)
+							}
+						})
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestSource_EmptyNodeId(t *testing.T) {
@@ -376,136 +393,143 @@ func TestSource_EmptyNodeId(t *testing.T) {
 func TestOpenSource_Failing_MissingFiles(t *testing.T) {
 	tests := []string{"accounts", "extensions", "branches", "values"}
 
-	sourceFactories := []struct {
-		name    string
-		factory func(dir string) nodeSourceFactory
-	}{
-		{"hashWithNodes", func(dir string) nodeSourceFactory { return &nodeSourceHashWithNodesFactory{directory: dir} }},
-		{"hashWithChildNodes", func(dir string) nodeSourceFactory { return &nodeSourceHashWithChildNodesFactory{directory: dir} }},
+	for _, config := range allMptConfigs {
+		config := config
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("%s %s", config.Name, test), func(t *testing.T) {
+				t.Parallel()
+
+				dir := t.TempDir()
+				fmt.Printf("%s %s %s\n", config.Name, test, dir)
+				aEnc, bEnc, eEnc, vEnc := config.GetEncoders()
+				// create all stocks first
+				stock1, err := file.OpenStock[uint64, mpt.AccountNode](aEnc, path.Join(dir, "accounts"))
+				if err != nil {
+					t.Fatalf("failed to open stock: %v", err)
+				}
+				if err := stock1.Close(); err != nil {
+					t.Fatalf("failed to close stock: %v", err)
+				}
+
+				stock2, err := file.OpenStock[uint64, mpt.ExtensionNode](eEnc, path.Join(dir, "extensions"))
+				if err != nil {
+					t.Fatalf("failed to open stock: %v", err)
+				}
+				if err := stock2.Close(); err != nil {
+					t.Fatalf("failed to close stock: %v", err)
+				}
+
+				stock3, err := file.OpenStock[uint64, mpt.BranchNode](bEnc, path.Join(dir, "branches"))
+				if err != nil {
+					t.Fatalf("failed to open stock: %v", err)
+				}
+				if err := stock3.Close(); err != nil {
+					t.Fatalf("failed to close stock: %v", err)
+				}
+
+				stock4, err := file.OpenStock[uint64, mpt.ValueNode](vEnc, path.Join(dir, "values"))
+				if err != nil {
+					t.Fatalf("failed to open stock: %v", err)
+				}
+				if err := stock4.Close(); err != nil {
+					t.Fatalf("failed to close stock: %v", err)
+				}
+
+				// delete one of the stocks
+				if err := os.RemoveAll(path.Join(dir, test)); err != nil {
+					t.Fatalf("failed to remove directory: %v", err)
+				}
+
+				factory := stockNodeSourceFactory{directory: dir, config: config}
+				if _, err := factory.open(); err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			})
+		}
 	}
+}
 
-	for _, test := range tests {
-		t.Run(test, func(t *testing.T) {
+func TestNodeSourceFactoryForLiveDB_CanRead_Nodes(t *testing.T) {
+	for _, config := range allMptConfigs {
+		config := config
+		t.Run(config.Name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
+			live := createMptState(t, dir, config)
 
-			// create all stocks first
-			stock1, err := file.OpenStock[uint64, mpt.AccountNode](mpt.AccountNodeWithPathLengthEncoderWithNodeHash{}, path.Join(dir, "accounts"))
+			// collect all nodes from the live db
+			nodes := make(map[mpt.NodeId]mpt.Node)
+			// collect all nodes from the live db
+			if err := live.Visit(mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+				nodes[info.Id] = node
+				return mpt.VisitResponseContinue
+			})); err != nil {
+				t.Fatalf("failed to visit trie: %v", err)
+			}
+
+			if err := live.Close(); err != nil {
+				t.Fatalf("failed to close live db: %v", err)
+			}
+
+			// check that all nodes can be read from the source
+			factory := stockNodeSourceFactory{directory: dir, config: config}
+			source, err := factory.open()
 			if err != nil {
-				t.Fatalf("failed to open stock: %v", err)
+				t.Fatalf("failed to open node source: %v", err)
 			}
-			if err := stock1.Close(); err != nil {
-				t.Fatalf("failed to close stock: %v", err)
-			}
+			defer func() {
+				if err := source.Close(); err != nil {
+					t.Fatalf("failed to close source: %v", err)
+				}
+			}()
 
-			stock2, err := file.OpenStock[uint64, mpt.ExtensionNode](mpt.ExtensionNodeEncoderWithNodeHash{}, path.Join(dir, "extensions"))
-			if err != nil {
-				t.Fatalf("failed to open stock: %v", err)
-			}
-			if err := stock2.Close(); err != nil {
-				t.Fatalf("failed to close stock: %v", err)
-			}
+			// compare that all nodes from the trie can be read from the source
+			for id, node := range nodes {
+				sourceNode, err := source.get(id)
+				if err != nil {
+					t.Fatalf("failed to get node from source: %v", err)
+				}
 
-			stock3, err := file.OpenStock[uint64, mpt.BranchNode](mpt.BranchNodeEncoderWithNodeHash{}, path.Join(dir, "branches"))
-			if err != nil {
-				t.Fatalf("failed to open stock: %v", err)
-			}
-			if err := stock3.Close(); err != nil {
-				t.Fatalf("failed to close stock: %v", err)
-			}
-
-			stock4, err := file.OpenStock[uint64, mpt.ValueNode](mpt.ValueNodeWithPathLengthEncoderWithNodeHash{}, path.Join(dir, "values"))
-			if err != nil {
-				t.Fatalf("failed to open stock: %v", err)
-			}
-			if err := stock4.Close(); err != nil {
-				t.Fatalf("failed to close stock: %v", err)
-			}
-
-			// delete one of the stocks
-			if err := os.RemoveAll(path.Join(dir, test)); err != nil {
-				t.Fatalf("failed to remove directory: %v", err)
-			}
-
-			for _, factory := range sourceFactories {
-				t.Run(factory.name, func(t *testing.T) {
-					source := factory.factory(dir)
-					if _, err := source.open(); err == nil {
-						t.Errorf("expected error, got nil")
-					}
-				})
+				matchNodes(t, node, sourceNode)
 			}
 		})
 	}
 }
 
-func TestNodeSourceFactoryForLiveDB_CanRead_Nodes(t *testing.T) {
-	dir := t.TempDir()
-	live := createMptState(t, dir)
-
-	// collect all nodes from the live db
-	nodes := make(map[mpt.NodeId]mpt.Node)
-	// collect all nodes from the live db
-	if err := live.Visit(mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
-		nodes[info.Id] = node
-		return mpt.VisitResponseContinue
-	})); err != nil {
-		t.Fatalf("failed to visit trie: %v", err)
-	}
-
-	if err := live.Close(); err != nil {
-		t.Fatalf("failed to close live db: %v", err)
-	}
-
-	// check that all nodes can be read from the source
-	factory := nodeSourceHashWithChildNodesFactory{directory: dir}
-	source, err := factory.open()
-	if err != nil {
-		t.Fatalf("failed to open node source: %v", err)
-	}
-	defer func() {
-		if err := source.Close(); err != nil {
-			t.Fatalf("failed to close source: %v", err)
+// matchNodes compares two nodes and fails the test if they are not equal.
+func matchNodes(t *testing.T, a, b mpt.Node) {
+	switch n := a.(type) {
+	case *mpt.AccountNode:
+		if got, want := n.Address(), b.(*mpt.AccountNode).Address(); got != want {
+			t.Errorf("expected address %v, got %v", want, got)
 		}
-	}()
-
-	// compare that all nodes from the trie can be read from the source
-	for id, node := range nodes {
-		sourceNode, err := source.get(id)
-		if err != nil {
-			t.Fatalf("failed to get node from source: %v", err)
+		if got, want := n.Info(), b.(*mpt.AccountNode).Info(); got != want {
+			t.Errorf("expected info %v, got %v", want, got)
 		}
-
-		switch n := node.(type) {
-		case *mpt.AccountNode:
-			if got, want := n.Address(), sourceNode.(*mpt.AccountNode).Address(); got != want {
-				t.Errorf("expected address %v, got %v", want, got)
-			}
-			if got, want := n.Info(), sourceNode.(*mpt.AccountNode).Info(); got != want {
-				t.Errorf("expected info %v, got %v", want, got)
-			}
-			if got, want := n.GetStorage(), sourceNode.(*mpt.AccountNode).GetStorage(); got.Id() != want.Id() {
-				t.Errorf("expected storage %v, got %v", want, got)
-			}
-		case *mpt.ExtensionNode:
-			if got, want := n.Path(), sourceNode.(*mpt.ExtensionNode).Path(); got != want {
-				t.Errorf("expected path %v, got %v", want, got)
-			}
-			if got, want := n.GetNext(), sourceNode.(*mpt.ExtensionNode).GetNext(); got.Id() != want.Id() {
-				t.Errorf("expected next %v, got %v", want, got)
-			}
-		case *mpt.BranchNode:
-			for i := 0; i < 16; i++ {
-				if got, want := n.GetChildren()[i], sourceNode.(*mpt.BranchNode).GetChildren()[i]; got.Id() != want.Id() {
-					t.Errorf("expected children %v, got %v", want, got)
-				}
+		if got, want := n.GetStorage(), b.(*mpt.AccountNode).GetStorage(); got.Id() != want.Id() {
+			t.Errorf("expected storage %v, got %v", want, got)
+		}
+	case *mpt.ExtensionNode:
+		if got, want := n.Path(), b.(*mpt.ExtensionNode).Path(); got != want {
+			t.Errorf("expected path %v, got %v", want, got)
+		}
+		if got, want := n.GetNext(), b.(*mpt.ExtensionNode).GetNext(); got.Id() != want.Id() {
+			t.Errorf("expected next %v, got %v", want, got)
+		}
+	case *mpt.BranchNode:
+		for i := 0; i < 16; i++ {
+			if got, want := n.GetChildren()[i], b.(*mpt.BranchNode).GetChildren()[i]; got.Id() != want.Id() {
+				t.Errorf("expected children %v, got %v", want, got)
 			}
 		}
 	}
 }
 
 // runTestWithArchive runs a test with a new archive that is pre-populated data.
-func runTestWithArchive(t *testing.T, action func(trie *mpt.ArchiveTrie)) {
-	trie := createArchive(t, t.TempDir())
+func runTestWithArchive(t *testing.T, config mpt.MptConfig, action func(trie *mpt.ArchiveTrie)) {
+	trie := createArchive(t, t.TempDir(), config)
 	defer func() {
 		if err := trie.Close(); err != nil {
 			t.Fatalf("failed to close archive archive: %v", err)
@@ -516,8 +540,8 @@ func runTestWithArchive(t *testing.T, action func(trie *mpt.ArchiveTrie)) {
 }
 
 // createArchive creates a new archive with pre-populated data.
-func createArchive(t *testing.T, dir string) *mpt.ArchiveTrie {
-	archive, err := mpt.OpenArchiveTrie(dir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
+func createArchive(t *testing.T, dir string, config mpt.MptConfig) *mpt.ArchiveTrie {
+	archive, err := mpt.OpenArchiveTrie(dir, config, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
 	if err != nil {
 		t.Fatalf("failed to create archive: %v", err)
 	}
@@ -535,10 +559,14 @@ func createArchive(t *testing.T, dir string) *mpt.ArchiveTrie {
 			newAddr := common.AddressFromNumber(j)
 
 			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
-			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})
-			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: newAddr, Nonce: common.ToNonce(u + 1)})
-			update.Codes = append(update.Codes, common.CodeUpdate{Account: newAddr, Code: code})
-			update.Slots = append(update.Slots, common.SlotUpdate{Account: newAddr, Key: common.Key{byte(j)}, Value: common.Value{byte(i)}})
+			update.Balances = append(update.Balances, common.BalanceUpdate{
+				Account: newAddr, Balance: amount.New(u + 1)})
+			update.Nonces = append(update.Nonces, common.NonceUpdate{
+				Account: newAddr, Nonce: common.ToNonce(u + 1)})
+			update.Codes = append(update.Codes, common.CodeUpdate{
+				Account: newAddr, Code: code})
+			update.Slots = append(update.Slots, common.SlotUpdate{
+				Account: newAddr, Key: common.Key{byte(j)}, Value: common.Value{byte(i)}})
 		}
 		err = archive.Add(u, update, nil)
 		if err != nil {
@@ -550,8 +578,8 @@ func createArchive(t *testing.T, dir string) *mpt.ArchiveTrie {
 }
 
 // createMptState creates a new live db with pre-populated data.
-func createMptState(t *testing.T, dir string) *mpt.MptState {
-	live, err := mpt.OpenGoFileState(dir, mpt.S5LiveConfig, mpt.NodeCacheConfig{Capacity: 1024})
+func createMptState(t *testing.T, dir string, config mpt.MptConfig) *mpt.MptState {
+	live, err := mpt.OpenGoFileState(dir, config, mpt.NodeCacheConfig{Capacity: 1024})
 	if err != nil {
 		t.Fatalf("failed to open live db: %v", err)
 	}

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -239,6 +239,11 @@ func (s *LiveTrie) Dump() {
 	s.forest.Dump(&s.root)
 }
 
+// GetConfig returns the configuration of the trie.
+func (s *LiveTrie) GetConfig() MptConfig {
+	return s.forest.getConfig()
+}
+
 // Check verifies internal invariants of the Trie instance. If the trie is
 // self-consistent, nil is returned and the Trie is read to be accessed. If
 // errors are detected, the Trie is to be considered in an invalid state and

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -1127,6 +1127,26 @@ func TestLiveTrie_CreateWitnessProof(t *testing.T) {
 
 }
 
+func TestLiveTrie_GetConfig(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			live, err := OpenInMemoryLiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			if err != nil {
+				t.Fatalf("cannot open live: %v", err)
+			}
+			defer func() {
+				if err := live.Close(); err != nil {
+					t.Fatalf("failed to close live: %v", err)
+				}
+			}()
+
+			if got, want := live.GetConfig(), config; got.Name != want.Name {
+				t.Errorf("unexpected config, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
 func benchmarkValueInsertion(trie *LiveTrie, b *testing.B) {
 	accounts := getTestAddresses(100)
 	keys := getTestKeys(100)

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -1111,6 +1111,10 @@ func (n *ExtensionNode) GetNext() NodeReference {
 	return n.next
 }
 
+func (n *ExtensionNode) Path() Path {
+	return n.path
+}
+
 func (n *ExtensionNode) getNextNodeInExtension(
 	source NodeSource,
 	path []Nibble,

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -354,6 +354,11 @@ func (s *MptState) GetCodes() map[common.Hash][]byte {
 	return s.codes.getCodes()
 }
 
+// GetConfig returns the configuration of the archive.
+func (s *MptState) GetConfig() MptConfig {
+	return s.trie.GetConfig()
+}
+
 // Flush codes and state trie
 func (s *MptState) Flush() error {
 	return errors.Join(

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -526,6 +526,26 @@ func TestMptState_GetRootId(t *testing.T) {
 	}
 }
 
+func TestMptState_GetConfig(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			mptState, err := OpenGoMemoryState(t.TempDir(), config, NodeCacheConfig{Capacity: 1024})
+			if err != nil {
+				t.Fatalf("cannot open mptState: %v", err)
+			}
+			defer func() {
+				if err := mptState.Close(); err != nil {
+					t.Fatalf("failed to close mptState: %v", err)
+				}
+			}()
+
+			if got, want := mptState.GetConfig(), config; got.Name != want.Name {
+				t.Errorf("unexpected config, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
 func TestState_GetCodes(t *testing.T) {
 	hasher := sha3.NewLegacyKeccak256()
 	for name, open := range mptStateFactories {


### PR DESCRIPTION
This PR uses async reading of MPT to speed up export of liveDB.

Experiment was taken to export liveDB from a block height beyond 80M blocks, a cloud VM with local SSD.

Originally, the export took approx. **1 day**, after the change, it takes approx. **2 hours**.