### PR TITLE
sends only the number of responses coming from workers

### DIFF
--- a/go/database/mpt/io/parallel_visit_test.go
+++ b/go/database/mpt/io/parallel_visit_test.go
@@ -232,7 +232,7 @@ func TestVisit_CanHandleSlowConsumer(t *testing.T) {
 				// throttling, the number of workers, the batch size, and the
 				// structure of the trie. The limit used here is a conservative
 				// upper bound which would get exceeded by a factor of 10 if the
-				// workers would not be throttled.
+				// workers were not throttled.
 				if got, limit := numResponses, 200; got > limit {
 					t.Errorf("expected at most %d responses, got %d", limit, got)
 				}


### PR DESCRIPTION
This PR resolves failures of tests, where the number of data produced by async workers in parallel trie visit is measured. 

The original code measured the total number of responses in the queue. It could easily exceed the expected limit, and the test failed. 

It seems that it was not originally intended by this test.  The test was supposed to measure only the volume of data produced by the workers, not to exceed memory limits by threads possibly rushing ahead in computation. 

During an execution, it can happen that all workers correctly stop producing data realising that too many responses were  produced. On the other hand, not to stall the execution, the main thread continues and still produces data, which piles up to the already existing number of responses. This is, correct behaviour as the execution cannot stop and the main thread must produce more data until it collects the data it needs.  It can lead to a situation, where the number of responses exceeds the tested limit. 

This PR added a `bool`  flag marking each response as either coming from a worker, or from the main thread.  It is then validated that only the amount of responses coming from workers is not exceeded.  The number of responses generated by the main thread is kept unbound (unchecked). 