### PR TITLE
decreases node cache size and number of import loops  

### DIFF
--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -346,16 +346,17 @@ func runImport(logger *Log, directory string, in io.Reader, config mpt.MptConfig
 		common.Keccak256([]byte{}): {},
 	}
 
-	counter := 0
-
 	progress := logger.NewProgressTracker("imported %d accounts, %.2f accounts/s", 1_000_000)
+
+	const changesToRecomputeHash = 1000
+	counter := 0
 	hashFound := false
 	var stateHash common.Hash
 	for {
 		// Update hashes periodically to avoid running out of memory
 		// for nodes with dirty hashes.
 		counter++
-		if (counter % 1000) == 0 {
+		if (counter % changesToRecomputeHash) == 0 {
 			if _, err := db.GetHash(); err != nil {
 				return root, hash, fmt.Errorf("failed to update hashes: %v", err)
 			}

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -50,6 +50,9 @@ const (
 	exportCacheCapacitySize = 2000
 )
 
+// The default size of the node cache for imports.
+const importNodeCacheSize = 100_000
+
 type HashType byte
 
 // So far there is only one hash type supported, the Ethereum hash. But for
@@ -321,7 +324,7 @@ func runImport(logger *Log, directory string, in io.Reader, config mpt.MptConfig
 	}
 
 	// Create a state.
-	db, err := mpt.OpenGoFileState(directory, config, mpt.NodeCacheConfig{})
+	db, err := mpt.OpenGoFileState(directory, config, mpt.NodeCacheConfig{Capacity: importNodeCacheSize})
 	if err != nil {
 		return root, hash, fmt.Errorf("failed to create empty state: %v", err)
 	}
@@ -352,7 +355,7 @@ func runImport(logger *Log, directory string, in io.Reader, config mpt.MptConfig
 		// Update hashes periodically to avoid running out of memory
 		// for nodes with dirty hashes.
 		counter++
-		if (counter % 100_000) == 0 {
+		if (counter % 1000) == 0 {
 			if _, err := db.GetHash(); err != nil {
 				return root, hash, fmt.Errorf("failed to update hashes: %v", err)
 			}


### PR DESCRIPTION
This PR updates import of liveDB. It reduces the number of loops when the hash is recomputed, and reduces the size of node cache. It reduces both 100 times. 

It was verified by importing ~90M block height that performance was not changed, while reducing the memory needs. 

New import took about 2,5h, the same time as it used to take before:

Running:

```
go run ./database/mpt/tool/ init-archive  /mnt/disks/ssd-array/live.dat /mnt/disks/ssd-array/init-archive

```

Before: 

```
2024/11/27 13:25:18 [t= 155:05] - imported 167000000 accounts, 62411.77 accounts/s
2024/11/27 13:25:38 [t= 155:25] - imported 168000000 accounts, 48905.98 accounts/s
2024/11/27 13:25:58 [t= 155:44] - imported 169000000 accounts, 51962.49 accounts/s
2024/11/27 13:26:13 [t= 156:00] - imported 170000000 accounts, 63809.84 accounts/s
2024/11/27 13:26:26 [t= 156:13] - imported 171000000 accounts, 77145.27 accounts/s

```

After:
```
2024/11/25 16:00:40 [t= 154:15] - imported 169000000 accounts, 54664.31 accounts/s
2024/11/25 16:00:55 [t= 154:30] - imported 170000000 accounts, 65377.09 accounts/s
2024/11/25 16:01:08 [t= 154:42] - imported 171000000 accounts, 80819.39 accounts/s
2024/11/25 16:01:15 [t= 154:50] - import done

```