### PR TITLE
exposes method to assess empty storage of an account into State

### DIFF
--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -423,6 +423,11 @@ func (s *Forest) HasEmptyStorage(rootRef *NodeReference, addr common.Address) (i
 		return VisitResponseContinue
 	})
 	exists, err := VisitPathToAccount(s, rootRef, addr, v)
+	if err != nil {
+		err = fmt.Errorf("failed to check storage for account %v: %w", addr, err)
+		s.errors = append(s.errors, err)
+	}
+
 	return isEmpty || !exists, err
 }
 

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -1995,6 +1995,20 @@ func TestForest_ErrorsAreForwardedAndCollected(t *testing.T) {
 				return err
 			},
 		},
+		"HasEmptyStorage-Failed-RootLookup": {
+			prepareRootLookupFailure,
+			func(f *Forest) error {
+				_, err := f.HasEmptyStorage(&rootRef, addr)
+				return err
+			},
+		},
+		"HasEmptyStorage-Failed-TreeNavigation": {
+			prepareTreeNavigationFailure,
+			func(f *Forest) error {
+				_, err := f.HasEmptyStorage(&rootRef, addr)
+				return err
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -653,6 +653,21 @@ func (mr *MockLiveStateMockRecorder) GetStorage(address, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockLiveState)(nil).GetStorage), address, key)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockLiveState) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockLiveStateMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockLiveState)(nil).HasEmptyStorage), addr)
+}
+
 // Root mocks base method.
 func (m *MockLiveState) Root() NodeReference {
 	m.ctrl.T.Helper()

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -288,6 +288,10 @@ func (cs *CppState) CreateWitnessProof(address common.Address, keys ...common.Ke
 	panic("not implemented")
 }
 
+func (cs *CppState) HasEmptyStorage(addr common.Address) (bool, error) {
+	panic("CppState does not support HasEmptyStorage operation")
+}
+
 func (cs *CppState) Export(context.Context, io.Writer) (common.Hash, error) {
 	return common.Hash{}, state.ExportNotSupported
 }

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -124,6 +124,10 @@ func (s *ArchiveState) GetCodeHash(address common.Address) (hash common.Hash, er
 	return codeHash, s.archiveError
 }
 
+func (s *ArchiveState) HasEmptyStorage(addr common.Address) (bool, error) {
+	panic("ArchiveState does not support HasEmptyStorage operation")
+}
+
 func (s *ArchiveState) Apply(block uint64, update common.Update) error {
 	panic("ArchiveState does not support Apply operation")
 }

--- a/go/state/gostate/go_schema1.go
+++ b/go/state/gostate/go_schema1.go
@@ -258,6 +258,10 @@ func (s *GoSchema1) GetCodeHash(address common.Address) (hash common.Hash, err e
 	return hash, nil
 }
 
+func (s *GoSchema1) HasEmptyStorage(addr common.Address) (bool, error) {
+	panic("HasEmptyStorage is not implemented for Scheme1")
+}
+
 func (s *GoSchema1) GetHash() (hash common.Hash, err error) {
 	sources := []common.HashProvider{
 		s.addressIndex,

--- a/go/state/gostate/go_schema2.go
+++ b/go/state/gostate/go_schema2.go
@@ -245,6 +245,10 @@ func (s *GoSchema2) GetCodeHash(address common.Address) (hash common.Hash, err e
 	return hash, nil
 }
 
+func (s *GoSchema2) HasEmptyStorage(addr common.Address) (bool, error) {
+	panic("HasEmptyStorage is not implemented for Scheme2")
+}
+
 func (s *GoSchema2) GetHash() (hash common.Hash, err error) {
 	sources := []common.HashProvider{
 		s.addressIndex,

--- a/go/state/gostate/go_schema3.go
+++ b/go/state/gostate/go_schema3.go
@@ -251,6 +251,10 @@ func (s *GoSchema3) GetCodeHash(address common.Address) (hash common.Hash, err e
 	return hash, nil
 }
 
+func (s *GoSchema3) HasEmptyStorage(addr common.Address) (bool, error) {
+	panic("HasEmptyStorage is not implemented for Scheme3")
+}
+
 func (s *GoSchema3) GetHash() (hash common.Hash, err error) {
 	sources := []common.HashProvider{
 		s.addressIndex,

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -185,6 +185,18 @@ func (s *GoState) GetCodeHash(address common.Address) (common.Hash, error) {
 	return h, s.stateError
 }
 
+func (s *GoState) HasEmptyStorage(addr common.Address) (bool, error) {
+	if err := s.stateError; err != nil {
+		return false, err
+	}
+
+	empty, err := s.live.HasEmptyStorage(addr)
+	if err != nil {
+		s.stateError = errors.Join(s.stateError, err)
+	}
+	return empty, s.stateError
+}
+
 func (s *GoState) GetHash() (common.Hash, error) {
 	if err := s.stateError; err != nil {
 		return common.Hash{}, err

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -495,6 +495,24 @@ func TestGetMemoryFootprint(t *testing.T) {
 	}
 }
 
+func TestGoState_HasEmptyStorage(t *testing.T) {
+	addr := common.Address{0x1}
+	ctrl := gomock.NewController(t)
+	live := state.NewMockLiveDB(ctrl)
+
+	live.EXPECT().HasEmptyStorage(addr).Return(true, nil)
+
+	state := newGoState(live, nil, nil)
+
+	empty, err := state.HasEmptyStorage(addr)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !empty {
+		t.Errorf("unexpected non-empty storage")
+	}
+}
+
 func TestGoState_FlushFlushesLiveDbAndArchive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	live := state.NewMockLiveDB(ctrl)
@@ -715,7 +733,7 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 	key := common.Key{0xB}
 	injectedErr := fmt.Errorf("injectedError")
 
-	const loops = 10
+	const loops = 11
 	for i := 0; i < loops; i++ {
 		i := i
 		t.Run(fmt.Sprintf("operation_%d", i), func(t *testing.T) {
@@ -733,8 +751,9 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 			liveDB.EXPECT().GetCodeSize(addr).Return(0, results[5]).AnyTimes()
 			liveDB.EXPECT().GetCodeHash(addr).Return(common.Hash{}, results[6]).AnyTimes()
 			liveDB.EXPECT().GetHash().Return(common.Hash{}, results[7]).AnyTimes()
-			liveDB.EXPECT().Flush().Return(results[8]).AnyTimes()
-			liveDB.EXPECT().Close().Return(results[9]).AnyTimes()
+			liveDB.EXPECT().HasEmptyStorage(gomock.Any()).Return(false, results[8]).AnyTimes()
+			liveDB.EXPECT().Flush().Return(results[9]).AnyTimes()
+			liveDB.EXPECT().Close().Return(results[10]).AnyTimes()
 
 			db := newGoState(liveDB, nil, []func(){})
 			// calls must succeed until the first failure,
@@ -771,6 +790,10 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 				}
 				shouldFail = shouldFail || errors.Is(results[7], injectedErr)
 				if _, err := db.GetHash(); shouldFail && !errors.Is(err, injectedErr) {
+					t.Errorf("operation should fail")
+				}
+				shouldFail = shouldFail || errors.Is(results[7], injectedErr)
+				if _, err := db.HasEmptyStorage(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
 				shouldFail = shouldFail || errors.Is(results[8], injectedErr)

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -792,11 +792,11 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 				if _, err := db.GetHash(); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[7], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[8], injectedErr)
 				if _, err := db.HasEmptyStorage(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[8], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[9], injectedErr)
 				if err := db.Flush(); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -49,6 +49,9 @@ type State interface {
 	// GetCodeHash returns the hash of the code of the input contract address.
 	GetCodeHash(address common.Address) (common.Hash, error)
 
+	// HasEmptyStorage returns true if the contract has no storage attached to it.
+	HasEmptyStorage(addr common.Address) (bool, error)
+
 	// Apply applies the provided updates to the state content.
 	Apply(block uint64, update common.Update) error
 
@@ -102,6 +105,7 @@ type LiveDB interface {
 	GetCode(address common.Address) (value []byte, err error)
 	GetCodeSize(address common.Address) (size int, err error)
 	GetCodeHash(address common.Address) (hash common.Hash, err error)
+	HasEmptyStorage(addr common.Address) (bool, error)
 	GetHash() (hash common.Hash, err error)
 	Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error)
 	Flush() error

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -56,6 +56,7 @@ type VmStateDB interface {
 	SetState(common.Address, common.Key, common.Value)
 	GetTransientState(common.Address, common.Key) common.Value
 	SetTransientState(common.Address, common.Key, common.Value)
+	HasEmptyStorage(addr common.Address) (bool, error)
 
 	// Code management.
 	GetCode(common.Address) []byte
@@ -886,6 +887,10 @@ func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value c
 	})
 
 	s.transientStorage.Put(sid, value)
+}
+
+func (s *stateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+	return s.state.HasEmptyStorage(addr)
 }
 
 func (s *stateDB) GetCode(addr common.Address) []byte {

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -393,6 +393,21 @@ func (mr *MockVmStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockVmStateDB)(nil).GetTransientState), arg0, arg1)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockVmStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockVmStateDBMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockVmStateDB)(nil).HasEmptyStorage), addr)
+}
+
 // HasSuicided mocks base method.
 func (m *MockVmStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -1048,6 +1063,21 @@ func (mr *MockStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockStateDB)(nil).GetTransientState), arg0, arg1)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockStateDBMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockStateDB)(nil).HasEmptyStorage), addr)
+}
+
 // HasSuicided mocks base method.
 func (m *MockStateDB) HasSuicided(arg0 common.Address) bool {
 	m.ctrl.T.Helper()
@@ -1640,6 +1670,21 @@ func (m *MockNonCommittableStateDB) GetTransientState(arg0 common.Address, arg1 
 func (mr *MockNonCommittableStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransientState", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetTransientState), arg0, arg1)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockNonCommittableStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockNonCommittableStateDBMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockNonCommittableStateDB)(nil).HasEmptyStorage), addr)
 }
 
 // HasSuicided mocks base method.

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4351,6 +4351,23 @@ func TestStateDB_ContractCreationAndDeletionCanBeRolledBack(t *testing.T) {
 	}
 }
 
+func TestStateDB_HasEmptyStorage(t *testing.T) {
+	addr := common.Address{0x1}
+	ctrl := gomock.NewController(t)
+	st := NewMockState(ctrl)
+
+	st.EXPECT().HasEmptyStorage(addr).Return(true, nil)
+
+	statedb := stateDB{state: st}
+	empty, err := statedb.HasEmptyStorage(addr)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !empty {
+		t.Errorf("unexpected non-empty storage")
+	}
+}
+
 type sameEffectAs struct {
 	want common.Update
 }

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -355,6 +355,21 @@ func (mr *MockStateMockRecorder) GetStorage(address, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockState)(nil).GetStorage), address, key)
 }
 
+// HasEmptyStorage mocks base method.
+func (m *MockState) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockStateMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockState)(nil).HasEmptyStorage), addr)
+}
+
 // Restore mocks base method.
 func (m *MockState) Restore(data backend.SnapshotData) error {
 	m.ctrl.T.Helper()
@@ -581,6 +596,21 @@ func (m *MockLiveDB) GetStorage(address common.Address, key common.Key) (common.
 func (mr *MockLiveDBMockRecorder) GetStorage(address, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockLiveDB)(nil).GetStorage), address, key)
+}
+
+// HasEmptyStorage mocks base method.
+func (m *MockLiveDB) HasEmptyStorage(addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockLiveDBMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockLiveDB)(nil).HasEmptyStorage), addr)
 }
 
 // RunPostRestoreTasks mocks base method.

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -95,6 +95,12 @@ func (s *syncedState) GetCodeHash(address common.Address) (common.Hash, error) {
 	return s.state.GetCodeHash(address)
 }
 
+func (s *syncedState) HasEmptyStorage(addr common.Address) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.HasEmptyStorage(addr)
+}
+
 func (s *syncedState) Apply(block uint64, update common.Update) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
There has been already a method to assess if a storage root of an account is empty or not.  This PR exposes this method to `State` and `StateDB`. 
