### PR TITLE
Add stringer to GetMemoryFootprint

### DIFF
--- a/go/carmen/memory_footprint.go
+++ b/go/carmen/memory_footprint.go
@@ -10,9 +10,14 @@
 
 package carmen
 
-import "github.com/Fantom-foundation/Carmen/go/common"
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Carmen/go/common"
+)
 
 type MemoryFootprint interface {
+	fmt.Stringer
 	// Total provides the number of bytes consumed by the database structure including all its subcomponents.
 	Total() uint64
 }


### PR DESCRIPTION
This PR adds `fmt.Stringer` which explicitly forces `String()` method to be implemented by `MemoryFootprint`.
This is necessary because `carmen.MemoryFootprint` needs to be passed as a `fmt.Stringer`