### PR TITLE
Kjezek/deadlock write buffer

### DIFF
--- a/go/database/mpt/write_buffer_test.go
+++ b/go/database/mpt/write_buffer_test.go
@@ -399,7 +399,7 @@ func TestWriteBuffer_Add_Cancel_Empty_DoesNotLock(t *testing.T) {
 	go func() {
 		started.Done()
 		for run.Load() {
-			buffer.(*writeBuffer).emptyBuffer()
+			buffer.(*writeBuffer).emptyBuffer(true)
 			heartbeat <- struct{}{}
 		}
 	}()
@@ -418,7 +418,7 @@ func TestWriteBuffer_Add_Cancel_Empty_DoesNotLock(t *testing.T) {
 	}()
 
 	started.Wait()
-	const loops = 10_000
+	const loops = 10_000_000
 	for i := 0; i < loops; i++ {
 		buffer.Add(id, node)
 	}


### PR DESCRIPTION
This PR fixes deadlock that could occur in `writeBuffer`.

It creates a test that extensively does `Add` and `Cancel` of the same node together with emptying the buffer. This quickly simulates the error in the previous version. 

Furthermore, it applies an experiment from https://github.com/Fantom-foundation/Carmen/pull/1047 that fixes the problem, i.e. the test is passing.  