### PR TITLE
fixes API issue in stateDB, HasEmptyStorage must not return error

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -56,7 +56,7 @@ type VmStateDB interface {
 	SetState(common.Address, common.Key, common.Value)
 	GetTransientState(common.Address, common.Key) common.Value
 	SetTransientState(common.Address, common.Key, common.Value)
-	HasEmptyStorage(addr common.Address) (bool, error)
+	HasEmptyStorage(addr common.Address) bool
 
 	// Code management.
 	GetCode(common.Address) []byte
@@ -889,8 +889,12 @@ func (s *stateDB) SetTransientState(addr common.Address, key common.Key, value c
 	s.transientStorage.Put(sid, value)
 }
 
-func (s *stateDB) HasEmptyStorage(addr common.Address) (bool, error) {
-	return s.state.HasEmptyStorage(addr)
+func (s *stateDB) HasEmptyStorage(addr common.Address) bool {
+	empty, err := s.state.HasEmptyStorage(addr)
+	if err != nil {
+		s.errors = append(s.errors, fmt.Errorf("failed to check empty storage for address %v: %w", addr, err))
+	}
+	return empty
 }
 
 func (s *stateDB) GetCode(addr common.Address) []byte {

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -394,12 +394,11 @@ func (mr *MockVmStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.C
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockVmStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+func (m *MockVmStateDB) HasEmptyStorage(addr common.Address) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // HasEmptyStorage indicates an expected call of HasEmptyStorage.
@@ -1064,12 +1063,11 @@ func (mr *MockStateDBMockRecorder) GetTransientState(arg0, arg1 any) *gomock.Cal
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+func (m *MockStateDB) HasEmptyStorage(addr common.Address) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // HasEmptyStorage indicates an expected call of HasEmptyStorage.
@@ -1673,12 +1671,11 @@ func (mr *MockNonCommittableStateDBMockRecorder) GetTransientState(arg0, arg1 an
 }
 
 // HasEmptyStorage mocks base method.
-func (m *MockNonCommittableStateDB) HasEmptyStorage(addr common.Address) (bool, error) {
+func (m *MockNonCommittableStateDB) HasEmptyStorage(addr common.Address) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasEmptyStorage", addr)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // HasEmptyStorage indicates an expected call of HasEmptyStorage.

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -3502,6 +3502,14 @@ func TestStateDB_CollectsErrorsAndReportsThemDuringACheck(t *testing.T) {
 				db.GetHash()
 			},
 		},
+		"has-empty-storage": {
+			setExpectations: func(state *MockState) {
+				state.EXPECT().HasEmptyStorage(gomock.Any()).Return(false, injectedError)
+			},
+			applyOperation: func(db StateDB) {
+				db.HasEmptyStorage(address1)
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -4359,11 +4367,7 @@ func TestStateDB_HasEmptyStorage(t *testing.T) {
 	st.EXPECT().HasEmptyStorage(addr).Return(true, nil)
 
 	statedb := stateDB{state: st}
-	empty, err := statedb.HasEmptyStorage(addr)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !empty {
+	if empty := statedb.HasEmptyStorage(addr); !empty {
 		t.Errorf("unexpected non-empty storage")
 	}
 }


### PR DESCRIPTION
 This PR fixes an issue in the API design of `HasEmptyStorage`.

While exported in `stateDb`, this method should not return an error. Errors are only tracked in stateDb, but not returned from each method. 