### PR TITLE
clear caches when closing resources to release memory

### DIFF
--- a/go/backend/archive/ldb/archive.go
+++ b/go/backend/archive/ldb/archive.go
@@ -50,7 +50,7 @@ func (a *Archive) Flush() error {
 }
 
 func (a *Archive) Close() error {
-	// no-op
+	a.accountHashCache.Clear()
 	return nil
 }
 

--- a/go/backend/depot/cache/cachedepot.go
+++ b/go/backend/depot/cache/cachedepot.go
@@ -95,6 +95,8 @@ func (m *Depot[I]) Flush() error {
 
 // Close the depot
 func (m *Depot[I]) Close() error {
+	m.cache.Clear()
+	m.sizeCache.Clear()
 	return m.depot.Close()
 }
 

--- a/go/backend/index/cache/cacheindex.go
+++ b/go/backend/index/cache/cacheindex.go
@@ -80,6 +80,7 @@ func (m *Index[K, I]) Flush() error {
 
 // Close closes the storage and clean-ups all possible dirty values.
 func (m *Index[K, I]) Close() error {
+	m.cache.Clear()
 	return m.wrapped.Close()
 }
 

--- a/go/backend/pagepool/pagepool.go
+++ b/go/backend/pagepool/pagepool.go
@@ -112,9 +112,10 @@ func (p *PagePool[ID, T]) Flush() (err error) {
 	return nil
 }
 
-func (p *PagePool[ID, T]) Close() (err error) {
+func (p *PagePool[ID, T]) Close() error {
+	err := p.Flush()
 	p.pagePool.Clear()
-	return p.Flush()
+	return err
 }
 
 // storePage persist the Page to the disk

--- a/go/backend/pagepool/pagepool.go
+++ b/go/backend/pagepool/pagepool.go
@@ -113,12 +113,8 @@ func (p *PagePool[ID, T]) Flush() (err error) {
 }
 
 func (p *PagePool[ID, T]) Close() (err error) {
-	err = p.Flush()
-	if err != nil {
-		p.pagePool.Clear()
-	}
-
-	return
+	p.pagePool.Clear()
+	return p.Flush()
 }
 
 // storePage persist the Page to the disk

--- a/go/backend/pagepool/pagepool_test.go
+++ b/go/backend/pagepool/pagepool_test.go
@@ -137,7 +137,9 @@ func TestPageClose(t *testing.T) {
 		t.Errorf("Page was not created, %v != %v", actualPage, newPage)
 	}
 
-	_ = pagePool.Close()
+	if err := pagePool.Close(); err != nil {
+		t.Errorf("cannot close the page pool: %v", err)
+	}
 
 	// close must persist the page
 	// try to get the page from the storage, and it must exist there

--- a/go/backend/store/cache/cachedstore.go
+++ b/go/backend/store/cache/cachedstore.go
@@ -11,6 +11,7 @@
 package cache
 
 import (
+	"errors"
 	"github.com/Fantom-foundation/Carmen/go/backend"
 	"github.com/Fantom-foundation/Carmen/go/backend/store"
 	"github.com/Fantom-foundation/Carmen/go/common"
@@ -75,10 +76,8 @@ func (m *Store[I, V]) Flush() error {
 }
 
 func (m *Store[I, V]) Close() error {
-	if err := m.Flush(); err != nil {
-		return err
-	}
-	return m.store.Close()
+	m.cache.Clear()
+	return errors.Join(m.Flush(), m.store.Close())
 }
 
 // GetMemoryFootprint provides the size of the store in memory in bytes

--- a/go/backend/store/cache/cachedstore.go
+++ b/go/backend/store/cache/cachedstore.go
@@ -76,8 +76,9 @@ func (m *Store[I, V]) Flush() error {
 }
 
 func (m *Store[I, V]) Close() error {
+	err := m.Flush()
 	m.cache.Clear()
-	return errors.Join(m.Flush(), m.store.Close())
+	return errors.Join(err, m.store.Close())
 }
 
 // GetMemoryFootprint provides the size of the store in memory in bytes

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -264,13 +264,11 @@ func (s *GoState) Flush() error {
 }
 
 func (s *GoState) Close() error {
-	if err := s.Flush(); err != nil {
-		return err
-	}
-
-	if err := s.live.Close(); err != nil {
-		s.stateError = errors.Join(s.stateError, err)
-	}
+	s.stateError = errors.Join(
+		s.stateError,
+		s.Flush(),
+		s.live.Close(),
+	)
 
 	// Shut down archive writer background worker.
 	if s.archiveWriter != nil {

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -624,6 +624,7 @@ func TestState_Flush_Or_Close_Corrupted_State_Detected(t *testing.T) {
 
 	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
 	liveDB.EXPECT().Flush().AnyTimes()
+	liveDB.EXPECT().Close().AnyTimes()
 
 	injectedErr := fmt.Errorf("injectedError")
 
@@ -791,10 +792,12 @@ func TestState_All_Archive_Operations_May_Cause_Failure(t *testing.T) {
 
 	liveDB := state.NewMockLiveDB(ctrl)
 	liveDB.EXPECT().Flush().AnyTimes()
+	liveDB.EXPECT().Close()
 
 	archiveDB := archive.NewMockArchive(ctrl)
 	archiveDB.EXPECT().GetBlockHeight().Return(uint64(0), false, injectedErr).Times(2)
 	archiveDB.EXPECT().Flush().AnyTimes()
+	archiveDB.EXPECT().Close()
 
 	db := newGoState(liveDB, archiveDB, []func(){})
 	// repeated calls must all fail


### PR DESCRIPTION
This PR releases items stored in `LruCache` when components using this cache are `Closed`. This reduces memory in tests of state package.  Heap dumps below shows the memory allocated before and after this change. The dumps were captured right after all tests passed. 


Before:
![state-mem-heap-before](https://github.com/user-attachments/assets/dd8a40b7-2826-408c-b729-031e275fc825)

After:
![state-mem-profile](https://github.com/user-attachments/assets/d1fab1dc-220c-433b-ac57-42c46b819c3a)
