### PR TITLE
Allow choosing cache config for some export/import funcs.

### DIFF
--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -2228,7 +2229,7 @@ func TestDatabase_Export(t *testing.T) {
 	if err := os.MkdirAll(liveDbLocation, 0755); err != nil {
 		t.Fatalf("cannot create live db location: %v", err)
 	}
-	if err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b); err != nil {
+	if err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b, mpt.NodeCacheConfig{}); err != nil {
 		t.Fatalf("cannot import live db: %v", err)
 	}
 

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"log"
 	"os"
 	"path/filepath"
@@ -574,7 +575,7 @@ func ExampleHistoricBlockContext_Export() {
 	}
 	liveDbLocation := filepath.Join(importedDbPath, "live")
 
-	err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b)
+	err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b, mpt.NodeCacheConfig{})
 	if err != nil {
 		log.Fatalf("cannot import live db")
 	}

--- a/go/database/mpt/io/interrupt_test.go
+++ b/go/database/mpt/io/interrupt_test.go
@@ -38,7 +38,9 @@ func TestExport_CanBeInterrupted(t *testing.T) {
 
 	tests := map[string]testFuncs{
 		"live": {
-			export:   Export,
+			export: func(ctx context.Context, log *Log, s string, writer io.Writer) error {
+				return Export(ctx, log, s, writer, mpt.NodeCacheConfig{})
+			},
 			createDB: createTestLive,
 			check:    checkCanOpenLiveDB,
 		},

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -28,7 +28,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 
 	buffer := bytes.NewBuffer(genesis)
 	targetDir := t.TempDir()
-	if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
+	if err := ImportLiveDb(NewLog(), targetDir, buffer, mpt.NodeCacheConfig{}); err != nil {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 	buffer := bytes.NewBuffer(genesis)
 	targetDir := t.TempDir()
 	genesisBlock := uint64(12)
-	if err := InitializeArchive(NewLog(), targetDir, buffer, genesisBlock); err != nil {
+	if err := InitializeArchive(NewLog(), targetDir, buffer, genesisBlock, mpt.NodeCacheConfig{}); err != nil {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
@@ -209,7 +209,7 @@ func exportExampleStateWithModification(t *testing.T, modify func(s *mpt.MptStat
 
 	// Export database to buffer.
 	var buffer bytes.Buffer
-	if err := Export(context.Background(), NewLog(), sourceDir, &buffer); err != nil {
+	if err := Export(context.Background(), NewLog(), sourceDir, &buffer, mpt.NodeCacheConfig{}); err != nil {
 		t.Fatalf("failed to export DB: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestImport_ImportIntoNonEmptyTargetDirectoryFails(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := ImportLiveDb(NewLog(), dir, nil); err == nil || !strings.Contains(err.Error(), "is not empty") {
+	if err := ImportLiveDb(NewLog(), dir, nil, mpt.NodeCacheConfig{}); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -233,7 +233,7 @@ func TestInitializeArchive_ImportIntoNonEmptyTargetDirectoryFails(t *testing.T) 
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := InitializeArchive(NewLog(), dir, nil, 0); err == nil || !strings.Contains(err.Error(), "is not empty") {
+	if err := InitializeArchive(NewLog(), dir, nil, 0, mpt.NodeCacheConfig{}); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -336,7 +336,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 
 		// Import live database.
 		targetDir := t.TempDir()
-		if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
+		if err := ImportLiveDb(NewLog(), targetDir, buffer, mpt.NodeCacheConfig{}); err != nil {
 			t.Fatalf("failed to import DB: %v", err)
 		}
 
@@ -412,7 +412,7 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 
 		// Import live database.
 		targetDir := t.TempDir()
-		if err := ImportLiveDb(nil, targetDir, buffer); err != nil {
+		if err := ImportLiveDb(nil, targetDir, buffer, mpt.NodeCacheConfig{}); err != nil {
 			t.Fatalf("failed to import DB: %v", err)
 		}
 
@@ -448,7 +448,7 @@ func TestIO_Live_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot write magic number: %v", err)
 	}
-	_, _, err = runImport(NewLog(), t.TempDir(), b, mpt.MptConfig{})
+	_, _, err = runImport(NewLog(), t.TempDir(), b, mpt.MptConfig{}, mpt.NodeCacheConfig{})
 	if err == nil {
 		t.Fatal("import must fail")
 	}

--- a/go/database/mpt/tool/export.go
+++ b/go/database/mpt/tool/export.go
@@ -71,7 +71,7 @@ func doExport(context *cli.Context) error {
 		}
 	} else {
 		// Passed LiveDB
-		exportErr = io.Export(ctx, logger, dir, out)
+		exportErr = io.Export(ctx, logger, dir, out, mpt.NodeCacheConfig{})
 	}
 
 	if err = errors.Join(

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -15,6 +15,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"io"
 	"os"
 
@@ -44,7 +45,10 @@ var ImportLiveAndArchiveCmd = cli.Command{
 }
 
 func doLiveDbImport(context *cli.Context) error {
-	return doImport(context, mptIo.ImportLiveDb)
+	f := func(logger *mptIo.Log, directory string, in io.Reader) error {
+		return mptIo.ImportLiveDb(logger, directory, in, mpt.NodeCacheConfig{})
+	}
+	return doImport(context, f)
 }
 
 func doArchiveImport(context *cli.Context) error {

--- a/go/database/mpt/tool/init_archive.go
+++ b/go/database/mpt/tool/init_archive.go
@@ -15,6 +15,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Carmen/go/database/mpt"
 	"io"
 	"os"
 
@@ -62,7 +63,7 @@ func doArchiveInit(context *cli.Context) error {
 		return err
 	}
 	return errors.Join(
-		mptIo.InitializeArchive(logger, dir, in, height),
+		mptIo.InitializeArchive(logger, dir, in, height, mpt.NodeCacheConfig{}),
 		file.Close(),
 	)
 }


### PR DESCRIPTION
This PR adds `mpt.NodeCacheConfig` to some Export/Import func in `io` package.
Reason for this PR:
Sonic integration tests showed Carmen used too much memory for each test, specifically ~2,5GB (first image). With this change we are able to reduce this to ~450MB (second image) when setting the Cache to lowest capacity possible.

<img width="474" alt="Screenshot 2024-11-22 at 9 31 33" src="https://github.com/user-attachments/assets/15806a45-cc49-4c15-9b07-ff05c3ab8d3c">


<img width="195" alt="Screenshot 2024-11-22 at 9 34 46" src="https://github.com/user-attachments/assets/22653e52-3f71-46b7-a878-602f5793f50f">
