### PR TITLE
introduces method HasEmptyStorge into carmen facade

### DIFF
--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -377,6 +377,9 @@ type TransactionContext interface {
 	// marked by call to Snapshot.
 	RevertToSnapshot(int)
 
+	// HasEmptyStorage returns true if the contract has no storage attached to it.
+	HasEmptyStorage(addr Address) bool
+
 	// Commit completes this transaction. Pending changes are considered
 	// committed for subsequent transactions in the same block. However,
 	// changes are only persisted when committing the enclosing block.
@@ -424,6 +427,9 @@ type QueryContext interface {
 	// GetStateHash get the state root hash for the state queried
 	// by this context.
 	GetStateHash() Hash
+
+	// HasEmptyStorage returns true if the contract has no storage attached to it.
+	HasEmptyStorage(addr Address) bool
 }
 
 // BulkLoad provides a context for fast filling of the database.

--- a/go/carmen/query.go
+++ b/go/carmen/query.go
@@ -106,6 +106,18 @@ func (c *queryContext) GetStateHash() Hash {
 	return Hash(res)
 }
 
+func (c *queryContext) HasEmptyStorage(addr Address) bool {
+	if c.err != nil {
+		return false
+	}
+	empty, err := c.state.HasEmptyStorage(common.Address(addr))
+	if err != nil {
+		c.err = err
+		return false
+	}
+	return empty
+}
+
 func (c *queryContext) Check() error {
 	return errors.Join(c.err, c.state.Check())
 }

--- a/go/carmen/query_test.go
+++ b/go/carmen/query_test.go
@@ -100,6 +100,16 @@ func TestQueryContext_QueriesAreForwarded(t *testing.T) {
 				}
 			},
 		},
+		"has-empty-storage": {
+			func(mock *state.MockState) {
+				mock.EXPECT().HasEmptyStorage(common.Address{1}).Return(true, nil)
+			},
+			func(query *queryContext, t *testing.T) {
+				if want, got := true, query.HasEmptyStorage(Address{1}); want != got {
+					t.Errorf("unexpected has-empty-storage, wanted %v, got %v", want, got)
+				}
+			},
+		},
 	}
 	for name, property := range properties {
 		t.Run(name, func(t *testing.T) {
@@ -188,6 +198,16 @@ func TestQueryContext_ErrorsArePropagated(t *testing.T) {
 			func(query *queryContext, t *testing.T) {
 				if want, got := (Hash{}), query.GetStateHash(); want != got {
 					t.Errorf("unexpected state hash, wanted %v, got %v", want, got)
+				}
+			},
+		},
+		"has-empty-storage": {
+			func(mock *state.MockState) {
+				mock.EXPECT().HasEmptyStorage(common.Address{1}).Return(false, injectedError)
+			},
+			func(query *queryContext, t *testing.T) {
+				if want, got := false, query.HasEmptyStorage(Address{1}); want != got {
+					t.Errorf("unexpected has-empty-storage, wanted %v, got %v", want, got)
 				}
 			},
 		},

--- a/go/carmen/transaction.go
+++ b/go/carmen/transaction.go
@@ -267,6 +267,13 @@ func (t *transactionContext) GetStateHash() Hash {
 	return Hash(t.state.GetHash())
 }
 
+func (t *transactionContext) HasEmptyStorage(addr Address) bool {
+	if t.state != nil {
+		return t.state.HasEmptyStorage(common.Address(addr))
+	}
+	return false
+}
+
 func (t *transactionContext) Commit() error {
 	if t.state == nil {
 		return fmt.Errorf("transaction context is invalid")

--- a/go/carmen/transaction_test.go
+++ b/go/carmen/transaction_test.go
@@ -162,6 +162,7 @@ func TestTransaction_Operations_Passthrough(t *testing.T) {
 	stateDB.EXPECT().IsSlotInAccessList(gomock.Any(), gomock.Any())
 	stateDB.EXPECT().Snapshot()
 	stateDB.EXPECT().RevertToSnapshot(10)
+	stateDB.EXPECT().HasEmptyStorage(gomock.Any())
 
 	stateDB.EXPECT().EndTransaction()
 	stateDB.EXPECT().Check()
@@ -208,6 +209,7 @@ func TestTransaction_Operations_Passthrough(t *testing.T) {
 	tx.AddSlotToAccessList(address, key)
 	tx.IsAddressInAccessList(address)
 	tx.IsSlotInAccessList(address, key)
+	tx.HasEmptyStorage(address)
 	tx.Snapshot()
 	tx.RevertToSnapshot(10)
 
@@ -268,6 +270,7 @@ func TestTransaction_AfterCommitAllOperationsAreNoops(t *testing.T) {
 	tx.AddSlotToAccessList(address, key)
 	tx.IsAddressInAccessList(address)
 	tx.IsSlotInAccessList(address, key)
+	tx.HasEmptyStorage(address)
 	tx.Snapshot()
 	tx.RevertToSnapshot(10)
 }


### PR DESCRIPTION
This PR adds method `HasEmptyStorage` from `stateDB` to the public facade