### PR TITLE
implements HasEmptyStorage in Archive

### DIFF
--- a/go/backend/archive/archive.go
+++ b/go/backend/archive/archive.go
@@ -18,8 +18,13 @@ import (
 	"github.com/Fantom-foundation/Carmen/go/common/witness"
 )
 
-// ErrWitnessProofNotSupported is returned when the archive does not support witness proofs.
-const ErrWitnessProofNotSupported = common.ConstError("witness proof not supported")
+const (
+	// ErrWitnessProofNotSupported is returned when the archive does not support witness proofs.
+	ErrWitnessProofNotSupported = common.ConstError("witness proof not supported")
+
+	// ErrEmptyStorageNotSupported is returned when the archive does not support empty storage queries.
+	ErrEmptyStorageNotSupported = common.ConstError("empty storage query not supported")
+)
 
 // An Archive retains a history of state mutations in a blockchain on a
 // block-level granularity. The history is recorded by adding per-block updates.
@@ -59,6 +64,9 @@ type Archive interface {
 
 	// CreateWitnessProof creates a witness proof for the given account and keys.
 	CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error)
+
+	// HasEmptyStorage returns true if the storage of the given account is empty.
+	HasEmptyStorage(block uint64, addr common.Address) (bool, error)
 
 	// MemoryFootprintProvider provides the size of the store in memory in bytes.
 	common.MemoryFootprintProvider

--- a/go/backend/archive/archive_mock.go
+++ b/go/backend/archive/archive_mock.go
@@ -247,3 +247,18 @@ func (mr *MockArchiveMockRecorder) GetStorage(block, account, slot any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorage", reflect.TypeOf((*MockArchive)(nil).GetStorage), block, account, slot)
 }
+
+// HasEmptyStorage mocks base method.
+func (m *MockArchive) HasEmptyStorage(block uint64, addr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasEmptyStorage", block, addr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasEmptyStorage indicates an expected call of HasEmptyStorage.
+func (mr *MockArchiveMockRecorder) HasEmptyStorage(block, addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasEmptyStorage", reflect.TypeOf((*MockArchive)(nil).HasEmptyStorage), block, addr)
+}

--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -330,6 +330,51 @@ func TestArchive_CreateWitnessProof(t *testing.T) {
 	}
 }
 
+func TestArchive_HasEmptyStorage(t *testing.T) {
+	for _, factory := range getArchiveFactories(t) {
+		t.Run(factory.label, func(t *testing.T) {
+			a := factory.getArchive(t.TempDir())
+			defer func() {
+				if err := a.Close(); err != nil {
+					t.Fatalf("failed to close archive; %s", err)
+				}
+			}()
+
+			const blocks = 10
+			for i := uint64(1); i <= blocks; i++ {
+				if err := a.Add(i, common.Update{
+					CreatedAccounts: []common.Address{{1, 2}},
+					Balances: []common.BalanceUpdate{
+						{Account: common.Address{1}, Balance: amount.New(12)},
+						{Account: common.Address{2}, Balance: amount.New(12)},
+					},
+					Slots: []common.SlotUpdate{
+						{Account: common.Address{1}, Key: common.Key{2}, Value: common.Value{3}},
+					},
+				}, nil); err != nil {
+					t.Fatalf("failed to add block: %v", err)
+				}
+			}
+
+			for i := uint64(1); i <= blocks; i++ {
+				for j := 1; j <= 3; j++ {
+					empty, err := a.HasEmptyStorage(i, common.Address{byte(j)})
+					if err != nil {
+						if errors.Is(err, archive.ErrEmptyStorageNotSupported) {
+							t.Skip(err)
+						}
+						t.Errorf("failed to check empty storage; %s", err)
+					}
+					// only address == 1 has storage
+					if got, want := empty, j != 1; got != want {
+						t.Errorf("unexpected empty storage; got: %t, want: %t", got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestAccountStatusOnly(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {

--- a/go/backend/archive/ldb/archive.go
+++ b/go/backend/archive/ldb/archive.go
@@ -343,6 +343,10 @@ func (a *Archive) CreateWitnessProof(_ uint64, _ common.Address, _ ...common.Key
 	return nil, archive.ErrWitnessProofNotSupported
 }
 
+func (a *Archive) HasEmptyStorage(_ uint64, _ common.Address) (bool, error) {
+	return false, archive.ErrEmptyStorageNotSupported
+}
+
 // GetMemoryFootprint provides the size of the archive in memory in bytes
 func (a *Archive) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*a))

--- a/go/backend/archive/sqlite/archive.go
+++ b/go/backend/archive/sqlite/archive.go
@@ -517,6 +517,10 @@ func (a *Archive) CreateWitnessProof(block uint64, address common.Address, keys 
 	return nil, archive.ErrWitnessProofNotSupported
 }
 
+func (a *Archive) HasEmptyStorage(_ uint64, _ common.Address) (bool, error) {
+	return false, archive.ErrEmptyStorageNotSupported
+}
+
 // GetMemoryFootprint provides the size of the archive in memory in bytes
 func (a *Archive) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*a))

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -376,6 +376,16 @@ func (a *ArchiveTrie) CreateWitnessProof(block uint64, address common.Address, k
 	return proof, a.addError(err)
 }
 
+// HasEmptyStorage returns true if account has empty storage in a certain block.
+func (a *ArchiveTrie) HasEmptyStorage(block uint64, addr common.Address) (bool, error) {
+	view, err := a.getView(block)
+	if err != nil {
+		return false, err
+	}
+	empty, err := view.HasEmptyStorage(addr)
+	return empty, a.addError(err)
+}
+
 // GetDiff computes the difference between the given source and target blocks.
 func (a *ArchiveTrie) GetDiff(srcBlock, trgBlock uint64) (Diff, error) {
 	a.rootsMutex.Lock()

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -125,7 +125,15 @@ func (s *ArchiveState) GetCodeHash(address common.Address) (hash common.Hash, er
 }
 
 func (s *ArchiveState) HasEmptyStorage(addr common.Address) (bool, error) {
-	panic("ArchiveState does not support HasEmptyStorage operation")
+	if err := s.archiveError; err != nil {
+		return false, err
+	}
+
+	empty, err := s.archive.HasEmptyStorage(s.block, addr)
+	if err != nil {
+		s.archiveError = errors.Join(s.archiveError, err)
+	}
+	return empty, s.archiveError
 }
 
 func (s *ArchiveState) Apply(block uint64, update common.Update) error {

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -109,6 +109,15 @@ func TestState_ArchiveState_FailingOperation_InvalidatesArchive(t *testing.T) {
 				return err
 			},
 		},
+		"hasEmptyStorage": {
+			func(archive *archive.MockArchive, injectedErr error) {
+				archive.EXPECT().HasEmptyStorage(gomock.Any(), gomock.Any()).Return(false, injectedErr)
+			},
+			func(stateArchive state.State) error {
+				_, err := stateArchive.HasEmptyStorage(common.Address{})
+				return err
+			},
+		},
 	}
 
 	testNames := make([]string, 0, len(tests))


### PR DESCRIPTION
This PR adds `HasEmptyStorage` method into `Archive` backed by `ArchiveTrie`. For other schemes this method is not supported at the moment. 